### PR TITLE
feat: add AI Agent Testing Platform Overview doc

### DIFF
--- a/docs/ai-agent-testing-platform-overview.md
+++ b/docs/ai-agent-testing-platform-overview.md
@@ -1,0 +1,273 @@
+---
+id: ai-agent-testing-platform-overview
+title: AI Agent Testing & Evaluation Platform — Solution Overview
+hide_title: false
+sidebar_label: Platform Overview
+description: A purpose-built quality-assurance platform for verifying, benchmarking, and continuously monitoring AI-powered agents across voice, chat, and multimodal interaction channels.
+keywords:
+ - ai agent testing platform
+ - agent evaluation platform
+ - voice agent testing
+ - chat agent testing
+ - agent to agent testing
+ - ai agent qa
+url: https://www.testmu.ai/support/docs/ai-agent-testing-platform-overview/
+site_name: LambdaTest
+slug: ai-agent-testing-platform-overview/
+canonical: https://www.testmu.ai/support/docs/ai-agent-testing-platform-overview/
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": BRAND_URL
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": `${BRAND_URL}/support/docs/`
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "AI Agent Testing Platform Overview",
+          "item": `${BRAND_URL}/support/docs/ai-agent-testing-platform-overview`
+        }]
+      })
+    }}
+></script>
+
+## Executive Summary
+
+Enterprises are investing heavily in AI-powered agents to handle customer interactions at scale — through phone calls, chat interfaces, and multimodal workflows. However, deploying these agents into production without rigorous, repeatable quality validation creates significant business risk: erratic behavior, regulatory exposure, and poor customer experience that is difficult to detect with conventional testing tools.
+
+This platform directly solves that problem. It is an end-to-end, AI-native testing and evaluation solution that automatically generates hundreds of realistic test scenarios, executes them across voice and chat channels, and scores agent behavior across more than fifteen quality dimensions — all without requiring manual scripting.
+
+The platform supports **four interaction modalities**: inbound phone calls, outbound phone calls, chat/webhook agents, and AI-generated image evaluation. A continuous scheduling engine and a production-readiness ("Go-Live") assessment module close the loop from development through post-launch monitoring.
+
+---
+
+## Market Analysis & Industry Context
+
+### Voice AI Market Growth
+
+AI voice agents are one of the fastest-growing enterprise technology categories. The market reached an estimated **$47 billion in 2025**, expanding at roughly **34% CAGR** since 2022, with projections toward **$89 billion by 2028**. Enterprise deployments surged approximately **340% year-over-year**, with two-thirds of Fortune 500 companies now running at least one production voice AI system.
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| AI voice agent market (2025) | **$47B** | AI Voice Research 2026 |
+| Market CAGR since 2022 | **34%** | AI Voice Research 2026 |
+| YoY growth in enterprise deployments | **340%** | AI Voice Research 2026 |
+| Fortune 500 companies in production | **67%** | AI Voice Research 2026 |
+
+### The Testing Gap — Why This Market Exists
+
+The rapid proliferation of AI agents has created a critical quality gap. Traditional test automation tools — built for deterministic software — fail when applied to AI systems. Research highlights three key failure modes:
+
+- **Non-determinism:** The same prompt can produce different reasoning paths and outputs on every run. Agents that score 60% on single-run benchmarks may show only 25% behavioral consistency across repeated trials — a gap invisible to conventional test scripts.
+- **Multi-turn complexity:** AI agents must maintain context, handle interruptions, and adapt across many conversation turns. Validating this requires realistic, goal-driven simulations — not canned input/output pairs.
+- **Evaluation subjectivity:** Metrics like empathy, accuracy, hallucination rate, and policy compliance cannot be captured by pass/fail assertions; they require AI-powered scoring.
+
+The broader software testing market is growing from **$55.8B (2024)** to a projected **$112.5B by 2034** (7.2% CAGR), with AI-specific testing as the highest-growth segment. Approximately **77.7% of organizations** are adopting AI-first quality engineering approaches in 2026.
+
+### The Business Cost of Inadequate AI QA
+
+Enterprises deploying voice agents without proper validation face compounding costs. Human call-center agents cost **$28–42 per hour fully loaded**; the promise of AI is an **85%+ cost reduction** per interaction. Realizing that promise requires that agents behave reliably at scale, under edge-case conditions, and in compliance with regulatory requirements. A single high-profile failure in a regulated industry (financial services, healthcare) can negate months of operational savings.
+
+---
+
+## Competitive Differentiation
+
+### Current Landscape
+
+Several point solutions have emerged to address pieces of the AI agent QA problem. However, they share a common constraint: each targets a narrow slice of the testing lifecycle.
+
+- **Specialized call-center QA tools** focus on telephony infrastructure and first-contact resolution metrics but do not cover chat agents, image agents, or structured evaluation frameworks.
+- **Voice-provider-native testers** are tightly coupled to a single telephony platform, limiting organizations that want provider flexibility or multi-provider redundancy.
+- **LLM evaluation libraries** offer metric scoring but require significant engineering effort to integrate with actual voice or chat agent endpoints, and provide no out-of-the-box scenario generation or scheduling.
+- **General-purpose test automation tools** (Selenium, Playwright derivatives) are fundamentally misaligned with AI-native systems — they cannot simulate realistic conversational behavior or reason about probabilistic outputs.
+
+### Platform Differentiators
+
+| Differentiator | Description |
+|---------------|-------------|
+| **Multi-Modal Coverage** | Single platform covers inbound phone, outbound phone, chat/webhook, and image modalities — no other single solution provides this breadth today. |
+| **AI-Generated Test Scenarios** | Upload existing requirements documents (PDFs, Word docs, images, audio, video) and the platform autonomously generates 60–100+ diverse, adversarial scenarios without manual authoring. |
+| **Real Phone-Call Execution** | Tests are executed as actual telephone calls — not simulations. The platform places or receives real calls, captures audio, and analyzes full conversation recordings. |
+| **15+ Evaluation Dimensions** | Conversations are scored across hallucination detection, bias, context awareness, conversation flow, compliance, error recovery, and more — not just pass/fail. |
+| **Continuous Scheduled Testing** | Cron-based scheduling runs full test suites automatically on any cadence — catching regressions the moment a model or prompt is updated, without human intervention. |
+| **Go-Live Readiness Assessment** | An aggregate production-readiness verdict (Green / Yellow / Red) with confidence scores, giving teams a clear, defensible signal before launching to real users. |
+| **Provider-Agnostic Architecture** | Works with multiple telephony and voice providers — teams are not locked into any single vendor. Existing provider contracts and phone numbers are reused. |
+| **Parallel Execution at Scale** | Full test suites run in parallel across a distributed execution infrastructure, compressing hours of testing into minutes and enabling rapid iteration cycles. |
+| **Requirements-Driven Generation** | Integrates natively with documentation platforms (e.g., Confluence) and source control so test scenarios stay synchronized with the latest product specifications. |
+
+### Head-to-Head Capability Comparison
+
+| Capability | Specialized Call-Center QA | Provider-Native Tester | LLM Eval Libraries | This Platform |
+|-----------|---------------------------|----------------------|-------------------|---------------|
+| Inbound voice / phone testing | ✅ Yes | ⚠️ Limited | ❌ No | ✅ Yes |
+| Outbound voice / phone testing | ⚠️ Limited | ❌ No | ❌ No | ✅ Yes |
+| Chat / webhook agent testing | ❌ No | ❌ No | ⚠️ Partial | ✅ Yes |
+| AI-generated test scenarios | ⚠️ Limited | ⚠️ Limited | ❌ No | ✅ Yes (60–100+) |
+| Requirements document ingestion | ❌ No | ❌ No | ❌ No | ✅ Yes (PDF, DOCX, audio, video) |
+| Multi-provider telephony support | ❌ No | ❌ No | ❌ N/A | ✅ Yes |
+| 15+ scored evaluation dimensions | ⚠️ 4–6 metrics | ⚠️ Partial | ⚠️ Configurable | ✅ Yes (standardized) |
+| Go-Live readiness verdict | ❌ No | ❌ No | ❌ No | ✅ Yes (Green / Yellow / Red) |
+| Scheduled / continuous regression runs | ⚠️ Limited | ❌ No | ❌ No | ✅ Yes |
+| Parallel distributed execution | ⚠️ Limited | ❌ No | ❌ No | ✅ Yes |
+| CI/CD pipeline integration | ❌ No | ❌ No | ⚠️ Limited | ✅ Yes |
+| Image / multimodal agent evaluation | ❌ No | ❌ No | ⚠️ Limited | ✅ Yes |
+
+---
+
+## Platform Architecture — High-Level Overview
+
+The platform is built as a cloud-native, API-first system composed of three logical layers: the **User Interface**, the **Testing Engine**, and the **Evaluation Layer**. All three are accessed through a single web application — no local installation is required.
+
+**Testing Flow:**
+
+`Requirements Input` → `Scenario Generation` → `Agent-to-Agent Execution` → `AI Evaluation` → `Results & Go-Live`
+
+### Supported Agent Types
+
+| Agent Type | How It Works | Primary Use Case |
+|-----------|-------------|-----------------|
+| **Inbound Phone Agent** | Platform places a real outbound call to the agent's phone number using a simulated caller persona following a scripted scenario. | IVR systems, inbound customer support voice bots, appointment scheduling agents |
+| **Outbound Phone Agent** | Platform provisions a recipient phone number; the agent under test places a call to it. The platform answers and evaluates the full conversation. | Sales dialers, collections agents, proactive outreach bots |
+| **Chat / Webhook Agent** | Platform sends multi-turn HTTP messages to the agent's API endpoint, simulating a real user conversation per the generated scenario. | Customer service chatbots, internal IT helpdesks, FAQ and knowledge bots |
+| **Image Generation Agent** | Platform submits generation prompts and evaluates the returned images against the original intent and quality criteria. | AI design tools, content generation pipelines, marketing asset platforms |
+
+---
+
+## Technical Integration Documentation
+
+### Connecting Your Agent
+
+Integration is designed to be low-effort. Depending on your agent type, onboarding requires one of the following:
+
+- **Chat Agent — Endpoint URL:** Provide the HTTPS endpoint your agent listens on (e.g., `https://your-agent.example.com/chat`), along with any required authentication headers or credentials. Multi-step auth flows (login → session token → API call) are supported natively through configurable endpoint profiles with encrypted secret storage.
+- **Phone Agent — Phone Number:** Provide the E.164-formatted phone number your voice agent answers on (for inbound), or the outbound dialing number. The platform handles call orchestration, recording, and teardown automatically. No changes to your telephony stack are required.
+- **Image Agent — API Endpoint:** Provide the generation endpoint and any prompt formatting requirements. The platform submits standardized prompts and retrieves generated assets for evaluation.
+
+### Phone Dial-Out Architecture
+
+The phone testing capability operates as follows:
+
+1. **Scenario Loading:** The platform selects a generated test scenario, which includes a caller persona, a conversation objective, and expected behavioral guardrails.
+2. **Voice Session Provisioning:** A real-time voice session is provisioned through the platform's telephony integration. The platform supports multiple underlying telephony providers; the operator configures their preferred provider and credentials once in the settings panel.
+3. **Call Initiation:** For *inbound* agent tests, the platform's simulated caller dials the target phone number. For *outbound* agent tests, the platform reserves a recipient number from its number pool and the agent under test is triggered to call it.
+4. **Live Conversation:** The AI-powered simulator follows the scenario script, adapting responses dynamically to the agent's answers — simulating realistic human conversation including interruptions, clarifications, topic pivots, and edge-case inputs.
+5. **Recording & Termination:** The full conversation audio is captured and stored securely. The call is ended either on scenario completion or when a configured maximum duration is reached.
+6. **Post-Call Analysis:** The platform's evaluation engine ingests the full audio recording, transcribes and analyzes the conversation, and produces dimension-level scores within minutes of call completion.
+
+:::info Provider Flexibility
+The platform is designed to be telephony-provider agnostic. Organizations can configure their existing voice provider accounts within the settings panel. No long-term platform-level telephony commitment is required, and provider credentials are stored with encryption-at-rest.
+:::
+
+### Chat Agent Integration Flow
+
+`Scenario Selected` → `HTTP Request to Agent` → `Agent Responds` → `Platform Continues Turn` → `Conversation Complete` → `Metrics Scored`
+
+Each conversation turn is executed in sequence. The platform's AI simulator reads the agent's response and determines the next message based on the scenario goal, prior context, and any configured behavioral constraints. An automated end condition (goal met, max turns reached, or unrecoverable error) terminates the session.
+
+### Authentication & Security
+
+- All platform APIs require authenticated sessions via a central identity provider.
+- Third-party credentials (telephony tokens, agent API keys) are stored encrypted and decrypted only at runtime during test execution.
+- All data in transit is TLS-encrypted; all stored assets (call recordings, documents) reside in encrypted object storage.
+- Private network agents can be reached through a secure tunnel proxy — no public exposure of internal endpoints is required.
+- Per-organization isolation ensures no cross-tenant data access.
+
+### CI/CD and Automation Integration
+
+The platform exposes a REST API for all core operations, enabling integration into any CI/CD pipeline. Teams can trigger test suite executions as part of their deployment workflow and receive structured pass/fail signals. Real-time status updates are streamed via server-sent events (SSE) for live build dashboards. In addition, a cron-based scheduler within the platform enables autonomous scheduled regression runs independent of deployment events.
+
+---
+
+## Data & Metrics Behavior
+
+### Evaluation Dimensions
+
+Every completed conversation — whether voice or chat — is automatically scored by the platform's evaluation engine across a standardized set of quality dimensions. Each dimension is scored on a normalized 0.0–1.0 scale, with configurable pass/fail thresholds per project.
+
+| Evaluation Dimensions | | |
+|----------------------|-|-|
+| Hallucination Detection | Bias Detection | Response Quality |
+| Context Awareness | Completeness | Conversation Flow |
+| User Satisfaction | Intent Recognition | Multi-Turn Reasoning |
+| Error Handling & Recovery | Consistency | Proactive Behavior |
+| Compliance & Governance | Data Privacy | Security Posture |
+| Escalation Accuracy | Personality & Tone | Audit Logging Quality |
+
+### Metric Threshold Configuration
+
+Each project can define custom minimum thresholds per metric dimension. For example, a regulated-industry deployment might require a Compliance score ≥ 0.95 and a Data Privacy score ≥ 0.98, while a consumer chatbot might prioritize Conversation Flow and User Satisfaction at a lower floor. Threshold profiles are version-controlled and can differ across environments (development, staging, production).
+
+### Go-Live Readiness Assessment
+
+The Go-Live Assessment module aggregates results across all evaluated scenarios and dimensions to produce a three-tier production-readiness verdict:
+
+| Verdict | Description |
+|---------|-------------|
+| 🟢 **GREEN** | All critical thresholds met. Agent demonstrates consistent, reliable behavior across tested scenarios. Cleared for production deployment. |
+| 🟡 **YELLOW** | Most thresholds met; one or more secondary metrics fall below target. Conditional approval with identified risk areas for monitoring. |
+| 🔴 **RED** | One or more critical thresholds not met. Specific failure categories are surfaced for remediation before production deployment is advisable. |
+
+The assessment includes a confidence level indicator (based on the volume and diversity of scenarios evaluated), an overall aggregate score, and a breakdown of pass/fail rates by the sixteen behavioral test categories.
+
+### Test Categories
+
+Generated scenarios are organized across sixteen behavioral categories, ensuring comprehensive coverage of agent capabilities and failure modes:
+
+| Test Categories | | |
+|----------------|-|-|
+| Conversational Flow | Intent Recognition | Context & Memory |
+| Multi-Turn Reasoning | User Experience | Personality & Tone |
+| Proactive Behavior | Multimodal Interactions | Third-Party Integration |
+| Error Handling | Consistency | Security |
+| Compliance & Governance | Data Privacy | Performance |
+| Recovery Mechanisms | | |
+
+### Cost & Usage Reporting
+
+The platform tracks per-test execution costs (call minutes consumed, AI evaluation compute) and aggregates usage at the project, suite, and organization level. This enables teams to maintain clear budget visibility and attribute testing costs accurately across internal teams or products.
+
+---
+
+## Onboarding & Time-to-Value
+
+| Step | What Happens | Estimated Time |
+|------|-------------|---------------|
+| **1. Project Setup** | Create a project, select agent type, configure the agent endpoint or phone number. | 5–10 minutes |
+| **2. Requirements Upload** | Upload existing product specifications, use-case documents, or compliance guidelines (PDF, DOCX, images, audio, video). | 5 minutes |
+| **3. Scenario Generation** | Platform AI analyzes uploaded documents and generates 60–100+ test scenarios, streamed live to the UI. | 3–8 minutes |
+| **4. First Test Run** | Execute a sample suite against the agent. Results, recordings, and dimension scores are available immediately post-run. | 20–40 minutes (suite dependent) |
+| **5. Threshold Configuration** | Tune pass/fail thresholds per dimension to align with project quality targets and regulatory requirements. | 15 minutes |
+| **6. Schedule & Automate** | Configure recurring scheduled runs and/or CI/CD pipeline hooks for continuous regression coverage. | 10 minutes |
+
+:::tip No engineering effort required
+The platform's AI reads your existing documentation and produces deployment-ready test cases. Teams without a dedicated QA function can achieve professional-grade agent validation from day one.
+:::
+
+---
+
+## Summary
+
+As AI agents move from pilots to production, the risk profile of inadequate quality assurance escalates from an engineering inconvenience to a business-critical liability. Existing tools address fragments of this challenge; no single solution prior to this platform has provided end-to-end coverage across voice, chat, and multimodal agent types within a unified, automated workflow.
+
+This platform closes that gap — delivering AI-generated test coverage, real phone call execution, multi-dimensional AI scoring, and production-readiness assessment in a single, no-code-to-operate product. It is purpose-built for the operational reality of enterprise AI deployment: non-deterministic outputs, multi-turn conversations, regulatory requirements, and the need for continuous rather than one-time validation.
+
+| Key Metric | Value |
+|-----------|-------|
+| Agent modalities supported | **4** (inbound voice, outbound voice, chat, image) |
+| Test scenarios auto-generated per project | **60–100+** from your documents |
+| Evaluation dimensions scored per conversation | **18+** |
+| Behavioral test categories | **16** covering the full agent capability spectrum |

--- a/sidebars.js
+++ b/sidebars.js
@@ -1244,6 +1244,11 @@ module.exports = {
       },
       {
         type: "doc",
+        label: "Platform Overview",
+        id: "ai-agent-testing-platform-overview",
+      },
+      {
+        type: "doc",
         label: "Test Your First AI Agent",
         id: "testing-your-first-ai-agent",
       },


### PR DESCRIPTION
## Summary

- Converts `AI_Agent_Testing_Platform_Overview.html` into a Docusaurus markdown doc (`docs/ai-agent-testing-platform-overview.md`)
- Covers all 8 sections: Executive Summary, Market Analysis, Competitive Differentiation, Platform Architecture, Technical Integration, Data & Metrics, Onboarding, and Summary
- Adds **Platform Overview** entry to `AgentToAgentSidebar` in `sidebars.js`, placed between "Getting Started" and "Test Your First AI Agent"

## Test plan
- [ ] Verify page renders at `/support/docs/ai-agent-testing-platform-overview/`
- [ ] Verify "Platform Overview" appears in the Agent-to-Agent sidebar
- [ ] Check all tables, callouts, and sections display correctly

Made with [Cursor](https://cursor.com)