### PR TITLE
Add guide for building iOS apps for Simulator testing

### DIFF
--- a/docs/build-ios-app-for-simulator-testing.md
+++ b/docs/build-ios-app-for-simulator-testing.md
@@ -1,0 +1,234 @@
+---
+id: build-ios-app-for-simulator-testing
+title: Building Your iOS App for Simulator Testing
+sidebar_label: Build iOS App for Simulators
+description: Learn how to build your iOS app correctly for testing on iOS Simulators on TestMu AI Cloud. Covers Xcode UI, command line builds, and build verification.
+keywords:
+  - ios simulator testing
+  - build ios app for simulator
+  - iphonesimulator sdk
+  - ios simulator build
+  - .app file simulator
+  - xcode simulator build
+  - arm64 simulator
+  - testmu ai ios simulator
+url: https://www.testmuai.com/support/docs/build-ios-app-for-simulator-testing/
+site_name: TestMu AI
+slug: build-ios-app-for-simulator-testing/
+canonical: https://www.testmuai.com/support/docs/build-ios-app-for-simulator-testing/
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": BRAND_URL
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": `${BRAND_URL}/support/docs/`
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Building Your iOS App for Simulator Testing",
+          "item": `${BRAND_URL}/support/docs/build-ios-app-for-simulator-testing/`
+        }]
+      })
+    }}
+></script>
+
+To test your iOS application on <BrandName /> iOS Simulators, your app must be built specifically for the **iOS Simulator** platform. A build intended for a physical iPhone will not work on the Simulator, even if the CPU architecture matches. This guide walks you through creating a Simulator-compatible build and verifying it before uploading.
+
+## Why Simulator Builds Are Different
+
+iOS apps are compiled with a **Mach-O platform** identifier that tells the system where the binary is meant to run:
+
+| Platform ID | Platform Name | Target |
+|---|---|---|
+| **2** | `iphoneos` | Physical iOS devices |
+| **7** | `iphonesimulator` | iOS Simulator |
+
+Even when the CPU architecture (e.g., arm64) matches between device and Simulator builds, the two platforms link against different system libraries. The Simulator will reject a device build, typically resulting in an immediate crash.
+
+:::warning Common Mistake
+Building your app for a physical device (e.g., selecting **Any iOS Device** in Xcode) and then uploading it to the Simulator will cause an immediate crash with errors like **"App quit unexpectedly."** You must build targeting the **iOS Simulator** SDK.
+:::
+
+## Prerequisites
+
+- [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) installed on a Mac (macOS 13 or later recommended)
+- Your iOS project source code
+- A <BrandName /> account with access to iOS Simulator testing
+
+## Method 1: Building via Xcode (UI)
+
+This is the most common method. Xcode handles the platform switching automatically based on the **Run Destination** you select.
+
+**Step 1:** Open your project (`.xcodeproj` or `.xcworkspace`) in Xcode.
+
+**Step 2:** Click the **scheme selector** in the top toolbar. In the destination dropdown, choose a specific **Simulator** (e.g., *iPhone 15 Pro*) from the **iOS Simulators** section.
+
+:::caution Important
+Do **not** select **Any iOS Device** or a physical device plugged into your Mac. You must select a Simulator destination.
+:::
+
+**Step 3:** Press **Cmd + B** or go to **Product > Build** to build the application.
+
+**Step 4:** Locate the generated `.app` file:
+- In the **Project Navigator**, expand the **Products** folder and right-click the `.app` file.
+- Select **Show in Finder** to open its location.
+- Alternatively, go to **File > Project Settings > Derived Data** to find the build output.
+
+**Step 5:** Compress the `.app` file into a `.zip` archive:
+- Right-click the `.app` file in Finder and select **Compress**.
+
+The resulting `.zip` file is ready to upload to <BrandName /> for Simulator testing.
+
+## Method 2: Building via Command Line (xcodebuild)
+
+If you use a CI/CD pipeline or prefer the terminal, use `xcodebuild` with the `-sdk iphonesimulator` flag.
+
+**Step 1:** Open Terminal and navigate to your project directory.
+
+**Step 2:** Run the following build command:
+
+```bash
+xcodebuild -project YourProject.xcodeproj \
+           -scheme YourScheme \
+           -configuration Debug \
+           -sdk iphonesimulator \
+           -arch arm64 \
+           build
+```
+
+:::tip
+If your project uses a **workspace** (e.g., with CocoaPods), replace `-project YourProject.xcodeproj` with `-workspace YourProject.xcworkspace`.
+:::
+
+**Key flags explained:**
+
+| Flag | Description |
+|---|---|
+| `-sdk iphonesimulator` | Targets the iOS Simulator platform (Platform 7) instead of physical devices |
+| `-arch arm64` | Builds for the arm64 architecture (required for modern Mac hardware) |
+| `-configuration Debug` | Uses the Debug build configuration (recommended for testing) |
+
+**Step 3:** Locate the `.app` output from the **Derived Data** directory. You can find the path in the build output, or use:
+
+```bash
+xcodebuild -project YourProject.xcodeproj \
+           -scheme YourScheme \
+           -configuration Debug \
+           -sdk iphonesimulator \
+           -arch arm64 \
+           -showBuildSettings | grep "BUILT_PRODUCTS_DIR"
+```
+
+**Step 4:** Compress the `.app` into a `.zip` file:
+
+```bash
+cd /path/to/build/output/
+zip -r YourApp.zip YourApp.app
+```
+
+The `.zip` file is now ready for upload.
+
+## Verifying Your Build
+
+Before uploading, verify that your `.app` is targeting the correct platform using the `vtool` command.
+
+**Step 1:** Run the following command:
+
+```bash
+vtool -show-build YourApp.app/YourApp
+```
+
+Replace the second `YourApp` with the actual binary name inside the `.app` bundle.
+
+**Step 2:** Check the output:
+
+- **Correct (Simulator build):**
+  ```
+  platform: IOSSIMULATOR
+  ```
+  or `platform 7`
+
+- **Incorrect (Device build):**
+  ```
+  platform: IOS
+  ```
+  or `platform 2`
+
+If the platform shows `IOS` or `platform 2`, the build is for physical devices and will not work on the Simulator. Rebuild using one of the methods above.
+
+:::tip Alternative Verification
+You can also use `otool` to check the architecture:
+```bash
+lipo -info YourApp.app/YourApp
+```
+This displays the architectures included in the binary (e.g., `arm64`).
+:::
+
+## Uploading to <BrandName />
+
+Once you have a verified Simulator build (`.zip` containing the `.app`):
+
+1. Log in to your <BrandName /> account.
+2. Navigate to **App Testing** > **iOS Simulators**.
+3. Upload the `.zip` file containing your `.app` build.
+4. Select the desired Simulator device and iOS version.
+5. Start your testing session.
+
+## Key Xcode Build Settings
+
+If your build still targets the wrong platform, check these settings in Xcode under **Build Settings**:
+
+| Setting | Value for Simulator |
+|---|---|
+| **Architectures** | `$(ARCHS_STANDARD)` |
+| **Base SDK** | iOS |
+| **Supported Platforms** | iOS Simulator |
+| **Validate Built Product** | No (for Debug/Simulator builds) |
+
+## Troubleshooting
+
+### App crashes immediately on the Simulator
+Your `.app` is likely built for physical devices (Platform 2). Verify the platform using `vtool` as described above, and rebuild targeting the Simulator SDK.
+
+### "No .app found inside zip" error
+Ensure you are compressing the `.app` bundle directly into a `.zip` file. The `.app` should be at the root level of the archive, not nested inside additional folders.
+
+### Build fails with architecture errors
+Ensure the `-arch arm64` flag is set. Your Simulator build must include the arm64 architecture.
+
+---
+
+That's all! In case you have any questions or need any additional information, you could reach out at our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24X7 Chat Support**</span> or mail us directly at support@testmuai.com.
+
+<nav aria-label="breadcrumbs">
+  <ul className="breadcrumbs">
+    <li className="breadcrumbs__item">
+      <a className="breadcrumbs__link" target="_self" href={BRAND_URL}>
+        Home
+      </a>
+    </li>
+    <li className="breadcrumbs__item">
+      <a className="breadcrumbs__link" target="_self" href={`${BRAND_URL}/support/docs/`}>
+        Support
+      </a>
+    </li>
+    <li className="breadcrumbs__item breadcrumbs__item--active">
+      <span className="breadcrumbs__link">
+        Build iOS App for Simulator Testing
+      </span>
+    </li>
+  </ul>
+</nav>

--- a/docs/troubleshooting-ios-app-testing.md
+++ b/docs/troubleshooting-ios-app-testing.md
@@ -43,28 +43,72 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 # Troubleshooting iOS App Testing
 ***
 
-While uploading .app files on Simulators, you may come across an error on the <BrandName /> platform - *No .app found inside zip*. In such cases, you may need to re-evaluate how you're building your iOS applications. To upload and test `. apps` files on Simulators, your iOS app need to be build for Simulators. 
+While uploading `.app` files on Simulators, you may encounter issues such as the app crashing immediately or the error *"No .app found inside zip"*. These problems typically occur when the app is not built correctly for the Simulator platform.
 
-Shown below are the steps for converting your `.app` file to a `.zip` file.
+:::tip
+For a complete step-by-step guide on building your iOS app for Simulator testing, see [Building Your iOS App for Simulator Testing](/docs/build-ios-app-for-simulator-testing/).
+:::
 
-1. Download and install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12).
+## Common Issues
 
-2. Open your testing project in Xcode.
+### App crashes immediately with "App quit unexpectedly"
 
- <img loading="lazy" src={require('../assets/images/troubleshoot-ios-testing/project-file.webp').default} alt="Integrating <BrandName /> With Testsigma" width="1281" height="722" className="doc_img"/>
+**Cause:** Your `.app` is built for physical iOS devices (Mach-O Platform 2 — `iphoneos`) instead of the iOS Simulator (Platform 7 — `iphonesimulator`).
 
-3. Head to **File** and click **Show in Finder** option to open the .app file once your build runs successfully.
+**Solution:** Rebuild your app targeting the iOS Simulator SDK. In Xcode, select a **Simulator destination** (e.g., *iPhone 15 Pro*) instead of *Any iOS Device*, then build. For command line builds, use the `-sdk iphonesimulator` flag:
 
- <img loading="lazy" src={require('../assets/images/troubleshoot-ios-testing/show-in-finder.webp').default} alt="Integrating <BrandName /> With Testsigma" width="1281" height="722" className="doc_img"/>
+```bash
+xcodebuild -project YourProject.xcodeproj \
+           -scheme YourScheme \
+           -configuration Debug \
+           -sdk iphonesimulator \
+           -arch arm64 \
+           build
+```
 
-4. Compress the `.app` file into a `.zip` file.
+You can verify the platform using:
 
- <img loading="lazy" src={require('../assets/images/troubleshoot-ios-testing/zip-file.webp').default} alt="Integrating <BrandName /> With Testsigma" width="1281" height="722" className="doc_img"/>
+```bash
+vtool -show-build YourApp.app/YourApp
+```
+
+The output should show `platform: IOSSIMULATOR` (Platform 7).
+
+:::info
+Your Simulator build must include the **arm64** architecture. There is no need to exclude it from Simulator builds.
+:::
+
+### "No .app found inside zip" error
+
+**Cause:** The `.zip` archive structure is incorrect. The `.app` bundle should be at the root of the archive.
+
+**Solution:**
+1. Build your app for the Simulator (as described above).
+2. Locate the `.app` file in Xcode: right-click the `.app` under **Products** and select **Show in Finder**.
+3. Right-click the `.app` file in Finder and select **Compress** to create the `.zip` file.
+
+ <img loading="lazy" src={require('../assets/images/troubleshoot-ios-testing/project-file.webp').default} alt="Open project in Xcode" width="1281" height="722" className="doc_img"/>
+
+ <img loading="lazy" src={require('../assets/images/troubleshoot-ios-testing/show-in-finder.webp').default} alt="Show in Finder" width="1281" height="722" className="doc_img"/>
+
+ <img loading="lazy" src={require('../assets/images/troubleshoot-ios-testing/zip-file.webp').default} alt="Compress to zip" width="1281" height="722" className="doc_img"/>
 
 Your `.zip` file is now ready for upload on <BrandName /> servers.
 
->**Note**: If you are unable to install the iOS zip file on the <BrandName /> platform, you need to remove the arm64 architecture from both your project and the pod project.<br /> <br />
-To do so, go to the **Build Settings** of your project. From **Excluded Architecture** dropdown, add any iOS Simulator SDK with value arm64 .<br /><br />
-<img loading="lazy" src={require('../assets/images/troubleshoot-ios-testing/6.webp').default} alt="Integrating <BrandName /> With Testsigma" width="1281" height="722" className="doc_img"/>
+### Build fails with architecture errors
 
-That’s all! In case you have any questions or need any additional information, you could reach out at our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24X7 Chat Support**</span> or mail us directly at support@testmuai.com.
+**Cause:** The project may have incorrect architecture settings.
+
+**Solution:** In Xcode **Build Settings**, verify:
+
+| Setting | Value |
+|---|---|
+| **Architectures** | `$(ARCHS_STANDARD)` |
+| **Base SDK** | iOS |
+| **Supported Platforms** | iOS Simulator |
+
+Ensure you are **not** excluding arm64 from Simulator builds.
+
+---
+
+That's all! In case you have any questions or need any additional information, you could reach out at our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24X7 Chat Support**</span> or mail us directly at support@testmuai.com.

--- a/sidebars.js
+++ b/sidebars.js
@@ -2882,6 +2882,7 @@ module.exports = {
     },
     [
       "app-automation-app-sim",
+      "build-ios-app-for-simulator-testing",
       "virtual-device-flutter-apps",
     ],
   ],


### PR DESCRIPTION
New doc explaining how to build iOS apps targeting the iphonesimulator SDK (Platform 7) for testing on TestMu AI Cloud, with Xcode UI and command line methods plus build verification steps. Also updates the outdated troubleshooting doc to remove incorrect arm64 exclusion advice.