### PR TITLE
TE-5426: Add tracking for sidebar and search navigation

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -217,6 +217,8 @@
       }
     }
     window.sendAmplitudeEvents = sendAmplitudeEvents;
+
+    // Sidebar navigation tracking
     window.addEventListener('click', function (event) {
       if (event.target.matches(".menu__link")) {
         const menuLink = event.target.closest("a");


### PR DESCRIPTION
## Summary
- Track sidebar navigation clicks with `Page Viewed` event
- Track search result clicks with `Page Viewed` event
- Keep existing HyperExecute tracking for backwards compatibility

## Test plan
- [ ] Click sidebar links and verify `Page Viewed` event fires in Amplitude
- [ ] Click search results and verify `Page Viewed` event fires
- [ ] Verify HyperExecute pages still fire `HYP: page changed - docs` event