### PR TITLE
TE-5426: Fix DocSearch click tracking

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -246,8 +246,8 @@
       }
 
       // Search result click tracking
-      if (event.target.matches(".DocSearch-Hit a")) {
-        const searchHit = event.target.closest(".DocSearch-Hit a");
+      const searchHit = event.target.closest(".DocSearch-Hit a");
+      if (searchHit && searchHit.href) {
         var page_title =
           searchHit.getAttribute("title") ||
           searchHit.textContent?.trim() ||


### PR DESCRIPTION
## Summary
- Fixed DocSearch result click tracking not firing events
- Changed from `event.target.matches(".DocSearch-Hit a")` to `event.target.closest(".DocSearch-Hit a")` to properly detect clicks on child elements inside the search result links

## Test plan
- [ ] Search for a term in DocSearch
- [ ] Click on a search result
- [ ] Verify "Page Viewed" event is logged in Amplitude

🤖 Generated with [Claude Code](https://claude.com/claude-code)