### PR TITLE
Added note for AI/ML in Tunnel Client

### DIFF
--- a/docs/testing-locally-hosted-pages.md
+++ b/docs/testing-locally-hosted-pages.md
@@ -48,7 +48,7 @@ slug: testing-locally-hosted-pages/
 
 <img loading="lazy" src={require('../assets/images/tunnel/tunnel.png').default} alt="TestNG HyperExecute Terminal Logs"  width="1920" height="868" className="doc_img"/>
 
-> All Tunnel credentials (access keys, API tokens, etc.) are private and confidential. A system compromise may result in their unauthorized disclosure; therefore, you must secure the machine running the LambdaTest tunnel. Do not share or expose credentials in public code, repositories, or environments. In the event of a compromise, you are solely responsible for immediately revoking and regenerating the credentials. LambdaTest assumes no liability for any losses arising from failure to comply.
+> All Tunnel credentials (access keys, API tokens, etc.) are private and confidential. A system compromise may result in their unauthorized disclosure; therefore, you must secure the machine running the LambdaTest tunnel. Do not share or expose credentials in public code, repositories, or environments. In the event of a compromise, you are solely responsible for immediately revoking and regenerating the credentials. LambdaTest assumes no liability for any losses arising from failure to comply. 
 
 ## Why to Use LambdaTest Tunnel?
 
@@ -57,6 +57,8 @@ LambdaTest Tunnel offers numerous benefits for web developers, testers, and QA p
 - **Secured and Encrypted :** It provides a secure and encrypted connection between your local machine and the virtual machines in the cloud, thereby ensuring the privacy of your test data and online communications.
 - **Cost Effective :** With LambdaTest Tunnel, you can test your web applications or websites, local folder, and files across a wide range of browsers and operating systems without setting up complex and expensive local testing environments.
 - **Test on Real Environment :** It lets you test your locally hosted web applications or websites on cloud-based real OS machines. You can even run accessibility tests on desktop browsers while testing locally hosted web applications and pages.
+
+> Please note that the LambdaTest tunnel client does not include any AI or ML capabilities, and none of the data it proxies is used for AI or ML training.
 
 ## Download the Tunnel Binary
 You can download the Tunnel Binary as per your respective machine architecture from the links given below :
@@ -75,4 +77,3 @@ You can download the Tunnel Binary as per your respective machine architecture f
 | FreeBSD/ARM64 | https://downloads.lambdatest.com/tunnel/v3/freebsd/arm64/LT| 
 | FreeBSD/A386 | https://downloads.lambdatest.com/tunnel/v3/freebsd/386/LT |
 | Solaris/AMD64 | https://downloads.lambdatest.com/tunnel/v3/solaris/amd64/LT |
-


### PR DESCRIPTION
This pull request updates the documentation for LambdaTest Tunnel to clarify its capabilities and ensure accuracy regarding its features and supported platforms. The most important changes are:

Documentation clarification:

* Added a note stating that the LambdaTest tunnel client does not include any AI or ML capabilities, and that no data proxied through the tunnel is used for AI or ML training.

Documentation cleanup:

* Removed an unnecessary blank line from the table listing download links for different machine architectures.