### PR TITLE
Insights - changes in the sidebar menu

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -3032,14 +3032,14 @@ module.exports = {
     },
     {
       type: "category",
-      collapsed: true,
+      collapsed: false,
       label: "Getting Started",
 
       items: ["analytics-dashboard-templates", "analytics-create-dashboard"],
     },
     {
       type: "category",
-      collapsed: true,
+      collapsed: false,
       label: "Widgets",
       link: {
         type: "doc",


### PR DESCRIPTION
This pull request includes a small change to the `sidebars.js` file. The change updates the `collapsed` property of two sidebar categories, "Getting Started" and "Widgets," to be set to `false` instead of `true`, ensuring these categories are expanded by default.