### PR TITLE
Add Documentation for Setting Device Date, Time & Hour Format in App Automation

### DIFF
--- a/docs/appium-date-and-time.md
+++ b/docs/appium-date-and-time.md
@@ -1,0 +1,132 @@
+---
+id: appium-date-and-time
+title: Set Custom Date, Time & Hour Format on Real Devices
+hide_title: true
+sidebar_label: Set Date and Time 
+description: This document provides information about configuring date, time, and hour-format on Real Devices using Appium automation on LambdaTest.
+keywords:
+ - Appium
+ - LambdaTest
+ - Set Date and Time
+ - Device Time Automation
+ - 12-hour format
+ - 24-hour format
+
+url: https://www.lambdatest.com/support/docs/appium-date-and-time/
+site_name: LambdaTest
+slug: appium-date-and-time/
+---
+
+
+import CodeBlock from '@theme/CodeBlock';
+import {YOUR_LAMBDATEST_USERNAME, YOUR_LAMBDATEST_ACCESS_KEY} from "@site/src/component/keys";
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.lambdatest.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.lambdatest.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Set Custom Date, Time & Hour Format on Real Devices",
+          "item": "https://www.lambdatest.com/support/docs/appium-date-and-time/"
+        }]
+      })
+    }}
+></script>
+
+# Set Device Date & Time
+
+LambdaTest now supports configuring custom **date**, **time**, and **hour-format** on Real Devices via Appium during automation testing sessions. This allows developers and testers to simulate specific date/time conditions to validate use cases like scheduled events, alarms, chats, or localization for time formats.
+
+By the end of this document, you will be able to:
+- Set a specific date and time on the device
+- Toggle between 12-hour and 24-hour formats
+- Enable/disable automatic time syncing with network settings
+
+---
+
+## Support for Automation on Real Devices
+
+To modify the date and time settings programmatically, use the `lambda_executor` Appium hook with the `updateDeviceSettings` action. You can provide multiple arguments including custom date, time, format toggle, and auto-time setting.
+
+### Appium Hook Example
+
+<CodeBlock language="js">
+{`driver.execute_script('lambda_executor: { 
+  "action": "updateDeviceSettings", 
+  "arguments": { 
+    "customDate": "Jun 20 2025", 
+    "customTime": "15:05", 
+    "twelveHourTime": "On", 
+    "setAutomatically": "On" 
+  } 
+}')`}
+</CodeBlock>
+
+
+---
+## Supported Arguments
+
+| Argument           | Format        | Description                                                                 |
+| ------------------ | ------------- | --------------------------------------------------------------------------- |
+| `customDate`       | `MMM DD YYYY` | Sets device date. Max 7 days from today.                                    |
+| `customTime`       | `HH:MM`       | Time in 24-hour format (e.g., 13:30). Interpreted based on `twelveHourTime`.|
+| `twelveHourTime`   | `On` / `Off`  | `On` for 12-hour, `Off` for 24-hour format.                                 |
+| `setAutomatically` | `On` / `Off`  | Enables or disables syncing with network time.                              |
+
+> 💡 **Note:** When `setAutomatically` is turned **On**, manual inputs for date and time are disabled on the device.
+
+---
+## Supported Platforms
+
+| Platform  | OS Version    | Support Status                  |
+| --------- | ------------- | ------------------------------- |
+| iOS       | 14 and above  | ✅ Fully Supported               |
+| Android   | 10 and above  | ⚠️ Manual: Supported🔧 Automation: In Progress |
+
+---
+
+## Example Use Cases
+
+- Validate how the app behaves across different time zones or locales.
+- Test reminder or calendar event triggering logic.
+- Test 12-hour vs. 24-hour format layout rendering.
+
+
+> **Note:** For configuring device date and time during **manual testing** on real devices, please refer to our [Set Date & Time on Real Devices (Manual)](support/docs/set-date-time-hour-format-real-devices/) guide.
+
+
+
+<nav aria-label="breadcrumbs">
+  <ul className="breadcrumbs">
+    <li className="breadcrumbs__item">
+      <a className="breadcrumbs__link" target="_self" href="https://www.lambdatest.com">
+        Home
+      </a>
+    </li>
+    <li className="breadcrumbs__item">
+      <a className="breadcrumbs__link" target="_self" href="https://www.lambdatest.com/support/docs/">
+        Support
+      </a>
+    </li>
+    <li className="breadcrumbs__item breadcrumbs__item--active">
+      <span className="breadcrumbs__link">
+       IP Geolocation
+      </span>
+    </li>
+  </ul>
+</nav>

--- a/docs/real-device-custom-date-and-time.md
+++ b/docs/real-device-custom-date-and-time.md
@@ -109,29 +109,6 @@ The modal includes four options to simulate various datetime-related behaviors:
 
 <img loading="lazy" src={require('../assets/images/real-device-app-testing/set-date-and-time-pic-5.png').default} className="doc_img"/>
 
----
-
-## Configure Date & Time via Appium
-
-You can configure date, time, time format (12h/24h), and toggle automatic syncing via a LambdaTest custom Appium executor hook.
-
-### Appium Hook:
-
-```js
-lambda_executor: { "action": "updateDeviceSettings", "arguments": { "customDate": "Jun 20 2025", "customTime": "15:05", "twelveHourTime": "On", "setAutomatically": "On" } } 
-```
-
-
-### Appium Hook:
-
-| Argument           | Format        | Description                                                                  |
-| ------------------ | ------------- | ---------------------------------------------------------------------------- |
-| `customDate`       | `MMM DD YYYY` | Future-only date. Max 7 days from current date.                              |
-| `customTime`       | `HH:MM`       | Time in 24-hour format. Interpreted based on selected hour format.           |
-| `twelveHourTime`   | `On` / `Off`  | Toggles between 12-hour (`On`) and 24-hour (`Off`) formats.                  |
-| `setAutomatically` | `On` / `Off`  | Enables or disables syncing time with network. Disabling allows manual edit. |
-
----
 
 ## Supported Platforms: 
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -2708,6 +2708,7 @@ module.exports = {
               "appium-custom-header",
               "basic-authentication-for-web-automation",
               "live-debug-in-app-automation",
+              "appium-date-and-time",
             ],
           },
           {


### PR DESCRIPTION
This PR adds support documentation for setting custom device date, time, and time format (12/24-hour) during App Automation sessions on LambdaTest Real Devices.

