### PR TITLE
Updated documentation for speedup-espresso

### DIFF
--- a/docs/accessibility-android-rules.md
+++ b/docs/accessibility-android-rules.md
@@ -43,7 +43,7 @@ import TabItem from '@theme/TabItem';
     }}
 ></script>
 
-skfgkjsjre
+
 
 | Rule Name | WCAG | Level | Impact | Description |
 |-----------|------|-------|--------|-------------|

--- a/docs/accessibility-android-rules.md
+++ b/docs/accessibility-android-rules.md
@@ -43,6 +43,8 @@ import TabItem from '@theme/TabItem';
     }}
 ></script>
 
+skfgkjsjre
+
 | Rule Name | WCAG | Level | Impact | Description |
 |-----------|------|-------|--------|-------------|
 | Missing Image Alt | 1.1.1 | A | Critical | Images lack alternative text descriptions that screen readers can announce to users. Add `android:contentDescription` to meaningful images or set to empty string for decorative images to ensure proper accessibility support. |

--- a/docs/accessibility-android-rules.md
+++ b/docs/accessibility-android-rules.md
@@ -43,8 +43,6 @@ import TabItem from '@theme/TabItem';
     }}
 ></script>
 
-
-
 | Rule Name | WCAG | Level | Impact | Description |
 |-----------|------|-------|--------|-------------|
 | Missing Image Alt | 1.1.1 | A | Critical | Images lack alternative text descriptions that screen readers can announce to users. Add `android:contentDescription` to meaningful images or set to empty string for decorative images to ensure proper accessibility support. |

--- a/docs/speedup-espresso.md
+++ b/docs/speedup-espresso.md
@@ -75,9 +75,14 @@ POST   /framework/v1/espresso/build
 You can not use the following filters simultaneously. 
 - `class` and `package`
 - `class` and `skipClass`
-- `annotation` and `skipAnnotation`
 - `package` and `skipPackage`
 :::
+
+:::info Note
+You can use the following filters simultaneously.
+- `annotation` and `skipAnnotation`
+:::
+
 
 ## Some Examples
 


### PR DESCRIPTION
This PR updates the documentation for speedup-espresso with the following changes:

Modified the Note section under Filters for Espresso Tests.

Previously, the note stated that you cannot use the following filters simultaneously:
class and package
class and skipClass
annotation and skipAnnotation
package and skipPackage

Since annotation and skipAnnotation can now be used together, they have been removed from the original note.

A new separate Note has been added to clarify this change.
