### PR TITLE
Insights: Fix broken links in analytics support documentation

### DIFF
--- a/docs/analytics-overview.md
+++ b/docs/analytics-overview.md
@@ -37,6 +37,14 @@ slug: analytics-overview/
 import NewTag from '../src/component/newTag';
 
 
+:::note Explore AI Dashboard CoPilot
+
+We have recently launched an AI Dashboard CoPilot <NewTag value="BETA" bgColor="#ffec02" color="#000" /> feature that provides intelligent recommendations, insights, and predictions tailored to your specific data.
+
+To know more about this feature, refer to the [AI Dashboard CoPilot](/docs/analytics-dashboard-copilot/) documentation.
+
+:::
+
 <img loading="lazy" src={require('../assets/images/analytics/Demo-Dashboard-with-Widget.webp').default} alt="cmd" width="768" height="373" className="doc_img"/>
 
 ## What is Insights?
@@ -77,14 +85,6 @@ Other LambdaTest products will be added soon with Insights support. For any requ
 
 ## Insights Modules
 
-:::note Explore AI Dashboard CoPilot
-
-We have recently launched an AI Dashboard CoPilot <NewTag value="BETA" bgColor="#ffec02" color="#000" /> feature that provides intelligent recommendations, insights, and predictions tailored to your specific data.
-
-To know more about this feature, refer to the [AI Dashboard CoPilot](/docs/analytics-dashboard-copilot/) documentation.
-
-:::
-
 <div className="support_main">  
 <a href="/docs/analytics-modules-resource-utilization/">
     <div className="support_inners">
@@ -114,6 +114,18 @@ To know more about this feature, refer to the [AI Dashboard CoPilot](/docs/analy
     <div className="support_inners">
       <h3>Test Case Insights &nbsp; <NewTag value="BETA" bgColor="#ffec02" color="#000" /></h3>
       <p>Get insights for `describe()` block level for your test frameworks in HyperExecute. Monitor the quality metrics at each test case.</p>
+    </div>
+  </a>
+    <a href="/docs/analytics-allure-api-widgets/">
+    <div className="support_inners">
+      <h3>API Test Insights &nbsp; <NewTag value="BETA" bgColor="#ffec02" color="#000" /></h3>
+      <p>Get API test time-series insights using Allure report integration with your test suite and run it on HyperExecute.</p>
+    </div>
+  </a>
+  <a href="/docs/analytics-sub-organization-widgets/">
+    <div className="support_inners">
+      <h3>Sub Organization Insights &nbsp; <NewTag value="BETA" bgColor="#ffec02" color="#000" /></h3>
+      <p>Monitor and allocate the right resources required for your organizations with advanced insights.</p>
     </div>
   </a>
 </div>

--- a/docs/analytics-widgets.md
+++ b/docs/analytics-widgets.md
@@ -80,7 +80,7 @@ To know more about this feature, refer to the [AI Dashboard CoPilot](/docs/analy
       <p>Get insights for `describe()` block level for your test frameworks in HyperExecute. Monitor the quality metrics at each test case.</p>
     </div>
   </a>
-  <a href="/docs/analytics-test-case-insights/">
+  <a href="/docs/analytics-allure-api-widgets/">
     <div className="support_inners">
       <h3>API Test Insights &nbsp; <NewTag value="BETA" bgColor="#ffec02" color="#000" /></h3>
       <p>Get API test time-series insights using Allure report integration with your test suite and run it on HyperExecute.</p>

--- a/docs/support.md
+++ b/docs/support.md
@@ -92,14 +92,14 @@ import NewTag from '../src/component/newTag';
     <div className="home_inners_box">
       <h2 className='homeMain_h2'><img  loading="eager" src={require('../assets/images/support/analytics-light-icon.png').default} alt="Image" width="16" height="16" className="home_icons home_light_icon no-zoom" role="presentation"/><img  loading="eager" src={require('../assets/images/support/analytics-dark-icon.png').default} alt="Image" width="16" height="16" className="home_icons home_dark_icon no-zoom" role="presentation"/>Insights</h2>
       <div className="home_inners">
-        <a href="/docs/analytics-dashboard-templates/"><p className="p_home_inners">Pre-built Dashboards</p></a>
-        <a href="/docs/analytics-create-dashboard/"><p className="p_home_inners">Custom Dashboards</p></a>
-        <a href="/docs/analytics-widgets/"><p className="p_home_inners">Widgets</p></a>
-        <a href="/docs/analytics-modules-test-intelligence-flaky-test-analytics/"><p className="p_home_inners">Dashboard AI CoPilot &nbsp; <NewTag  value="BETA" bgColor="#ffec02" color="#000" /></p></a>
-        <a href="/docs/analytics-modules-test-intelligence-flaky-test-analytics/"><p className="p_home_inners">Flaky Test Insights</p></a>
-        <a href="/docs/analytics-modules-test-intelligence-command-logs-analytics/"><p className="p_home_inners">Error Logs Insights</p></a>
-        <a href="/docs/analytics-test-case-insights/"><p className="p_home_inners">Test Case Insights</p></a>
-        <a href="/docs/analytics-allure-api-widgets/"><p className="p_home_inners">API Tests Insights</p></a>
+        <a href="/support/docs/analytics-dashboard-templates/"><p className="p_home_inners">Pre-built Dashboards</p></a>
+        <a href="/support/docs/analytics-create-dashboard/"><p className="p_home_inners">Custom Dashboards</p></a>
+        <a href="/support/docs/analytics-widgets/"><p className="p_home_inners">Widgets</p></a>
+        <a href="/support/docs/analytics-dashboard-copilot/"><p className="p_home_inners">Dashboard AI CoPilot &nbsp; <NewTag  value="BETA" bgColor="#ffec02" color="#000" /></p></a>
+        <a href="/support/docs/analytics-modules-test-intelligence-flaky-test-analytics/"><p className="p_home_inners">Flaky Test Insights</p></a>
+        <a href="/support/docs/analytics-modules-test-intelligence-command-logs-analytics/"><p className="p_home_inners">Error Logs Insights</p></a>
+        <a href="/support/docs/analytics-test-case-insights/"><p className="p_home_inners">Test Case Insights</p></a>
+        <a href="/support/docs/analytics-allure-api-widgets/"><p className="p_home_inners">API Tests Insights</p></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The following are the changes in this `PR`: 

- Fixes the docs home page url for the `Dashboard CoPilot` feature
- Fixes the url links for the Insights Modules sections
- Updates the Overview with new `BETA` modules for better discovery