### PR TITLE
[TE-1898] SCIM Group Provisioning docs — readability improvements

### DIFF
--- a/docs/azure-scim.md
+++ b/docs/azure-scim.md
@@ -114,6 +114,50 @@ In the above example we are using the appRoleAssignments attribute of microsoft 
 
 After custom attribute creation, we have to map them using “Add new mapping”
 
+## Provisioning Groups from Azure AD
+
+Once user provisioning is configured, you can also push Azure AD groups to <BrandName />.
+
+:::note Prerequisites
+Group Provisioning must be enabled for your org. Contact <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> to activate it.
+:::
+
+**Step 1:** In Azure portal, go to your <BrandName /> Enterprise Application > **Provisioning** > **Mappings**.
+
+**Step 2:** Click **Provision Azure Active Directory Groups** and ensure it is **Enabled**.
+
+**Step 3:** Review the attribute mappings. The required mappings are:
+- `displayName` → `displayName`
+- `members` → `members`
+
+**Step 4:** Under **Users and groups**, assign the groups you want to provision.
+
+**Step 5:** Start a provisioning cycle (or wait for the 40-minute auto sync).
+
+**Step 6:** In <BrandName />, go to **Settings** > **Organization Settings** > **SCIM Group Provisioning** to view the synced groups and configure mappings.
+
+### Setting Roles on Azure AD Groups
+
+Azure AD sends roles via the SCIM group extension `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group`. To assign roles:
+
+1. Create a custom attribute `LambdatestRoles` under the group schema in your Azure AD attribute mappings
+2. Map it to an Azure AD attribute or set it as a constant (e.g., `User`, `Admin`, or `Guest`)
+3. The role applies to **all** members of the group. Highest role wins across multiple groups (Admin > User > Guest)
+
+### What Happens After Provisioning
+
+| Azure AD Action | <BrandName /> Effect |
+|---|---|
+| Group provisioned | Group created, mapping rules evaluated, members synced |
+| Member added to group | Member added to all mapped <BrandName /> entities |
+| Member removed from group | Member removed (if no other group maps them there), role recomputed |
+| Group renamed | Group renamed, mapped entity renamed to match, rules re-evaluated |
+| Group deprovisioned | Group soft-deleted, members safely unassigned, roles recomputed |
+
+> For details on mapping, conflicts, and rules, see the [SCIM Provisioning guide](/support/docs/scim/#group-provisioning).
+
+---
+
 **Step 10:** To enable the Azure AD provisioning service for <BrandName />, change the Provisioning Status to On in the Settings section.
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/azure-ad/provisioning-on.png').default} alt="Image" width="404" height="206"  className="doc_img img_center"/><br/>
 

--- a/docs/jumpcloud-scim.md
+++ b/docs/jumpcloud-scim.md
@@ -115,6 +115,36 @@ In the documentation, we will discuss how to integrate JumpCloud with <BrandName
 - **Step 13:**  Go **Identity Management** and paste **SCIM Base URL** and **Bearer Token**. and then click Save button.
   <img loading="lazy" src={require('../assets/images/lambdatest-scim/jumpcloud-scim/18.png').default} alt="jira-self-hosted-integration"  className="doc_img"/> 
 
+## Provisioning Groups from JumpCloud
+
+Once SCIM user provisioning is working, you can also push JumpCloud user groups to <BrandName />.
+
+:::note Prerequisites
+Group Provisioning must be enabled for your org. Contact <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> to activate it.
+:::
+
+**Step 1:** In JumpCloud Admin Console, go to your <BrandName /> SSO Application > **User Groups** tab.
+
+**Step 2:** Select the user groups you want to provision to <BrandName />.
+
+**Step 3:** Click **Activate** to start pushing group membership via SCIM.
+
+**Step 4:** In <BrandName />, go to **Settings** > **Organization Settings** > **SCIM Group Provisioning** to view the synced groups and configure mappings.
+
+### What Happens After Provisioning
+
+| JumpCloud Action | <BrandName /> Effect |
+|---|---|
+| Group activated for provisioning | Group created, mapping rules evaluated, members synced |
+| User added to group | Member added to all mapped <BrandName /> entities |
+| User removed from group | Member removed (if no other group maps them there), role recomputed |
+| Group renamed | Group renamed, mapped entity renamed to match, rules re-evaluated |
+| Group deactivated/deleted | Group soft-deleted, members safely unassigned, roles recomputed |
+
+> For details on mapping, conflicts, and rules, see the [SCIM Provisioning guide](/support/docs/scim/#group-provisioning).
+
+---
+
 - **Step 14:** Enter email that does not exist on <BrandName /> platform and provide test email details, and click **Test Connection** and activate button.
   <img loading="lazy" src={require('../assets/images/lambdatest-scim/jumpcloud-scim/19.png').default} alt="jira-self-hosted-integration"  className="doc_img"/> 
   <img loading="lazy" src={require('../assets/images/lambdatest-scim/jumpcloud-scim/20.png').default} alt="jira-self-hosted-integration"  className="doc_img"/> 

--- a/docs/okta-scim.md
+++ b/docs/okta-scim.md
@@ -106,6 +106,44 @@ Also if you want to assign this attribute at a okta group level choose Attribute
 **Step 10:** To enable the Okta provisioning service for <BrandName />, set Create Users, Update User Attributes and Deactivate Users to enabled
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/okta/provisioning-enabled.png').default} alt="Image" width="404" height="206"  className="doc_img img_center"/><br/>
 
+## Pushing Groups from Okta
+
+Once user provisioning is working, you can push Okta groups to <BrandName /> for automatic team, concurrency group, or sub-org assignment.
+
+:::note Prerequisites
+Group Provisioning must be enabled for your org. Contact <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> to activate it.
+:::
+
+**Step 1:** In Okta, go to your <BrandName /> application > **Push Groups** tab.
+
+**Step 2:** Click **Push Groups** > choose **Find groups by name** or **Find groups by rule**.
+
+**Step 3:** Search for or select the groups you want to push, then click **Save**.
+
+**Step 4:** Okta will immediately push the group and its members to <BrandName /> via SCIM.
+
+**Step 5:** In <BrandName />, go to **Settings** > **Organization Settings** > **SCIM Group Provisioning** to view the pushed groups and configure mappings.
+
+### Setting Roles on Okta Groups
+
+To assign <BrandName /> roles (Admin, User, Guest) to all members of an Okta group:
+
+1. In your Okta app's **Push Groups** settings, the `LambdatestRoles` attribute is sent automatically if configured
+2. Alternatively, set `LambdatestRoles` in the SCIM group extension: `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group`
+3. The role applies to **all** members of the group. When a user is in multiple groups, the **highest** role wins (Admin > User > Guest)
+
+### What Happens After Pushing
+
+| Okta Action | <BrandName /> Effect |
+|---|---|
+| Push a group | Group created, mapping rules evaluated, members synced |
+| Add member to group | Member added to all mapped <BrandName /> entities |
+| Remove member from group | Member removed (if no other group maps them there), role recomputed |
+| Rename group in Okta | Group renamed, mapped entity renamed to match, rules re-evaluated |
+| Unlink/delete pushed group | Group soft-deleted, members safely unassigned, roles recomputed |
+
+> For details on mapping, conflicts, and rules, see the [SCIM Provisioning guide](/support/docs/scim/#group-provisioning).
+
 > That's all you need to know about <BrandName /> SCIM Auto User Provisioning with Okta. In case you have any questions please feel free to reach out to us via the <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> or email us over [support@testmuai.com](mailto:support@testmuai.com).
 
 

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -499,10 +499,6 @@ A single SCIM group can have **multiple mappings** — e.g., map `eng-backend` t
 
 > **Mapping statuses:** `Pending` → `Approved` / `Auto-Approved` (members synced) or `Rejected` (no sync). If no mapping rule matches, the group stays **Pending** until an admin maps it manually.
 
-:::warning Entity rename sync
-When a SCIM group is renamed in your IDP, the mapped team or concurrency group is **automatically renamed to match**. If you rename an entity manually in <BrandName />, the next IDP group rename will overwrite it. To control names, rename in your IDP.
-:::
-
 **To map manually:** Go to **SCIM Group Provisioning** dashboard > click a Pending group > select target type and entity > **Approve**.
 
 <!-- <img loading="lazy" src={require('../assets/images/lambdatest-scim/group-approve-mapping.png').default} alt="Approving a SCIM group mapping" width="404" height="206" className="doc_img img_center"/><br/> -->

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -507,21 +507,6 @@ When a SCIM group is renamed in your IDP, the mapped team or concurrency group i
 
 <!-- <img loading="lazy" src={require('../assets/images/lambdatest-scim/group-approve-mapping.png').default} alt="Approving a SCIM group mapping" width="404" height="206" className="doc_img img_center"/><br/> -->
 
-### Deleted Target {#target-deleted}
-
-If an admin deletes a team, concurrency group, or sub-org that has an active SCIM mapping, the mapping is flagged as `target_deleted` and the status changes to **Pending**.
-
-:::warning Manual re-mapping required
-When a target is deleted, the mapping **will not auto-create a replacement** — even if a matching mapping rule with auto-approve exists. This is intentional: auto-creating the same entity that was just deleted would cause a loop. An admin must manually update the mapping to point to a new (or recreated) target.
-:::
-
-**To fix a `target_deleted` mapping:**
-
-1. Go to **SCIM Group Provisioning** dashboard
-2. Find the group with `target_deleted` status
-3. Click the group and select a **new target entity**
-4. Click **Approve** — members will be synced to the new target
-
 ### Mapping Rules (Automatic Mapping)
 
 Instead of mapping each group manually, create rules that auto-match groups by name.
@@ -640,6 +625,21 @@ Two scenarios:
 :::tip To avoid conflicts
 Prefer **teams** when users need to be in multiple groups — teams never create conflicts. Only use concurrency groups and sub-orgs when you need exclusive assignment.
 :::
+
+### Deleted Target {#target-deleted}
+
+If an admin deletes a team, concurrency group, or sub-org that has an active SCIM mapping, the mapping is flagged as `target_deleted` and the status changes to **Pending**.
+
+:::warning Manual re-mapping required
+When a target is deleted, the mapping **will not auto-create a replacement** — even if a matching mapping rule with auto-approve exists. This is intentional: auto-creating the same entity that was just deleted would cause a loop. An admin must manually update the mapping to point to a new (or recreated) target.
+:::
+
+**To fix a `target_deleted` mapping:**
+
+1. Go to **SCIM Group Provisioning** dashboard
+2. Find the group with `target_deleted` status
+3. Click the group and select a **new target entity**
+4. Click **Approve** — members will be synced to the new target
 
 ### Group API Operations
 

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -123,10 +123,16 @@ Any SCIM 2.0-compliant IDP works. Use these settings:
 |---|---|
 | **SCIM Base URL** | From Organization Settings > Security |
 | **Authentication** | Bearer Token (HTTP Header) |
-| **User Schema** | `urn:ietf:params:scim:schemas:core:2.0:User` |
-| **Group Schema** | `urn:ietf:params:scim:schemas:core:2.0:Group` |
-| **LambdaTest User Extension** | `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User` |
-| **LambdaTest Group Extension** | `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group` |
+| **SCIM Version** | 2.0 |
+| **Users Resource** | `/Users` |
+| **Groups Resource** | `/Groups` |
+
+**Custom Attribute Schema URNs** — add these to your IDP's SCIM custom attribute configuration to send role and group assignments:
+
+| Schema URN | Purpose | Attributes |
+|---|---|---|
+| `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User` | User extension | `OrganizationRole` (Admin/User/Guest), `LambdatestGroup` (concurrency group name) |
+| `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group` | Group extension | `LambdatestRoles` (array of Admin/User/Guest — applied to all group members) |
 
 </TabItem>
 </Tabs>
@@ -157,19 +163,30 @@ Any SCIM 2.0-compliant IDP works. Use these settings:
   "active": true,
   "name": { "givenName": "Jane", "familyName": "Doe", "formatted": "Jane Doe" },
   "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole": "User"
+    "OrganizationRole": "User",
+    "LambdatestGroup": "Engineering"
   }
 }
 ```
+
+**Standard Attributes**
 
 | Attribute | Required | Notes |
 |---|---|---|
 | `userName` | Yes | Must be a valid email. **Cannot be changed after creation.** |
 | `active` | Yes | `true` = enabled, `false` = deactivated |
 | `name` | Yes | `givenName`, `familyName`, `formatted` |
-| `OrganizationRole` | No | `Admin`, `User` (default), or `Guest` |
 
-> **What can be updated:** Only `OrganizationRole` and `active` can be updated via SCIM. `userName` is immutable after creation. `name` can only be changed from <BrandName /> Account Settings.
+**Custom Attributes** (LambdaTest Extension)
+
+These attributes are part of the `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User` extension schema. To send them from your IDP, add this schema URN to your IDP's custom attribute configuration.
+
+| Attribute | Full SCIM Path | Required | Values | Notes |
+|---|---|---|---|---|
+| `OrganizationRole` | `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User:OrganizationRole` | No | `Admin`, `User`, `Guest` | Sets the user's organization role. Defaults to `User` if not provided. |
+| `LambdatestGroup` | `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User:LambdatestGroup` | No | _(concurrency group name)_ | Assigns the user to a concurrency group by name. The group must already exist in your organization. Contact support to enable concurrency groups. |
+
+> **What can be updated:** `OrganizationRole`, `LambdatestGroup`, and `active` can be updated via SCIM. `userName` is immutable after creation. `name` can only be changed from <BrandName /> Account Settings.
 
 ### User API Operations
 
@@ -188,7 +205,8 @@ Any SCIM 2.0-compliant IDP works. Use these settings:
   "active": true,
   "name": { "givenName": "Jane", "familyName": "Doe", "formatted": "Jane Doe" },
   "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole": "User"
+    "OrganizationRole": "User",
+    "LambdatestGroup": "Engineering"
   }
 }
 ```
@@ -206,7 +224,8 @@ Any SCIM 2.0-compliant IDP works. Use these settings:
   "active": true,
   "name": { "givenName": "Jane", "familyName": "Doe", "formatted": "Jane Doe" },
   "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User": {
-    "OrganizationRole": "User"
+    "OrganizationRole": "User",
+    "LambdatestGroup": "Engineering"
   }
 }
 ```
@@ -302,10 +321,19 @@ Filter by email: `?filter=userName eq "jane@company.com"`
   "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
   "Operations": [
     { "op": "Replace", "path": "active", "value": false },
-    { "op": "Replace", "path": "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User:OrganizationRole", "value": "Guest" }
+    { "op": "Replace", "path": "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User:OrganizationRole", "value": "Guest" },
+    { "op": "Replace", "path": "urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User:LambdatestGroup", "value": "QA-Team" }
   ]
 }
 ```
+
+**Patchable paths:**
+
+| Path | Value | Description |
+|---|---|---|
+| `active` | `true` / `false` | Enable or disable the user |
+| `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User:OrganizationRole` | `Admin`, `User`, `Guest` | Change organization role |
+| `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User:LambdatestGroup` | _(group name)_ | Move user to a different concurrency group |
 
 **Response:** `200 OK` — returns the full updated user object.
 
@@ -440,15 +468,28 @@ Once activated, you can control it from **Settings** > **Organization Settings**
 }
 ```
 
+**Standard Attributes**
+
 | Attribute | Required | Notes |
 |---|---|---|
 | `displayName` | Yes | Must be **unique** within your org |
 | `members` | No | Array of `{ "value": "<user_scim_id>" }` |
-| `LambdatestRoles` | No | `Admin`, `User`, or `Guest` — applied to all members |
+
+**Custom Attributes** (LambdaTest Extension)
+
+These attributes are part of the `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group` extension schema. To send them from your IDP, add this schema URN to your IDP's custom attribute configuration.
+
+| Attribute | Full SCIM Path | Required | Values | Notes |
+|---|---|---|---|---|
+| `LambdatestRoles` | `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group:LambdatestRoles` | No | `Admin`, `User`, `Guest` | Assigns organization roles to **all members** of the group. When set, all users in this group inherit these roles. Highest role wins if a user is in multiple groups. |
 
 ### Mapping Groups to LambdaTest Entities
 
 Once a group is pushed, it needs to be **mapped** to tell <BrandName /> what to do with its members. Select your target entity type below to see the details relevant to you:
+
+:::note Feature Activation
+**Teams**, **Concurrency Groups**, and **Sub-Organizations** are not enabled by default. Reach out to our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> or email [support@testmuai.com](mailto:support@testmuai.com) to get them activated for your organization before mapping groups to these entities.
+:::
 
 <Tabs className="docs__val" groupId="entity-type" queryString="entity">
 <TabItem value="team" label="Team" default>

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -493,6 +493,8 @@ This is the simplest and most common mapping. If you're just starting out, **Tea
 </TabItem>
 </Tabs>
 
+---
+
 A single SCIM group can have **multiple mappings** — e.g., map `eng-backend` to both a Team and a Concurrency Group simultaneously.
 
 > **Mapping statuses:** `Pending` → `Approved` / `Auto-Approved` (members synced) or `Rejected` (no sync). If no mapping rule matches, the group stays **Pending** until an admin maps it manually.
@@ -610,6 +612,8 @@ Two scenarios:
 
 </TabItem>
 </Tabs>
+
+---
 
 **To resolve:**
 

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -588,21 +588,21 @@ Conflicts happen when a user belongs to multiple SCIM groups that compete for th
 **When do conflicts happen?**
 
 <Tabs className="docs__val" groupId="entity-type">
-<TabItem value="team" label="Team" default>
-
-**Never.** Teams are additive — a user can be in as many teams as needed.
-
-</TabItem>
-<TabItem value="group" label="Concurrency Group">
+<TabItem value="group" label="Concurrency Group" default>
 
 When the same user is in two SCIM groups mapped to **different** concurrency groups. Example: Group A → "QA Pool" and Group B → "Dev Pool" — the user can only be in one.
 
 </TabItem>
 <TabItem value="suborg" label="Sub-Organization">
 
-Two scenarios:
-1. **Same type:** User in two groups mapped to **different** sub-orgs (e.g., Group X → "US Team", Group Y → "EU Team")
-2. **Cross-type:** User in a sub-org group **and** a concurrency group or team group from a **different** SCIM group. Sub-orgs take users out of the parent org's resource pool, making parent-org team/group assignments invalid.
+When the same user is in two SCIM groups mapped to **different** sub-orgs. Example: Group X → "US Team" and Group Y → "EU Team" — the user can only be in one.
+
+</TabItem>
+<TabItem value="crosstype" label="Cross-Type">
+
+When a user is mapped to a **sub-organization** from one SCIM group and a **concurrency group or team** from another SCIM group. Example: Group A maps to Sub-Org "US Team" and Group B maps to Concurrency Group "Dev Pool".
+
+**Why does this conflict?** Moving a user to a sub-org takes them out of the parent org's resource pool entirely. Team and concurrency group assignments in the parent org become invalid.
 
 </TabItem>
 </Tabs>

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -78,7 +78,7 @@ Go to **Settings** > **Organization Settings** > **Security** tab. Copy the **SC
 
 Paste the SCIM Base URL and Bearer Token into your IDP's provisioning settings.
 
-<Tabs className="docs__val" groupId="idp-provider">
+<Tabs className="docs__val" groupId="idp-provider" queryString="idp">
 <TabItem value="okta" label="Okta" default>
 
 Full walkthrough: [Okta SCIM Guide](/support/docs/scim/okta/)
@@ -173,7 +173,7 @@ Any SCIM 2.0-compliant IDP works. Use these settings:
 
 ### User API Operations
 
-<Tabs className="docs__val">
+<Tabs className="docs__val" groupId="user-op" queryString="user-op">
 <TabItem value="create-user" label="Create" default>
 
 **Request:** POST `https://auth.lambdatest.com/api/scim/Users`
@@ -450,7 +450,7 @@ Once activated, you can control it from **Settings** > **Organization Settings**
 
 Once a group is pushed, it needs to be **mapped** to tell <BrandName /> what to do with its members. Select your target entity type below to see the details relevant to you:
 
-<Tabs className="docs__val" groupId="entity-type">
+<Tabs className="docs__val" groupId="entity-type" queryString="entity">
 <TabItem value="team" label="Team" default>
 
 **Teams are additive** — a user can belong to multiple teams at once, so there are no conflicts.
@@ -507,7 +507,7 @@ A single SCIM group can have **multiple mappings** — e.g., map `eng-backend` t
 
 Instead of mapping each group manually, create rules that auto-match groups by name.
 
-<Tabs className="docs__val">
+<Tabs className="docs__val" groupId="rule-type" queryString="rule">
 <TabItem value="prefix" label="Prefix" default>
 
 Matches group names **starting with** a pattern (case-insensitive).
@@ -587,7 +587,7 @@ Conflicts happen when a user belongs to multiple SCIM groups that compete for th
 
 **When do conflicts happen?**
 
-<Tabs className="docs__val" groupId="entity-type">
+<Tabs className="docs__val" groupId="entity-type" queryString="entity">
 <TabItem value="group" label="Concurrency Group" default>
 
 When the same user is in two SCIM groups mapped to **different** concurrency groups. Example: Group A → "QA Pool" and Group B → "Dev Pool" — the user can only be in one.
@@ -639,7 +639,7 @@ When a target is deleted, the mapping **will not auto-create a replacement** —
 
 ### Group API Operations
 
-<Tabs className="docs__val">
+<Tabs className="docs__val" groupId="group-op" queryString="group-op">
 <TabItem value="create-group" label="Create" default>
 
 **Request:** POST `https://auth.lambdatest.com/api/scim/Groups`
@@ -828,7 +828,7 @@ Filter by name: `?filter=displayName eq "eng-backend"` | Paginate: `?startIndex=
 
 Quick reference for common scenarios. Everything below is handled automatically — no action needed unless noted.
 
-<Tabs className="docs__val">
+<Tabs className="docs__val" groupId="sync-source" queryString="sync">
 <TabItem value="idp-changes" label="Your IDP changes" default>
 
 | You do this in your IDP | What happens in LambdaTest | Action needed? |

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -449,6 +449,10 @@ Once a group is pushed, it needs to be **mapped** to tell <BrandName /> what to 
 
 > **Mapping statuses:** `Pending` → `Approved` / `Auto-Approved` (members synced) or `Rejected` (no sync)
 
+**Entity rename sync:** When a SCIM group is renamed in your IDP, the mapped <BrandName /> entity (team or concurrency group) is **automatically renamed to match**. This keeps names consistent between your IDP and <BrandName /> without manual intervention. Sub-organizations are not renamed (they have independent naming).
+
+**Deleted target handling:** If an admin deletes a team, concurrency group, or sub-org that has an active SCIM mapping, the mapping is flagged with `target_deleted: true` and reverts to **Pending** status on the next sync. The admin needs to re-approve the mapping with a new target.
+
 **To map manually:** Go to **SCIM Group Provisioning** dashboard > click a Pending group > select target type and entity > **Approve**.
 
 <!-- <img loading="lazy" src={require('../assets/images/lambdatest-scim/group-approve-mapping.png').default} alt="Approving a SCIM group mapping" width="404" height="206" className="doc_img img_center"/><br/> -->
@@ -502,7 +506,7 @@ Matches **every group**. Use as a low-priority catch-all fallback.
 7. Click **Save**
 
 
-### Role Assignment
+### Role Assignment {#roles}
 
 Roles can be set per-user (User extension `OrganizationRole`) or per-group (Group extension `LambdatestRoles`). Roles work **independently of mappings** — even unmapped groups apply their roles to members immediately.
 
@@ -514,18 +518,51 @@ When a user is in **multiple groups with different roles**, the highest-priority
 | `org-admins` | Admin |
 | **Effective role** | **Admin** (highest wins) |
 
-### Conflicts
+**Role changes are applied in both directions** — roles can be upgraded *and* downgraded:
 
-Conflicts happen when a user belongs to multiple SCIM groups mapped to **different exclusive entities** (e.g., different concurrency groups or different sub-orgs).
+| Scenario | What happens |
+|---|---|
+| User added to a group with `Admin` role | Role upgraded to Admin (if currently lower) |
+| User removed from the `Admin` group | Role **downgraded** to the next highest across remaining groups (e.g., User) |
+| All groups removed, or no roles set | Role defaults to **User** |
+| Group's `LambdatestRoles` changed from `Admin` to `Guest` | All members' roles recomputed — may downgrade |
 
-**To resolve:** SCIM Group Provisioning dashboard > **Conflicts** section > select the winning group > **Resolve**.
+:::note
+Roles are recomputed across **all** of a user's SCIM groups whenever any group membership or role changes. The effective role is always the highest across all current group memberships.
+:::
 
-The user is moved to the winning group's target. <BrandName /> remembers this decision — if the same situation recurs, no new conflict is created.
+### One Group per Entity
+
+Each <BrandName /> entity (team, concurrency group, or sub-org) can only be mapped from **one SCIM group at a time**. If you try to create a second mapping to the same entity, the request is rejected. This ensures a clear ownership model — one IDP group controls one <BrandName /> entity.
+
+### Conflicts {#conflicts}
+
+Conflicts happen when a user belongs to multiple SCIM groups whose mappings compete for the **same exclusive slot**. There are three types:
+
+| Conflict Type | When it happens | Example |
+|---|---|---|
+| **Exclusive Group** | User mapped to two different **concurrency groups** | Group A → "QA Pool", Group B → "Dev Pool" — user can only be in one |
+| **Exclusive Sub-Org** | User mapped to two different **sub-organizations** | Group X → "US Team", Group Y → "EU Team" — user can only be in one |
+| **Cross-Type Exclusive** | User mapped to a **sub-org** from one group and a **concurrency group or team** from another | Group A → Sub-Org "US Team", Group B → Concurrency Group "Dev Pool" — sub-org assignment is exclusive with other entity types |
+
+:::info What happens during a conflict
+The user **keeps their current assignment** until an admin resolves the conflict. No automatic changes are made — SCIM does not silently override existing assignments when there's ambiguity.
+:::
+
+**To resolve:**
+
+1. Go to **SCIM Group Provisioning** dashboard > **Conflicts** tab
+2. Each conflict card shows the **Current** group (the one the user is already assigned to) and the **Incoming** group (the one trying to claim the user)
+3. Click **Keep Current** to keep the existing assignment, or **Use Incoming** to switch the user to the new group's target
+4. <BrandName /> remembers this decision — if the IDP pushes the same combination again, no new conflict is created
+
+<!-- <img loading="lazy" src={require('../assets/images/lambdatest-scim/conflict-resolution.png').default} alt="Resolving a SCIM group conflict" width="404" height="206" className="doc_img img_center"/><br/> -->
 
 :::tip To avoid conflicts
 - Don't put the same user in two SCIM groups that map to **different concurrency groups**.
 - Don't put the same user in two SCIM groups that map to **different sub-organizations**.
-- Prefer **teams** when users need to be in multiple groups — teams have no conflicts.
+- Don't put the same user in a sub-org group **and** a concurrency group / team group — sub-orgs are exclusive with other entity types.
+- Prefer **teams** when users need to be in multiple groups — teams never create conflicts.
 :::
 
 ### Group API Operations
@@ -723,19 +760,22 @@ Quick reference for what happens during common operations. These are handled aut
 
 | Action | What happens | Admin action needed? |
 |---|---|---|
-| **Group renamed** | Name updated. Mapping rules re-evaluated — if a different rule matches, mapping reverts to **Pending**. Members unaffected. | Only if mapping status changed to Pending |
-| **Group deleted** | Soft-deleted. Roles recomputed. Members safely unassigned (checks other groups first). Mappings rejected. Conflicts auto-resolved. | No |
-| **Member removed from group** | Unassigned from mapped entities — but only if no other SCIM group maps them to the same target. Otherwise seamlessly reassigned or conflict created. | Only if conflict created |
+| **Group renamed** | Name updated. Mapped team/concurrency group **renamed to match**. Mapping rules re-evaluated — if a different rule matches, mapping reverts to **Pending**. Members unaffected. | Only if mapping status changed to Pending |
+| **Group deleted** | Soft-deleted. Roles recomputed (may downgrade). Members safely unassigned (checks other groups first). Mappings rejected. Conflicts auto-resolved. | No |
+| **Member added to group** | Added to all approved-mapped entities. Role recomputed. If assignment creates a conflict (exclusive entity), conflict raised for admin resolution. | Only if conflict created |
+| **Member removed from group** | Unassigned from mapped entities — but only if no other SCIM group maps them to the same target. Role recomputed (may downgrade). If another group was waiting (lost a conflict), it may now be applied. | Only if conflict created |
 | **Previously deleted group re-pushed** | Group restored. Members must be re-pushed. Mapping rules re-evaluated. | Depends on rules |
+| **Roles changed on group** | All members' roles recomputed immediately (may upgrade or downgrade). | No |
 
 ### Changes from LambdaTest Admin
 
 | Action | What happens | Important |
 |---|---|---|
-| **Team / group / sub-org renamed** | **Nothing breaks.** Mappings use internal IDs, not names. | No action needed |
-| **Mapped entity deleted** | Mapping reverts to Pending with target cleared on next sync. | Re-approve with a new target |
+| **Team / group / sub-org renamed** | **Nothing breaks.** Mappings use internal IDs, not names. However, the next IDP group rename will overwrite the entity name to match the IDP group name. | Entity names follow the IDP |
+| **Mapped entity deleted** | Mapping flagged as `target_deleted` and reverts to Pending on next sync. | Re-approve with a new target |
 | **Member manually removed from team** | Removal is immediate but **temporary** — next IDP sync re-adds them. | To permanently remove, do it **in your IDP** |
 | **Manual assignment to concurrency group / sub-org** | SCIM overrides non-SCIM assignments for exclusive entities on next sync. | Avoid conflicting manual + SCIM assignments |
+| **Manual role change for a SCIM-managed user** | Role may be overwritten on next IDP sync if the user's SCIM groups have roles configured. | Manage roles via IDP groups instead |
 
 <br />
 
@@ -758,18 +798,30 @@ Quick reference for what happens during common operations. These are handled aut
 | Issue | Solution |
 |---|---|
 | Members not appearing in teams or sub-orgs | Group mapping is still **Pending**. Approve it in the dashboard or create an auto-approve mapping rule. |
-| User has an unexpected role | Roles follow highest-priority-wins (Admin > User > Guest). Check all SCIM group memberships — they may inherit Admin from another group. |
+| User has an unexpected role | Roles follow highest-priority-wins (Admin > User > Guest). Check **all** SCIM group memberships — they may inherit Admin from another group. |
+| User's role didn't change after updating the group | Roles are recomputed across all groups. If another group still has the higher role, the effective role won't change. Remove the role from **all** groups. |
 | User keeps getting re-added after manual removal | SCIM is the source of truth. Remove the user from the group **in your IDP** instead. |
-| Group mapping reverted to Pending | Group was renamed (rules re-evaluated) or target entity was deleted. Re-approve with a valid target. |
-| Auto-approve didn't create my sub-organization | Sub-orgs are never auto-created (billing setup required). Approve manually and select the target. |
+| Group mapping reverted to Pending | Group was renamed (rules re-evaluated) or the target entity was deleted. Re-approve with a valid target. |
+| Auto-approve didn't create my sub-organization | Sub-orgs are **never** auto-created (billing/setup required). Create the sub-org first, then approve the mapping manually. |
+| Conflict shows "Unknown conflict type" or empty type | The conflict was created before cross-type support was added. Ask support to run a data migration. |
+| Can't map two SCIM groups to the same team | Each entity can only be mapped from one group. Use a single SCIM group, or merge the groups in your IDP. |
+| Members are in the SCIM group but not in the sub-org | Check for **conflicts** in the dashboard. The user may belong to another group with a competing exclusive mapping. |
+| IDP roles not showing in the groups list | Ensure the group has `LambdatestRoles` set in the IDP extension. Roles appear in the group detail and list views. |
 
 ### FAQ
 
 | Question | Answer |
 |---|---|
-| Can a group be mapped to multiple targets? | Yes. Each mapping syncs independently. |
-| Can I disable group provisioning without affecting users? | Yes. The toggle only affects group operations. |
+| Can a group be mapped to multiple targets? | Yes. A single group can map to a Team **and** a Concurrency Group simultaneously. Each mapping syncs independently. |
+| Can two groups map to the same entity? | No. Each entity can only be owned by one SCIM group. This prevents conflicting membership lists. |
+| Can I disable group provisioning without affecting users? | Yes. The toggle only blocks new IDP group operations. Existing groups, mappings, and assignments are preserved. |
 | Can I restore a deleted group? | Push a group with the same `displayName` from your IDP — the soft-deleted record is restored. Members must be re-pushed. |
+| Can roles be downgraded? | Yes. When a user is removed from a group with a higher role, their effective role is recomputed across remaining groups and may decrease. |
+| What if a user is in no SCIM groups? | Their role defaults to **User**. No entity assignments are made. |
+| Does the group search in the dashboard support partial matching? | Yes. Search is **case-insensitive** and matches anywhere in the group name (not just prefix). Leading/trailing spaces are trimmed. |
+| What happens to a conflict if I delete one of the conflicting groups? | The conflict is **auto-resolved** in favor of the remaining group. No admin action needed. |
+| Can I have both a mapping rule and a manual mapping? | Mapping rules only apply when a group is first created or renamed. Once a mapping exists (manual or auto), rules don't overwrite it. |
+| What's the difference between Approved and Auto-Approved? | Both sync members identically. **Auto-Approved** means a mapping rule approved it automatically. **Approved** means an admin approved it manually. |
 
 ---
 

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -875,53 +875,16 @@ Quick reference for common scenarios. Everything below is handled automatically 
 
 ### FAQ
 
-<details>
-<summary><strong>Can a group be mapped to multiple targets?</strong></summary>
-
-Yes. A single SCIM group can map to a Team **and** a Concurrency Group simultaneously. Each mapping syncs independently.
-</details>
-
-<details>
-<summary><strong>Can two SCIM groups map to the same entity?</strong></summary>
-
-No. Each entity (team, concurrency group, or sub-org) can only be owned by one SCIM group. This prevents conflicting membership lists.
-</details>
-
-<details>
-<summary><strong>Can I disable group provisioning without losing data?</strong></summary>
-
-Yes. The toggle only blocks new IDP group operations. Existing groups, mappings, and assignments are preserved. Toggle back ON to resume.
-</details>
-
-<details>
-<summary><strong>Can I restore a deleted group?</strong></summary>
-
-Yes. Push a group with the same `displayName` from your IDP — the soft-deleted record is restored. Members need to be re-pushed.
-</details>
-
-<details>
-<summary><strong>Can roles be downgraded?</strong></summary>
-
-Yes. Roles are recomputed across all groups. When a user is removed from a group with a higher role, their effective role drops to the next highest across remaining groups. If no groups have roles, it defaults to **User**.
-</details>
-
-<details>
-<summary><strong>What happens to a conflict when one group is deleted?</strong></summary>
-
-The conflict is **auto-resolved** in favor of the remaining group. No admin action needed.
-</details>
-
-<details>
-<summary><strong>What's the difference between Approved and Auto-Approved?</strong></summary>
-
-Both sync members identically. **Auto-Approved** means a mapping rule matched and approved it automatically. **Approved** means an admin approved it manually.
-</details>
-
-<details>
-<summary><strong>Do mapping rules overwrite existing mappings?</strong></summary>
-
-No. Rules only apply when a group is first created or renamed. Once a mapping exists (manual or auto), rules don't overwrite it.
-</details>
+| Question | Answer |
+|---|---|
+| Can a group be mapped to multiple targets? | Yes. A single SCIM group can map to a Team **and** a Concurrency Group simultaneously. Each mapping syncs independently. |
+| Can two SCIM groups map to the same entity? | No. Each entity can only be owned by one SCIM group. This prevents conflicting membership lists. |
+| Can I disable group provisioning without losing data? | Yes. The toggle only blocks new IDP operations. Existing groups, mappings, and assignments are preserved. Toggle back ON to resume. |
+| Can I restore a deleted group? | Yes. Push a group with the same `displayName` from your IDP — the soft-deleted record is restored. Members need to be re-pushed. |
+| Can roles be downgraded? | Yes. Roles are recomputed across all groups. If the highest role is removed, the effective role drops to the next highest. Defaults to **User** if none set. |
+| What happens to a conflict when one group is deleted? | The conflict is **auto-resolved** in favor of the remaining group. No admin action needed. |
+| What's the difference between Approved and Auto-Approved? | Both sync members identically. **Auto-Approved** = mapping rule matched automatically. **Approved** = admin approved manually. |
+| Do mapping rules overwrite existing mappings? | No. Rules only apply when a group is first created or renamed. Existing mappings (manual or auto) are not overwritten. |
 
 ---
 

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -503,11 +503,24 @@ A single SCIM group can have **multiple mappings** — e.g., map `eng-backend` t
 When a SCIM group is renamed in your IDP, the mapped team or concurrency group is **automatically renamed to match**. If you rename an entity manually in <BrandName />, the next IDP group rename will overwrite it. To control names, rename in your IDP.
 :::
 
-**Deleted target:** If an admin deletes a mapped team, concurrency group, or sub-org, the mapping reverts to **Pending**. Re-approve with a new target.
-
 **To map manually:** Go to **SCIM Group Provisioning** dashboard > click a Pending group > select target type and entity > **Approve**.
 
 <!-- <img loading="lazy" src={require('../assets/images/lambdatest-scim/group-approve-mapping.png').default} alt="Approving a SCIM group mapping" width="404" height="206" className="doc_img img_center"/><br/> -->
+
+### Deleted Target {#target-deleted}
+
+If an admin deletes a team, concurrency group, or sub-org that has an active SCIM mapping, the mapping is flagged as `target_deleted` and the status changes to **Pending**.
+
+:::warning Manual re-mapping required
+When a target is deleted, the mapping **will not auto-create a replacement** — even if a matching mapping rule with auto-approve exists. This is intentional: auto-creating the same entity that was just deleted would cause a loop. An admin must manually update the mapping to point to a new (or recreated) target.
+:::
+
+**To fix a `target_deleted` mapping:**
+
+1. Go to **SCIM Group Provisioning** dashboard
+2. Find the group with `target_deleted` status
+3. Click the group and select a **new target entity**
+4. Click **Approve** — members will be synced to the new target
 
 ### Mapping Rules (Automatic Mapping)
 
@@ -837,7 +850,7 @@ Quick reference for common scenarios. Everything below is handled automatically 
 | You do this in LambdaTest | What happens | Important |
 |---|---|---|
 | **Rename a team / group / sub-org** | Works fine, but the next IDP group rename will overwrite it. | To control names, rename **in your IDP** |
-| **Delete a mapped entity** | Mapping reverts to Pending. | Re-approve with a new target |
+| **Delete a mapped entity** | Mapping flagged as `target_deleted`, reverts to Pending. Auto-create is blocked. | [Manually re-map](#target-deleted) to a new target |
 | **Manually remove a member from a team** | Removal is immediate but **temporary** — next IDP sync re-adds them. | Remove **in your IDP** instead |
 | **Manually assign user to concurrency group / sub-org** | SCIM overrides non-SCIM assignments on next sync. | Use SCIM groups for exclusive assignments |
 | **Manually change a SCIM-managed user's role** | May be overwritten on next IDP sync. | Manage roles **in your IDP** |
@@ -869,7 +882,7 @@ Quick reference for common scenarios. Everything below is handled automatically 
 | Members are in the SCIM group but not in the sub-org | Check for [conflicts](#conflicts). The user may belong to another group with a competing exclusive mapping. |
 | User has an unexpected role | Check **all** SCIM group memberships — roles follow highest-wins (Admin > User > Guest). The user may inherit Admin from another group. |
 | User keeps getting re-added after manual removal | SCIM is the source of truth. Remove the user **in your IDP** instead. |
-| Group mapping reverted to Pending | The group was renamed (rules re-evaluated) or the target entity was deleted. Re-approve with a valid target. |
+| Group mapping reverted to Pending | The group was renamed (rules re-evaluated) or the target entity was deleted (`target_deleted`). If renamed, rules may auto-approve. If deleted, [manual re-mapping](#target-deleted) is required. |
 | Auto-approve didn't create my sub-organization | Sub-orgs are never auto-created (billing/setup required). Create the sub-org first, then approve manually. |
 | Can't map two SCIM groups to the same team | Each entity can only be mapped from one SCIM group. Use a single group, or merge in your IDP. |
 


### PR DESCRIPTION
## Summary
Improvements to the SCIM Group Provisioning documentation for clarity and usability:

- **Quick Start box** at top of Group Provisioning section for fast onboarding
- **Entity-specific tabs** (Team / Concurrency Group / Sub-Org) in mapping and conflicts sections — users only read what's relevant to them
- **Cross-Type conflict tab** replacing the empty Team tab in Conflicts
- **Deleted Target section** — explains `target_deleted` flag, why auto-create is blocked (loop prevention), and manual re-mapping steps
- **"What Happens When..."** renamed from "Side Effects" with IDP vs Admin tabs
- **URL-controllable tabs** via `queryString` for deep-linking (`?entity=suborg`, `?idp=okta`, etc.)
- FAQ as clean table (fixes grey outline from `<details>` elements)
- Separators between tabbed and non-tabbed sections
- Removed redundant entity rename sync callout (already in entity tabs + sync behavior table)
- IDP-specific docs (Okta, Azure AD, JumpCloud) updated with group provisioning sections

## Files changed
- `docs/scim.md` — main SCIM doc
- `docs/okta-scim.md` — added group provisioning section
- `docs/azure-scim.md` — added group provisioning section
- `docs/jumpcloud-scim.md` — added group provisioning section

## Test plan
- [ ] `npm run start` → verify `/support/docs/scim/` renders correctly
- [ ] Verify entity-type tabs sync across mapping and conflicts sections
- [ ] Verify query string deep-links work (e.g., `?entity=suborg`, `?idp=okta`)
- [ ] Check IDP-specific docs link back to main SCIM doc correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)