### PR TITLE
[TE-1898] Unified SCIM Provisioning documentation — users & groups

### DIFF
--- a/docs/scim.md
+++ b/docs/scim.md
@@ -1,18 +1,30 @@
 ---
 id: scim
-title: Getting Started With Scim User Provisioning
+title: SCIM Provisioning — Users & Groups
 hide_title: false
 sidebar_label: SCIM
-description: The SCIM specification is designed to make managing user identities easier. SCIM allows your Identity Provider (IdP) to manage users within your TestMu AI workspace  
+description: Automate user and group lifecycle management with SCIM 2.0. Provision users, sync groups, map to teams, concurrency groups, and sub-organizations — all from your Identity Provider.
 keywords:
     - TestMu AI SCIM
+    - SCIM Provisioning
+    - SCIM 2.0
+    - User Provisioning
+    - Group Provisioning
+    - IDP Groups
+    - Okta SCIM
+    - Azure AD SCIM
+    - JumpCloud SCIM
+    - Team Mapping
+    - Role Mapping
+    - Concurrency Groups
 url: https://www.testmuai.com/support/docs/scim/
 site_name: LambdaTest
 slug: scim/
 canonical: https://www.testmuai.com/support/docs/scim/
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
-
 
 <script type="application/ld+json"
       dangerouslySetInnerHTML={{ __html: JSON.stringify({
@@ -31,117 +43,180 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
         },{
           "@type": "ListItem",
           "position": 3,
-          "name": "Scim",
+          "name": "SCIM Provisioning",
           "item": `${BRAND_URL}/support/docs/scim/`
         }]
       })
     }}
 ></script>
-The SCIM specification is designed to make managing user identities easier. SCIM allows your Identity Provider (IdP) to manage users within your <BrandName /> workspace
-> SSO must be integrated before enabling SCIM. Please see [Getting Started With Single Sign On (SSO)](/support/docs/single-sign-on/) or [support@testmuai.com](mailto:support@testmuai.com) for questions.
 
-## Benefits Of SCIM
-Here are the following benefits of integrating SCIM with <BrandName />:
+SCIM (System for Cross-domain Identity Management) lets your Identity Provider (IDP) automatically manage users and groups within your <BrandName /> organization — no manual account setup required.
 
-- **Efficiency and Automation**: SCIM automates the process of user identity management, making it more efficient and less error-prone. It enables automatic provisioning and de-provisioning of user accounts, reducing manual administrative tasks and associated errors.
-- **Consistency:**: SCIM ensures that user data is consistent across different systems and services. When a user's attributes (like role) are updated in the identity provider, SCIM can be used to propagate those changes to all connected service providers, maintaining accurate and up-to-date information.
-- **Security and Access Control:**:  By centralizing identity management through SCIM, organizations can better enforce access control policies and ensure that users have appropriate access rights to the resources they need. This can help mitigate security risks associated with improper access permissions.
-- **Assigning Groups to Users (If Groups Are Activated in Your Organization) :** If your organization has group functionality enabled, you can assign existing <BrandName /> groups to users provisioned through an Identity Provider (IdP) such as Microsoft Azure AD, Okta, and others using SCIM. 
-> Connect with our [24/7 customer support](mailto:support@testmuai.com) team to get the **Group** feature enabled for your organization.
+| Capability | What it does |
+|---|---|
+| **User Provisioning** | Auto-create, update, and deactivate user accounts |
+| **Group Provisioning** | Sync IDP groups and map them to <BrandName /> teams, concurrency groups, or sub-orgs |
+| **Role Assignment** | Set organization roles (Admin / User / Guest) from your IDP |
 
+> **SSO is required.** If you haven't set up SSO yet, see [Getting Started with SSO](/support/docs/single-sign-on/) first.
 
-## Feature Of SCIM
-<BrandName /> provides the support for the below SCIM features.
+<br />
 
-- **User Provisioning and De-provisioning**:  SCIM facilitates the automatic provisioning and de-provisioning of user accounts across different systems and services. When a user is added or removed from the identity provider, SCIM can be used to propagate these changes to your <BrandName /> account.
-- **Updating User Attributes**: Using SCIM you can update user attribute such as **Organization Role** directly from your Identity Provider.
+---
 
-## Copy SCIM Base URL and Bearer Token (Auth Header Required by IdP)
-**Step 1:** Sign in to your <BrandName /> account. Don't have an account, [register for free](https://accounts.lambdatest.com/register).
+## Setup {#setup}
 
-<img loading="lazy" src={require('../assets/images/lambdatest-mfa/dashboard.webp').default} alt="Image" width="404" height="206"  className="doc_img img_center"/><br/>
+**What you need:** Enterprise plan, SSO configured, Admin access, and an IDP that supports SCIM 2.0 (Okta, Azure AD, JumpCloud, etc.).
 
-**Step 2:**  Head to **Settings** and select **Organization Settings** from the dropdown.
+### Step 1 — Copy SCIM Credentials
 
-<img loading="lazy" src={require('../assets/images/lambdatest-mfa/org-settings.webp').default} alt="Image" width="404" height="206"  className="doc_img img_center"/><br/>
+Go to **Settings** > **Organization Settings** > **Security** tab. Copy the **SCIM Base URL** and **Bearer Token**.
 
-**Step 3:**  Head to the **Security** tab and click and copy the **SCIM Base URL and Bearer Token** option.
+<img loading="lazy" src={require('../assets/images/lambdatest-scim/scim-base-url.png').default} alt="SCIM Base URL and Bearer Token" width="404" height="206" className="doc_img img_center"/><br/>
 
-<img loading="lazy" src={require('../assets/images/lambdatest-scim/scim-base-url.png').default} alt="Image" width="404" height="206"  className="doc_img img_center"/><br/>
+### Step 2 — Configure Your IDP
 
-## SCIM User Attributes
-```javascript
-{
-    "schemas": [
-        "urn:ietf:params:scim:schemas:core:2.0:User",
-        "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
-    ],
-    "userName": "tester@test.com",
-    "active": true,
-    "name": {
-        "formatted": "givenName familyName",
-        "familyName": "familyName",
-        "givenName": "givenName"
-    },
-  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole" : "User"
-  }
-}
-```
+Paste the SCIM Base URL and Bearer Token into your IDP's provisioning settings.
 
-**schemas(required)**: An array of schema URNs (Uniform Resource Names) that define the structure and attributes of the user object. In this case, the JSON conforms to the SCIM (System for Cross-domain Identity Management) schema for users, including an extension schema for enterprise-specific attributes.
+<Tabs className="docs__val" groupId="idp-provider">
+<TabItem value="okta" label="Okta" default>
 
-**id** Unique Identifier assigned to provisioned users by <BrandName />
+Full walkthrough: [Okta SCIM Guide](/support/docs/scim/okta/)
 
-**userName(required)**: The username associated with the user **(Must be Email)**
+1. **Applications** > your <BrandName /> app > **Provisioning** tab > **Configure API Integration**
+2. Check **Enable API Integration**, paste credentials, click **Test API Credentials** > **Save**
+3. Under **To App**, enable: Create Users, Update User Attributes, Deactivate Users
+4. **Assignments** tab > assign users or groups
+5. *(For groups)* **Push Groups** tab > **Push Groups** > Find by name or rule
 
-**active(required)**: A boolean indicating whether the user's account is active or not.
+:::tip
+Member changes in pushed Okta groups are automatically synced to <BrandName />.
+:::
 
-**name(required)** An object containing the user's name information. The formatted property provides the full name, while familyName and givenName represent the family and given names respectively.
+</TabItem>
+<TabItem value="azure" label="Azure AD">
 
-**urn:ietf:params:scim:schemas:extension:<BrandName />:2.0:User**:This extension schema is used to add custom attributes or properties to the user object that are not part of the standard SCIM (System for Cross-domain Identity Management) core schema.
-Here you can set **OrganizationRole** which can have either of (Admin/User/Guest) values. If this attribute is not passed OrganizationRole is set to **User** by default
+Full walkthrough: [Azure AD SCIM Guide](/support/docs/scim/azure/)
 
-## Creating Users 
+1. **Enterprise Applications** > your <BrandName /> app > **Provisioning** > set to **Automatic**
+2. Under **Admin Credentials**, paste SCIM Base URL (Tenant URL) and Bearer Token (Secret Token) > **Test Connection** > **Save**
+3. Under **Mappings**, enable user and group provisioning
+4. Under **Users and groups**, assign what you want to provision
+5. Start a provisioning cycle (or wait for the 40-minute auto sync)
 
-If the user you want to add does not have a <BrandName /> account, user will be created. If the user has an existing account with <BrandName /> and is part of another organization then the user won't be auto provisioned, and you will need to add the user to your organization via team invite
+</TabItem>
+<TabItem value="jumpcloud" label="JumpCloud">
 
-## Updating User Attributes
-Only Organization Role can be updated for users, userName(email) can't be updated once user is created and Name can only be updated from <BrandName /> Account Settings page
+Full walkthrough: [JumpCloud SCIM Guide](/support/docs/scim/jumpcloud/)
 
+1. **SSO Applications** > your <BrandName /> app > **Identity Management** tab
+2. Enable **SCIM Provisioning**, paste credentials
+3. Configure attribute mappings (userName, name, active)
+4. **User Groups** tab > select groups > **Activate** > **Save**
 
-## Deleting or Deactivating users 
-User accounts can only be deactivated (active:false) via PUT/PATCH or DELETE User requests, For permanently deleting account users need to request account deletion from <BrandName /> Account Settings page
+</TabItem>
+<TabItem value="other" label="Other IDPs">
 
-## User Operations
-## Create User 
+Any SCIM 2.0-compliant IDP works. Use these settings:
 
-### Request 
+| Setting | Value |
+|---|---|
+| **SCIM Base URL** | From Organization Settings > Security |
+| **Authentication** | Bearer Token (HTTP Header) |
+| **User Schema** | `urn:ietf:params:scim:schemas:core:2.0:User` |
+| **Group Schema** | `urn:ietf:params:scim:schemas:core:2.0:Group` |
+| **LambdaTest User Extension** | `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User` |
+| **LambdaTest Group Extension** | `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group` |
 
-POST `https://auth.lambdatest.com/api/scim/Users`
+</TabItem>
+</Tabs>
 
-```javascript
+<br />
+
+---
+
+## User Provisioning {#user-provisioning}
+
+### How It Works
+
+| Scenario | What happens |
+|---|---|
+| New user (email doesn't exist) | Account created and added to your org |
+| Existing user (same org) | Attributes (role, active) updated |
+| Existing user (different org) | **Not** provisioned — invite via team invite first |
+
+### Schema & Attributes
+
+```json
 {
   "schemas": [
     "urn:ietf:params:scim:schemas:core:2.0:User",
     "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
   ],
-  "userName": "tester@test.com",
+  "userName": "jane@company.com",
   "active": true,
-  "name": {
-    "formatted": "givenName familyName",
-    "familyName": "familyName",
-    "givenName": "givenName"
-  },
+  "name": { "givenName": "Jane", "familyName": "Doe", "formatted": "Jane Doe" },
   "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole" : "User"
+    "OrganizationRole": "User"
   }
 }
 ```
 
-### Response 
+| Attribute | Required | Notes |
+|---|---|---|
+| `userName` | Yes | Must be a valid email. **Cannot be changed after creation.** |
+| `active` | Yes | `true` = enabled, `false` = deactivated |
+| `name` | Yes | `givenName`, `familyName`, `formatted` |
+| `OrganizationRole` | No | `Admin`, `User` (default), or `Guest` |
 
-HTTP/1.1 201 Created
+> **What can be updated:** Only `OrganizationRole` and `active` can be updated via SCIM. `userName` is immutable after creation. `name` can only be changed from <BrandName /> Account Settings.
+
+### User API Operations
+
+<Tabs className="docs__val">
+<TabItem value="create-user" label="Create" default>
+
+**Request:** POST `https://auth.lambdatest.com/api/scim/Users`
+
+```json
+{
+  "schemas": [
+    "urn:ietf:params:scim:schemas:core:2.0:User",
+    "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
+  ],
+  "userName": "jane@company.com",
+  "active": true,
+  "name": { "givenName": "Jane", "familyName": "Doe", "formatted": "Jane Doe" },
+  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
+    "OrganizationRole": "User"
+  }
+}
+```
+
+**Response:** `201 Created`
+
+```json
+{
+  "schemas": [
+    "urn:ietf:params:scim:schemas:core:2.0:User",
+    "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
+  ],
+  "id": "23123",
+  "userName": "jane@company.com",
+  "active": true,
+  "name": { "givenName": "Jane", "familyName": "Doe", "formatted": "Jane Doe" },
+  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
+    "OrganizationRole": "User"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="get-user" label="Get by ID">
+
+**Request:** GET `https://auth.lambdatest.com/api/scim/Users/{id}`
+
+**Response:** `200 OK`
 
 ```json
 {
@@ -150,329 +225,555 @@ HTTP/1.1 201 Created
     "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
   ],
   "id": "23123",
-  "userName": "tester@test.com",
+  "userName": "jane@company.com",
   "active": true,
-  "name": {
-    "formatted": "givenName familyName",
-    "familyName": "familyName",
-    "givenName": "givenName"
-  },
+  "name": { "givenName": "Jane", "familyName": "Doe", "formatted": "Jane Doe" },
   "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole" : "User"
+    "OrganizationRole": "User"
   }
 }
 ```
 
-## GET Users
+**Errors:** `404 Not Found` if user doesn't exist. `400 Bad Request` if user belongs to a different org.
 
-### Request 
+</TabItem>
+<TabItem value="list-users" label="List / Filter">
 
-GET `https://auth.lambdatest.com/api/scim/USERS`
+**Request:** GET `https://auth.lambdatest.com/api/scim/Users`
 
-### Response
+Filter by email: `?filter=userName eq "jane@company.com"`
 
-HTTP/1.1 200 OK
+**Response:** `200 OK`
 
 ```json
 {
-    "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-    "totalResults": 1,
-    "Resources": [{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "totalResults": 1,
+  "startIndex": 1,
+  "itemsPerPage": 20,
+  "Resources": [
+    {
       "schemas": [
         "urn:ietf:params:scim:schemas:core:2.0:User",
         "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
       ],
       "id": "23123",
-      "userName": "tester@test.com",
+      "userName": "jane@company.com",
       "active": true,
-      "name": {
-        "formatted": "givenName familyName",
-        "familyName": "familyName",
-        "givenName": "givenName"
-      },
+      "name": { "givenName": "Jane", "familyName": "Doe", "formatted": "Jane Doe" },
       "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-        "OrganizationRole" : "User"
+        "OrganizationRole": "User"
       }
-    }],
-    "startIndex": 1,
-    "itemsPerPage": 20
+    }
+  ]
 }
 ```
 
-### Response - Zero Results
+**Zero results:** Returns `"totalResults": 0` with empty `"Resources": []`.
 
-HTTP/1.1 200 OK
-```json
-{
-    "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-    "totalResults": 0,
-    "Resources": [],
-    "startIndex": 1,
-    "itemsPerPage": 20
-}
-```
+**Errors:** `400 Bad Request` if user belongs to a different org.
 
-## GET Users by query
+</TabItem>
+<TabItem value="update-put" label="Update (PUT)">
 
-### Request
-
-You can only filter users using email in the following format
-
-GET `https://auth.lambdatest.com/api/scim/Users?filter=userName` eq "tester@test.com"
-
-### Response
+**Request:** PUT `https://auth.lambdatest.com/api/scim/Users/{id}`
 
 ```json
 {
-    "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-    "totalResults": 1,
-    "Resources": [{
-      "schemas": [
-        "urn:ietf:params:scim:schemas:core:2.0:User",
-        "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
-      ],
-      "id": "23123",
-      "userName": "tester@test.com",
-      "active": true,
-      "name": {
-        "formatted": "givenName familyName",
-        "familyName": "familyName",
-        "givenName": "givenName"
-      },
-      "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-        "OrganizationRole" : "User"
-      }
-    }],
-    "startIndex": 1,
-    "itemsPerPage": 20
-}
-```
-
-### Response Zero results
-HTTP/1.1 200 OK
-```json
-{
-    "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
-    "totalResults": 0,
-    "Resources": [],
-    "startIndex": 1,
-    "itemsPerPage": 20
-}
-```
-### Response User is part of a different org
-HTTP/1.1 400 Bad Request
-
-
-## GET User by id
-
-### Request
-
-GET `https://auth.lambdatest.com/api/scim/Users/id`
-
-### Response 
-HTTP/1.1 200 OK
-```json
-{
-  "schemas": [
-    "urn:ietf:params:scim:schemas:core:2.0:User",
-    "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
-  ],
-  "id": "23123",
-  "userName": "tester@test.com",
-  "active": true,
-  "name": {
-    "formatted": "givenName familyName",
-    "familyName": "familyName",
-    "givenName": "givenName"
-  },
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
   "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole" : "User"
-  }
-}
-```
-
-### Response User not found 
-HTTP/1.1 404 Not Found
-
-### Response User is part of a different org
-HTTP/1.1 400 Bad Request
-
-
-## Update a specific User (PUT)
-
-Only  OrganizationRole or Active Fields can be updated
-
-### Request 
-
-PUT `https://auth.lambdatest.com/api/scim/Users/id` HTTP/1.1
-```json
-{
-    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
-  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole" : "User"
+    "OrganizationRole": "Admin"
   },
   "active": true
 }
 ```
 
-### Response 
-HTTP/1.1 200 OK
+**Response:** `200 OK` — returns the full updated user object.
+
+**Errors:** `404 Not Found` if user doesn't exist. `400 Bad Request` if user belongs to a different org.
+
+</TabItem>
+<TabItem value="update-patch" label="Update (PATCH)">
+
+**Request:** PATCH `https://auth.lambdatest.com/api/scim/Users/{id}`
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    { "op": "Replace", "path": "active", "value": false },
+    { "op": "Replace", "path": "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User:OrganizationRole", "value": "Guest" }
+  ]
+}
+```
+
+**Response:** `200 OK` — returns the full updated user object.
+
+**Errors:** `404 Not Found` if user doesn't exist. `400 Bad Request` if user belongs to a different org.
+
+</TabItem>
+<TabItem value="disable-user" label="Disable">
+
+**Request:** PATCH `https://auth.lambdatest.com/api/scim/Users/{id}`
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    { "op": "Replace", "path": "active", "value": false }
+  ]
+}
+```
+
+**Response:** `200 OK` — returns user object with `"active": false`.
+
+**Errors:** `404 Not Found` if user doesn't exist. `400 Bad Request` if user belongs to a different org.
+
+</TabItem>
+<TabItem value="delete-user" label="Delete">
+
+**Request:** DELETE `https://auth.lambdatest.com/api/scim/Users/{id}`
+
+**Response:** `204 No Content`
+
+:::warning
+DELETE only **deactivates** the account — it does not permanently delete it. For permanent deletion, the user must request it from <BrandName /> Account Settings.
+:::
+
+**Errors:** `404 Not Found` if user doesn't exist. `400 Bad Request` if user belongs to a different org.
+
+</TabItem>
+</Tabs>
+
+<br />
+
+---
+
+## Group Provisioning {#group-provisioning}
+
+### How It Works
+
+Groups and members are stored **as soon as your IDP pushes them** — even before any mapping is configured. Mapping only controls **where** members are assigned (which team, group, or sub-org).
+
+<div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0', margin: '2rem 0'}}>
+
+  <div style={{border: '1px solid #d1d5db', borderRadius: '10px', padding: '16px 28px', textAlign: 'center', width: '100%', maxWidth: '500px', background: '#f9fafb'}}>
+    <div style={{fontSize: '11px', textTransform: 'uppercase', letterSpacing: '1px', color: '#6b7280', marginBottom: '4px'}}>Step 1 — Your IDP (automatic)</div>
+    <div style={{fontSize: '15px', fontWeight: 600, color: '#111827'}}>Groups & members pushed via SCIM</div>
+  </div>
+
+  <div style={{fontSize: '22px', lineHeight: '1', color: '#9ca3af', userSelect: 'none'}}>↓</div>
+
+  <div style={{border: '1px solid #d1d5db', borderRadius: '10px', padding: '16px 28px', textAlign: 'center', width: '100%', maxWidth: '500px', background: '#f9fafb'}}>
+    <div style={{fontSize: '11px', textTransform: 'uppercase', letterSpacing: '1px', color: '#6b7280', marginBottom: '4px'}}>Step 2 — LambdaTest (automatic)</div>
+    <div style={{fontSize: '15px', fontWeight: 600, color: '#111827'}}>Group stored & roles applied to members</div>
+    <div style={{fontSize: '12px', color: '#6b7280', marginTop: '4px'}}>Members get roles immediately, even without mapping</div>
+  </div>
+
+  <div style={{fontSize: '22px', lineHeight: '1', color: '#9ca3af', userSelect: 'none'}}>↓</div>
+
+  <div style={{border: '1px solid #d1d5db', borderRadius: '10px', padding: '16px 28px', textAlign: 'center', width: '100%', maxWidth: '500px', background: '#f9fafb'}}>
+    <div style={{fontSize: '11px', textTransform: 'uppercase', letterSpacing: '1px', color: '#6b7280', marginBottom: '4px'}}>Step 3 — Admin (manual) or Mapping Rules (automatic)</div>
+    <div style={{fontSize: '15px', fontWeight: 600, color: '#111827'}}>Group mapped to a LambdaTest entity</div>
+  </div>
+
+  <div style={{display: 'flex', justifyContent: 'center', gap: '8px', marginTop: '-4px'}}>
+    <div style={{fontSize: '22px', lineHeight: '1', color: '#9ca3af', userSelect: 'none'}}>↙</div>
+    <div style={{fontSize: '22px', lineHeight: '1', color: '#9ca3af', userSelect: 'none'}}>↓</div>
+    <div style={{fontSize: '22px', lineHeight: '1', color: '#9ca3af', userSelect: 'none'}}>↘</div>
+  </div>
+
+  <div style={{display: 'flex', gap: '12px', width: '100%', maxWidth: '600px', justifyContent: 'center', flexWrap: 'wrap'}}>
+    <div style={{border: '1px solid #d1d5db', borderRadius: '10px', padding: '14px 18px', textAlign: 'center', flex: '1', minWidth: '150px', background: '#fff'}}>
+      <div style={{fontSize: '14px', fontWeight: 600, color: '#111827'}}>Team</div>
+      <span style={{display: 'inline-block', marginTop: '6px', background: '#e5e7eb', color: '#374151', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.5px', padding: '2px 8px', borderRadius: '999px'}}>Additive</span>
+      <div style={{fontSize: '11px', color: '#6b7280', marginTop: '6px'}}>Multiple teams allowed</div>
+    </div>
+    <div style={{border: '1px solid #d1d5db', borderRadius: '10px', padding: '14px 18px', textAlign: 'center', flex: '1', minWidth: '150px', background: '#fff'}}>
+      <div style={{fontSize: '14px', fontWeight: 600, color: '#111827'}}>Concurrency Group</div>
+      <span style={{display: 'inline-block', marginTop: '6px', background: '#e5e7eb', color: '#374151', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.5px', padding: '2px 8px', borderRadius: '999px'}}>Exclusive</span>
+      <div style={{fontSize: '11px', color: '#6b7280', marginTop: '6px'}}>User can only belong to one</div>
+    </div>
+    <div style={{border: '1px solid #d1d5db', borderRadius: '10px', padding: '14px 18px', textAlign: 'center', flex: '1', minWidth: '150px', background: '#fff'}}>
+      <div style={{fontSize: '14px', fontWeight: 600, color: '#111827'}}>Sub-Organization</div>
+      <span style={{display: 'inline-block', marginTop: '6px', background: '#e5e7eb', color: '#374151', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.5px', padding: '2px 8px', borderRadius: '999px'}}>Exclusive</span>
+      <div style={{fontSize: '11px', color: '#6b7280', marginTop: '6px'}}>User can only belong to one</div>
+    </div>
+  </div>
+
+</div>
+
+### Enabling & Disabling
+
+:::note
+Group provisioning is not enabled by default. Reach out to our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> or email [support@testmuai.com](mailto:support@testmuai.com) to get it activated for your organization.
+:::
+
+Once activated, you can control it from **Settings** > **Organization Settings** > **Security** > **SCIM Group Provisioning**.
+
+<!-- <img loading="lazy" src={require('../assets/images/lambdatest-scim/group-provisioning-toggle.png').default} alt="SCIM Group Provisioning toggle" width="404" height="206" className="doc_img img_center"/><br/> -->
+
+> **When toggled OFF:** New IDP group operations (create/update/delete) are rejected with `403`. Existing groups, mappings, and assignments are preserved — nothing is deleted. Toggle back ON to resume syncing.
+
+### Group Schema & Attributes
+
 ```json
 {
   "schemas": [
-    "urn:ietf:params:scim:schemas:core:2.0:User",
-    "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
+    "urn:ietf:params:scim:schemas:core:2.0:Group",
+    "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group"
   ],
-  "id": "23123",
-  "userName": "tester@test.com",
-  "active": true,
-  "name": {
-    "formatted": "givenName familyName",
-    "familyName": "familyName",
-    "givenName": "givenName"
-  },
-  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole" : "User"
+  "displayName": "eng-backend",
+  "members": [{ "value": "12345" }, { "value": "67890" }],
+  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group": {
+    "LambdatestRoles": ["User"]
   }
 }
 ```
-### Response User not found
-HTTP/1.1 404 Not Found
 
-### Response User is part of a different org
-HTTP/1.1 400 Bad Request
+| Attribute | Required | Notes |
+|---|---|---|
+| `displayName` | Yes | Must be **unique** within your org |
+| `members` | No | Array of `{ "value": "<user_scim_id>" }` |
+| `LambdatestRoles` | No | `Admin`, `User`, or `Guest` — applied to all members |
 
-## Update a specific User (PATCH)
+### Mapping Groups to LambdaTest Entities
 
-Only OrganizationRole or Active Fields can be updated
+Once a group is pushed, it needs to be **mapped** to tell <BrandName /> what to do with its members. A single group can have **multiple mappings** — e.g., map `eng-backend` to both a Team and a Concurrency Group simultaneously.
 
-### Request
+| Target | Type | On member removal | Auto-create | Conflicts |
+|---|---|---|---|---|
+| **Team** | `Additive` — user can be in multiple teams | Removed from team (unless another SCIM group maps them there) | Yes | No |
+| **Concurrency Group** | `Exclusive` — user can only belong to one | Moved back to org default group | Yes | Yes — if same user maps to two different groups |
+| **Sub-Organization** | `Exclusive` — user can only belong to one | Moved back to root org | No (requires manual setup) | Yes — if same user maps to two different sub-orgs |
 
-PATCH `https://auth.lambdatest.com/api/scim/Users/id` HTTP/1.1
+> **Mapping statuses:** `Pending` → `Approved` / `Auto-Approved` (members synced) or `Rejected` (no sync)
+
+**To map manually:** Go to **SCIM Group Provisioning** dashboard > click a Pending group > select target type and entity > **Approve**.
+
+<!-- <img loading="lazy" src={require('../assets/images/lambdatest-scim/group-approve-mapping.png').default} alt="Approving a SCIM group mapping" width="404" height="206" className="doc_img img_center"/><br/> -->
+
+### Mapping Rules (Automatic Mapping)
+
+Instead of mapping each group manually, create rules that auto-match groups by name.
+
+<Tabs className="docs__val">
+<TabItem value="prefix" label="Prefix" default>
+
+Matches group names **starting with** a pattern (case-insensitive).
+
+`eng-` matches `eng-backend`, `eng-frontend`, `ENG-DevOps`
+
+</TabItem>
+<TabItem value="regex" label="Regex">
+
+Matches group names against a **regular expression**.
+
+`^qa-.*-team$` matches `qa-mobile-team`, `qa-web-team`
+
+</TabItem>
+<TabItem value="all" label="Match All">
+
+Matches **every group**. Use as a low-priority catch-all fallback.
+
+</TabItem>
+</Tabs>
+
+**Each rule has an auto-approve toggle:**
+- **ON** → finds (or creates) the target entity by name → mapping approved → members synced immediately.
+- **OFF** → creates a Pending mapping → admin approves manually.
+
+**Rules are evaluated by priority** (highest first). First match wins.
+
+| Priority | Rule | Target | Auto-Approve | Example match |
+|---|---|---|---|---|
+| 3 | Prefix: `eng-` | Team | ON | `eng-backend` → auto-approved Team |
+| 2 | Prefix: `qa-` | Team | ON | `qa-mobile` → auto-approved Team |
+| 1 | Match All | Concurrency Group | OFF | `design-ops` → Pending |
+
+**To create a rule:**
+
+1. Go to **SCIM Group Provisioning** dashboard
+2. Click **Add Mapping Rule**
+3. Select a **rule type** (Prefix, Regex, or Match All)
+4. Enter the **pattern** to match group names against
+5. Choose the **target type** (Team, Concurrency Group, or Sub-Organization)
+6. Toggle **auto-approve** ON if you want matched groups to be approved automatically
+7. Click **Save**
+
+
+### Role Assignment
+
+Roles can be set per-user (User extension `OrganizationRole`) or per-group (Group extension `LambdatestRoles`). Roles work **independently of mappings** — even unmapped groups apply their roles to members immediately.
+
+When a user is in **multiple groups with different roles**, the highest-priority role wins: **Admin > User > Guest**
+
+| Group | Role |
+|---|---|
+| `eng-team` | User |
+| `org-admins` | Admin |
+| **Effective role** | **Admin** (highest wins) |
+
+### Conflicts
+
+Conflicts happen when a user belongs to multiple SCIM groups mapped to **different exclusive entities** (e.g., different concurrency groups or different sub-orgs).
+
+**To resolve:** SCIM Group Provisioning dashboard > **Conflicts** section > select the winning group > **Resolve**.
+
+The user is moved to the winning group's target. <BrandName /> remembers this decision — if the same situation recurs, no new conflict is created.
+
+:::tip To avoid conflicts
+- Don't put the same user in two SCIM groups that map to **different concurrency groups**.
+- Don't put the same user in two SCIM groups that map to **different sub-organizations**.
+- Prefer **teams** when users need to be in multiple groups — teams have no conflicts.
+:::
+
+### Group API Operations
+
+<Tabs className="docs__val">
+<TabItem value="create-group" label="Create" default>
+
+**Request:** POST `https://auth.lambdatest.com/api/scim/Groups`
+
 ```json
 {
   "schemas": [
-    "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+    "urn:ietf:params:scim:schemas:core:2.0:Group",
+    "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group"
   ],
-  "Operations": [
+  "displayName": "eng-backend",
+  "members": [
+    { "value": "23123" },
+    { "value": "23456" }
+  ],
+  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group": {
+    "LambdatestRoles": ["User"]
+  }
+}
+```
+
+**Response:** `201 Created`
+
+```json
+{
+  "schemas": [
+    "urn:ietf:params:scim:schemas:core:2.0:Group",
+    "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group"
+  ],
+  "id": "50001",
+  "displayName": "eng-backend",
+  "members": [
+    { "value": "23123", "display": "jane@company.com" },
+    { "value": "23456", "display": "bob@company.com" }
+  ],
+  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group": {
+    "LambdatestRoles": ["User"]
+  },
+  "meta": {
+    "resourceType": "Group",
+    "created": "2025-01-15T10:30:00Z",
+    "lastModified": "2025-01-15T10:30:00Z"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="list-groups" label="List / Filter">
+
+**Request:** GET `https://auth.lambdatest.com/api/scim/Groups`
+
+Filter by name: `?filter=displayName eq "eng-backend"` | Paginate: `?startIndex=1&count=20`
+
+**Response:** `200 OK`
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "totalResults": 1,
+  "startIndex": 1,
+  "itemsPerPage": 20,
+  "Resources": [
     {
-      "op": "Replace",
-      "path": "active",
-      "value": false
-    },
-    {
-      "op": "Replace",
-      "path": "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User:OrganizationRole",
-      "value": "User"
+      "schemas": [
+        "urn:ietf:params:scim:schemas:core:2.0:Group",
+        "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group"
+      ],
+      "id": "50001",
+      "displayName": "eng-backend",
+      "members": [
+        { "value": "23123", "display": "jane@company.com" },
+        { "value": "23456", "display": "bob@company.com" }
+      ],
+      "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group": {
+        "LambdatestRoles": ["User"]
+      },
+      "meta": {
+        "resourceType": "Group",
+        "created": "2025-01-15T10:30:00Z",
+        "lastModified": "2025-01-15T10:30:00Z"
+      }
     }
   ]
 }
 ```
 
-### Response
-HTTP/1.1 200 OK
+**Zero results:** Returns `"totalResults": 0` with empty `"Resources": []`.
+
+</TabItem>
+<TabItem value="update-group" label="Update">
+
+**PUT** (full replace) to `https://auth.lambdatest.com/api/scim/Groups/{id}` — replaces entire membership list. Members removed from the list are unassigned from all mapped entities.
+
+**PATCH** (partial) to `https://auth.lambdatest.com/api/scim/Groups/{id}`:
+
+<Tabs className="docs__val">
+<TabItem value="patch-add" label="Add Members" default>
+
 ```json
 {
-  "schemas": [
-    "urn:ietf:params:scim:schemas:core:2.0:User",
-    "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
-  ],
-  "id": "23123",
-  "userName": "tester@test.com",
-  "active": false,
-  "name": {
-    "formatted": "givenName familyName",
-    "familyName": "familyName",
-    "givenName": "givenName"
-  },
-  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole" : "User"
-  }
-}
-```
-### Response User not found
-HTTP/1.1 404 Not Found
-
-### Response User is part of a different org
-HTTP/1.1 400 Bad Request
-
-## Disable a specific User (PATCH)
-
-Only OrganizationRole or Active Fields can be updated
-
-### Request
-
-PATCH `https://auth.lambdatest.com/api/scim/Users/id` HTTP/1.1
-```json
-{
-  "schemas": [
-    "urn:ietf:params:scim:api:messages:2.0:PatchOp"
-  ],
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
   "Operations": [
     {
-      "op": "Replace",
-      "path": "active",
-      "value": false
+      "op": "Add",
+      "path": "members",
+      "value": [{ "value": "99999" }]
     }
   ]
 }
 ```
 
-### Response
-HTTP/1.1 200 OK
+</TabItem>
+<TabItem value="patch-remove" label="Remove Members">
+
 ```json
 {
-  "schemas": [
-    "urn:ietf:params:scim:schemas:core:2.0:User",
-    "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User"
-  ],
-  "id": "23123",
-  "userName": "tester@test.com",
-  "active": false,
-  "name": {
-    "formatted": "givenName familyName",
-    "familyName": "familyName",
-    "givenName": "givenName"
-  },
-  "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole" : "User"
-  }
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    {
+      "op": "Remove",
+      "path": "members",
+      "value": [{ "value": "12345" }]
+    }
+  ]
 }
 ```
-### Response User not found
-HTTP/1.1 404 Not Found
 
-### Response User is part of a different org
-HTTP/1.1 400 Bad Request
+</TabItem>
+<TabItem value="patch-rename" label="Rename">
 
-## Delete User
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    {
+      "op": "Replace",
+      "path": "displayName",
+      "value": "eng-platform"
+    }
+  ]
+}
+```
 
-Note: Delete User Request only sets user account to inactive
+</TabItem>
+<TabItem value="patch-roles" label="Update Roles">
 
-### Request
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    {
+      "op": "Replace",
+      "path": "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group:LambdatestRoles",
+      "value": ["Admin"]
+    }
+  ]
+}
+```
 
-DELETE `https://auth.lambdatest.com/api/scim/Users/id` HTTP/1.1
+</TabItem>
+</Tabs>
 
+**Response:** `200 OK` — returns the updated group object with new membership and `meta.lastModified` timestamp.
 
-### Response
-HTTP/1.1 204 No Content
+**Errors:** `404 Not Found` if group doesn't exist. `409 Conflict` if renamed to an existing `displayName`.
 
-### Response User not found
-HTTP/1.1 404 Not Found
+</TabItem>
+<TabItem value="delete-group" label="Delete">
 
-### Response User is part of a different org
-HTTP/1.1 400 Bad Request
+**Request:** DELETE `https://auth.lambdatest.com/api/scim/Groups/{id}`
 
+**Response:** `204 No Content`
 
-## See Limitations
+**On delete:** group is soft-deleted, roles recomputed, members safely unassigned from all mapped entities (checking other group memberships first), mappings rejected, related conflicts auto-resolved.
 
-The following is the list of <BrandName /> SCIM limitations
+**Errors:** `404 Not Found` if group doesn't exist.
 
-* Users existing in another organizations won't be auto provisioned
-* Delete User Request only sets user account to inactive
+</TabItem>
+</Tabs>
 
+<br />
 
-> That's all you need to know about Single sign-on(SSO) authentication feature.In case you have any questions please feel free to reach out to us via the <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> or email us over [support@testmuai.com](mailto:support@testmuai.com).
+---
+
+## Side Effects & Behaviors {#side-effects}
+
+Quick reference for what happens during common operations. These are handled automatically — no action required unless noted.
+
+### Changes from Your IDP
+
+| Action | What happens | Admin action needed? |
+|---|---|---|
+| **Group renamed** | Name updated. Mapping rules re-evaluated — if a different rule matches, mapping reverts to **Pending**. Members unaffected. | Only if mapping status changed to Pending |
+| **Group deleted** | Soft-deleted. Roles recomputed. Members safely unassigned (checks other groups first). Mappings rejected. Conflicts auto-resolved. | No |
+| **Member removed from group** | Unassigned from mapped entities — but only if no other SCIM group maps them to the same target. Otherwise seamlessly reassigned or conflict created. | Only if conflict created |
+| **Previously deleted group re-pushed** | Group restored. Members must be re-pushed. Mapping rules re-evaluated. | Depends on rules |
+
+### Changes from LambdaTest Admin
+
+| Action | What happens | Important |
+|---|---|---|
+| **Team / group / sub-org renamed** | **Nothing breaks.** Mappings use internal IDs, not names. | No action needed |
+| **Mapped entity deleted** | Mapping reverts to Pending with target cleared on next sync. | Re-approve with a new target |
+| **Member manually removed from team** | Removal is immediate but **temporary** — next IDP sync re-adds them. | To permanently remove, do it **in your IDP** |
+| **Manual assignment to concurrency group / sub-org** | SCIM overrides non-SCIM assignments for exclusive entities on next sync. | Avoid conflicting manual + SCIM assignments |
+
+<br />
+
+---
+
+## Troubleshooting {#troubleshooting}
+
+### API Errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Invalid or expired Bearer Token | Regenerate in Organization Settings > Security |
+| `403 Forbidden` | Group Provisioning is disabled | Enable the toggle in Security settings |
+| `404 Not Found` | ID doesn't exist or belongs to a different org | Verify via a List call |
+| `409 Conflict` | Group with same `displayName` already exists | Rename or delete the existing group |
+| `400 Bad Request` | User exists in a different organization | Invite them via team invite first |
+
+### Common Issues
+
+| Issue | Solution |
+|---|---|
+| Members not appearing in teams or sub-orgs | Group mapping is still **Pending**. Approve it in the dashboard or create an auto-approve mapping rule. |
+| User has an unexpected role | Roles follow highest-priority-wins (Admin > User > Guest). Check all SCIM group memberships — they may inherit Admin from another group. |
+| User keeps getting re-added after manual removal | SCIM is the source of truth. Remove the user from the group **in your IDP** instead. |
+| Group mapping reverted to Pending | Group was renamed (rules re-evaluated) or target entity was deleted. Re-approve with a valid target. |
+| Auto-approve didn't create my sub-organization | Sub-orgs are never auto-created (billing setup required). Approve manually and select the target. |
+
+### FAQ
+
+| Question | Answer |
+|---|---|
+| Can a group be mapped to multiple targets? | Yes. Each mapping syncs independently. |
+| Can I disable group provisioning without affecting users? | Yes. The toggle only affects group operations. |
+| Can I restore a deleted group? | Push a group with the same `displayName` from your IDP — the soft-deleted record is restored. Members must be re-pushed. |
+
+---
+
+> That's all you need to know about SCIM Provisioning with <BrandName />. In case you have any questions please feel free to reach out to us via the <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> or email us over [support@testmuai.com](mailto:support@testmuai.com).
 
 
 <nav aria-label="breadcrumbs">
@@ -489,7 +790,7 @@ The following is the list of <BrandName /> SCIM limitations
     </li>
     <li className="breadcrumbs__item breadcrumbs__item--active">
       <span className="breadcrumbs__link">
-        Single Sign On
+        SCIM Provisioning
       </span>
     </li>
   </ul>

--- a/sidebars.js
+++ b/sidebars.js
@@ -4431,7 +4431,7 @@ module.exports = {
     [
       {
         type: "doc",
-        label: "Getting Started with Scim",
+        label: "SCIM Provisioning",
         id: "scim",
       },
       {


### PR DESCRIPTION
## Summary
- Merged separate user provisioning and group provisioning docs into a single unified SCIM page (`docs/scim.md`)
- Added group provisioning documentation: flowcharts, mapping targets (teams, concurrency groups, sub-orgs), mapping rules (prefix/regex/match-all), role assignment, conflict resolution
- Added full API request/response examples for all user and group SCIM operations (Create, Get by ID, List/Filter, Update PUT, Update PATCH, Disable, Delete)
- Added interactive elements: tabs for IDP setup and PATCH operations, visual flowchart for group provisioning flow, mapping status flow, side effects & behaviors reference tables
- Updated sidebar label from "Getting Started with Scim" to "SCIM Provisioning"
- Added contact support note for enabling group provisioning (feature flag gated)

## Test plan
- [ ] Verify `npx docusaurus build` compiles successfully (Client + Server)
- [ ] Preview at `/support/docs/scim/` — check all tabs render correctly
- [ ] Verify flowchart renders properly on desktop and mobile
- [ ] Verify all API code blocks have correct JSON formatting
- [ ] Check sidebar shows "SCIM Provisioning" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)