### PR TITLE
Fix documentation issues for Mintlify migration

### DIFF
--- a/snippets/FrameworkGrid.mdx
+++ b/snippets/FrameworkGrid.mdx
@@ -2,7 +2,7 @@ export const FrameworkGrid = () => {
   const frameworks = [
     {
       title: 'Java',
-      icon: '/support/assets/images/getting-started/java-icon.webp',
+      icon: '/assets/images/getting-started/java-icon.webp',
       items: [
         { name: 'Java', link: '/support/docs/appium-java/' },
         { name: 'JUnit', link: '/support/docs/appium-java-junit/' },
@@ -13,7 +13,7 @@ export const FrameworkGrid = () => {
     },
     {
       title: 'JavaScript',
-      icon: '/support/assets/images/getting-started/color-js.webp',
+      icon: '/assets/images/getting-started/color-js.webp',
       items: [
         { name: 'JavaScript', link: '/support/docs/appium-nodejs/' },
         { name: 'WebDriverIO', link: '/support/docs/appium-nodejs-webdriverio/' },
@@ -22,7 +22,7 @@ export const FrameworkGrid = () => {
     },
     {
       title: 'Python',
-      icon: '/support/assets/images/getting-started/python-icon.webp',
+      icon: '/assets/images/getting-started/python-icon.webp',
       items: [
         { name: 'Python', link: '/support/docs/appium-python/' },
         { name: 'Behave', link: '/support/docs/appium-python-behave/' },
@@ -33,7 +33,7 @@ export const FrameworkGrid = () => {
     },
     {
       title: 'Ruby',
-      icon: '/support/assets/images/getting-started/ruby-icon.webp',
+      icon: '/assets/images/getting-started/ruby-icon.webp',
       items: [
         { name: 'Ruby', link: '/support/docs/appium-ruby/' },
         { name: 'Cucumber', link: '/support/docs/appium-ruby-cucumber/' },
@@ -42,7 +42,7 @@ export const FrameworkGrid = () => {
     },
     {
       title: 'PHP',
-      icon: '/support/assets/images/getting-started/php-icon.webp',
+      icon: '/assets/images/getting-started/php-icon.webp',
       items: [
         { name: 'PHP', link: '/support/docs/appium-php/' },
         { name: 'Behat', link: '/support/docs/appium-php-behat/' },
@@ -50,7 +50,7 @@ export const FrameworkGrid = () => {
     },
     {
       title: 'C#',
-      icon: '/support/assets/images/getting-started/c-sharp-icon.webp',
+      icon: '/assets/images/getting-started/c-sharp-icon.webp',
       items: [
         { name: 'C#', link: '/support/docs/appium-csharp/' },
         { name: 'NUnit', link: '/support/docs/appium-csharp-nunit/' },

--- a/snippets/FrameworkGridHyperexecute.mdx
+++ b/snippets/FrameworkGridHyperexecute.mdx
@@ -4,7 +4,7 @@ export const FrameworkGridHyperexecute = () => {
   const seleniumFrameworks = [
     {
       title: 'Java',
-      icon: '/support/assets/images/getting-started/java-icon.webp',
+      icon: '/assets/images/getting-started/java-icon.webp',
       items: [
         { name: 'TestNG', link: '/support/docs/testng-on-hyperexecute-grid' },
         { name: 'JUnit', link: '/support/docs/junit-on-hyperexecute-grid' },
@@ -13,7 +13,7 @@ export const FrameworkGridHyperexecute = () => {
     },
     {
       title: 'JavaScript',
-      icon: '/support/assets/images/getting-started/color-js.webp',
+      icon: '/assets/images/getting-started/color-js.webp',
       items: [
         { name: 'WebdriverIO', link: '/support/docs/webdriverio-on-hyperexecute-grid' },
         { name: 'Protractor', link: '/support/docs/protractor-on-hyperexecute-grid' },
@@ -23,7 +23,7 @@ export const FrameworkGridHyperexecute = () => {
     },
     {
       title: 'C#',
-      icon: '/support/assets/images/getting-started/c-sharp-icon.webp',
+      icon: '/assets/images/getting-started/c-sharp-icon.webp',
       items: [
         { name: 'NUnit', link: '/support/docs/nunit-on-hyperexecute-grid' },
         { name: 'SpecFlow', link: '/support/docs/specflow-on-hyperexecute-grid' },
@@ -31,7 +31,7 @@ export const FrameworkGridHyperexecute = () => {
     },
     {
       title: 'Python',
-      icon: '/support/assets/images/getting-started/python-icon.webp',
+      icon: '/assets/images/getting-started/python-icon.webp',
       items: [
         { name: 'PyUnit', link: '/support/docs/pyunit-on-hyperexecute-grid' },
         { name: 'PyTest', link: '/support/docs/pytest-on-hyperexecute-grid' },
@@ -41,7 +41,7 @@ export const FrameworkGridHyperexecute = () => {
     },
     {
       title: 'Ruby',
-      icon: '/support/assets/images/getting-started/ruby-icon.webp',
+      icon: '/assets/images/getting-started/ruby-icon.webp',
       items: [
         { name: 'Ruby', link: '/support/docs/ruby-on-hyperexecute-grid/' },
         { name: 'Capybara', link: '/support/docs/capybara-on-hyperexecute-grid' },
@@ -52,7 +52,7 @@ export const FrameworkGridHyperexecute = () => {
   const cypressFrameworks = [
     {
       title: '',
-      icon: '/support/assets/images/getting-started/cypress_logo.png',
+      icon: '/assets/images/getting-started/cypress_logo.png',
       items: [
         { name: 'Cypress v9', link: '/support/docs/cypressv9-on-hyperexecute' },
         { name: 'Cypress v10', link: '/support/docs/cypressv10-on-hyperexecute' },
@@ -63,7 +63,7 @@ export const FrameworkGridHyperexecute = () => {
   const appiumFrameworks = [
     {
       title: '',
-      icon: '/support/assets/images/getting-started/appium.jpeg',
+      icon: '/assets/images/getting-started/appium.jpeg',
       items: [
         { name: 'Mobile Application', link: '/support/docs/hyperexecute-appium-testing' },
         { name: 'Web Application', link: '/support/docs/hyperexecute-appium-testing' },
@@ -74,7 +74,7 @@ export const FrameworkGridHyperexecute = () => {
   const espressoFrameworks = [
     {
       title: '',
-      icon: '/support/assets/images/getting-started/espresso.png',
+      icon: '/assets/images/getting-started/espresso.png',
       items: [
         { name: 'Espresso', link: '/support/docs/hyperexecute-espresso-testing' },
       ]
@@ -84,7 +84,7 @@ export const FrameworkGridHyperexecute = () => {
   const maestroFrameworks = [
     {
       title: '',
-      icon: '/support/assets/images/getting-started/maestro.png',
+      icon: '/assets/images/getting-started/maestro.png',
       items: [
         { name: 'Maestro', link: '/support/docs/hyperexecute-maestro-testing' },
       ]
@@ -94,7 +94,7 @@ export const FrameworkGridHyperexecute = () => {
   const xcuiFrameworks = [
     {
       title: '',
-      icon: '/support/assets/images/getting-started/xcui.jpeg',
+      icon: '/assets/images/getting-started/xcui.jpeg',
       items: [
         { name: 'XCUI', link: '/support/docs/hyperexecute-xcui-testing' },
       ]
@@ -104,7 +104,7 @@ export const FrameworkGridHyperexecute = () => {
   const puppeteerFrameworks = [
     {
       title: 'JavaScript',
-      icon: '/support/assets/images/getting-started/color-js.webp',
+      icon: '/assets/images/getting-started/color-js.webp',
       items: [
         { name: 'Jest', link: '/support/docs/jest-on-hyperexecute' },
         { name: 'Mocha', link: '/support/docs/mocha-on-hyperexecute' },
@@ -116,7 +116,7 @@ export const FrameworkGridHyperexecute = () => {
   const playwrightFrameworks = [
     {
       title: 'Python',
-      icon: '/support/assets/images/getting-started/python-icon.webp',
+      icon: '/assets/images/getting-started/python-icon.webp',
       items: [
         { name: 'PyTest', link: '/support/docs/pytest-on-hyperexecute' },
         { name: 'Python', link: '/support/docs/playwright-vanillajs-on-hyperexecute' },
@@ -124,7 +124,7 @@ export const FrameworkGridHyperexecute = () => {
     },
     {
       title: 'JavaScript',
-      icon: '/support/assets/images/getting-started/color-js.webp',
+      icon: '/assets/images/getting-started/color-js.webp',
       items: [
         { name: 'VanillaJs', link: '/support/docs/playwright-vanillajs-on-hyperexecute' },
         { name: 'CodeceptJs', link: '/support/docs/playwright-codeceptjs-on-hyperexecute' },
@@ -133,14 +133,14 @@ export const FrameworkGridHyperexecute = () => {
     },
     {
       title: 'Java',
-      icon: '/support/assets/images/getting-started/java-icon.webp',
+      icon: '/assets/images/getting-started/java-icon.webp',
       items: [
         { name: 'JUnit', link: '/support/docs/playwright-junit-on-hyperexecute' },
       ]
     },
     {
       title: 'C#',
-      icon: '/support/assets/images/getting-started/c-sharp-icon.webp',
+      icon: '/assets/images/getting-started/c-sharp-icon.webp',
       items: [
         { name: '.Net', link: '/support/docs/playwright-dotnet-on-hyperexecute' },
       ]

--- a/snippets/HyperExecuteSupportedLanguageRepos.mdx
+++ b/snippets/HyperExecuteSupportedLanguageRepos.mdx
@@ -2,7 +2,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
   const seleniumFrameworks = [
     {
       title: 'Java',
-      icon: '/support/assets/images/getting-started/java-icon.webp',
+      icon: '/assets/images/getting-started/java-icon.webp',
       items: [
         { name: 'TestNG', link: 'https://github.com/LambdaTest/testng-selenium-hyperexecute-sample/tree/main/' },
         { name: 'JUnit', link: 'https://github.com/LambdaTest/junit-selenium-hyperexecute-sample/' },
@@ -11,7 +11,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
     },
     {
        title: 'JavaScript',
-       icon: '/support/assets/images/getting-started/color-js.webp',
+       icon: '/assets/images/getting-started/color-js.webp',
        items: [
          { name: 'WebdriverIO', link: 'https://github.com/LambdaTest/WebdriverIO-HyperExecute-Sample.git' },
          { name: 'Protractor', link: 'https://github.com/LambdaTest/Protractor-HyperExecute-Sample.git' },
@@ -21,7 +21,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
     },
     {
         title: 'C#',
-        icon: '/support/assets/images/getting-started/c-sharp-icon.webp',
+        icon: '/assets/images/getting-started/c-sharp-icon.webp',
         items: [
             { name: 'NUnit', link: 'https://github.com/LambdaTest/nunit-selenium-hyperexecute-sample.git' },
             { name: 'SpecFlow', link: 'https://github.com/LambdaTest/specflow-selenium-hyperexecute-sample.git' },
@@ -29,7 +29,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
     },
     {
         title: 'Python',
-        icon: '/support/assets/images/getting-started/python-icon.webp',
+        icon: '/assets/images/getting-started/python-icon.webp',
         items: [
             { name: 'PyUnit', link: 'https://github.com/LambdaTest/pyunit-selenium-hyperexecute-sample.git' },
             { name: 'PyTest', link: 'https://github.com/LambdaTest/pytest-selenium-hyperexecute-sample.git' },
@@ -39,7 +39,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
     },
     {
         title: 'Ruby',
-        icon: '/support/assets/images/getting-started/ruby-icon.webp',
+        icon: '/assets/images/getting-started/ruby-icon.webp',
         items: [
             { name: 'Ruby', link: 'https://github.com/LambdaTest/Ruby-HyperExecute-Sample.git' },
             { name: 'Capybara', link: 'https://github.com/LambdaTest/Capybara-HyperExecute-Sample.git' },
@@ -50,14 +50,14 @@ export const HyperExecuteSupportedLanguageRepos = () => {
   const playwrightFrameworks = [
     {
       title: 'Java',
-      icon: '/support/assets/images/getting-started/java-icon.webp',
+      icon: '/assets/images/getting-started/java-icon.webp',
       items: [
         { name: 'JUnit', link: 'https://github.com/LambdaTest/hyperexecute-java-playwright-sample.git' },
       ]
     },
     {
        title: 'JavaScript',
-       icon: '/support/assets/images/getting-started/color-js.webp',
+       icon: '/assets/images/getting-started/color-js.webp',
        items: [
          { name: 'VanillaJs', link: 'https://github.com/LambdaTest/HyperExecute-Playwright-Vanilla-Javascript.git' },
          { name: 'CodeceptJs', link: 'https://github.com/LambdaTest/HyperExecute-Playwright-CodeceptJs.git' },
@@ -66,14 +66,14 @@ export const HyperExecuteSupportedLanguageRepos = () => {
     },
     {
         title: 'C#',
-        icon: '/support/assets/images/getting-started/c-sharp-icon.webp',
+        icon: '/assets/images/getting-started/c-sharp-icon.webp',
         items: [
             { name: '.Net', link: 'https://github.com/LambdaTest/dotnet_playwright_hyperexecute_sample' },
         ]
     },
     {
         title: 'Python',
-        icon: '/support/assets/images/getting-started/python-icon.webp',
+        icon: '/assets/images/getting-started/python-icon.webp',
         items: [
             { name: 'Python', link: 'https://github.com/LambdaTest/hyperexecute-playwright-python-sample.git' },
             { name: 'PyTest', link: 'https://github.com/LambdaTest/hyperexecute-playwright-pypi-sample.git' },
@@ -84,7 +84,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
   const puppeteerFrameworks = [
     {
        title: 'JavaScript',
-       icon: '/support/assets/images/getting-started/color-js.webp',
+       icon: '/assets/images/getting-started/color-js.webp',
        items: [
          { name: 'Jest', link: 'https://github.com/LambdaTest/hyperexecute-puppeteer-jest-sample.git' },
          { name: 'Mocha', link: 'https://github.com/LambdaTest/hyperexecute-puppeteer-mocha-sample.git' },
@@ -96,7 +96,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
   const cypressFrameworks = [
     {
        title: '',
-       icon: '/support/assets/images/getting-started/cypress_logo.png',
+       icon: '/assets/images/getting-started/cypress_logo.png',
        items: [
          { name: 'Cypress v9', link: 'https://github.com/LambdaTest/hyperexecute-cypress-v9-sample' },
          { name: 'Cypress v10', link: 'https://github.com/LambdaTest/hyperexecute-cypress-v15-sample' },
@@ -107,7 +107,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
   const appiumFrameworks = [
     {
        title: '',
-       icon: '/support/assets/images/getting-started/appium.jpeg',
+       icon: '/assets/images/getting-started/appium.jpeg',
        items: [
          { name: 'Mobile Application', link: 'https://github.com/LambdaTest/hyperexecute-appium-testng/' },
          { name: 'Emulator', link: 'https://github.com/LambdaTest/hyperexecute-appium-testng/tree/android-emulator' },
@@ -118,7 +118,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
   const espressoFrameworks = [
     {
        title: '',
-       icon: '/support/assets/images/getting-started/espresso.png',
+       icon: '/assets/images/getting-started/espresso.png',
        items: [
          { name: 'Espresso', link: 'https://github.com/LambdaTest/hyperexecute-real-device-espresso' },
        ]
@@ -128,7 +128,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
   const maestroFrameworks = [
     {
        title: '',
-       icon: '/support/assets/images/getting-started/maestro.png',
+       icon: '/assets/images/getting-started/maestro.png',
        items: [
          { name: 'Maestro', link: 'https://github.com/LambdaTest/hyperexecute-maestro-sample-test' },
          { name: 'Emulator', link: 'https://github.com/LambdaTest/hyperexecute-maestro-sample-test/tree/android-emulator' },
@@ -140,7 +140,7 @@ export const HyperExecuteSupportedLanguageRepos = () => {
   const xcuiFrameworks = [
     {
        title: '',
-       icon: '/support/assets/images/getting-started/xcui.jpeg',
+       icon: '/assets/images/getting-started/xcui.jpeg',
        items: [
          { name: 'XCUI', link: 'https://github.com/LambdaTest/hyperexecute-xcui-sample' },
        ]

--- a/snippets/SeleniumSupportedLanguage.mdx
+++ b/snippets/SeleniumSupportedLanguage.mdx
@@ -2,7 +2,7 @@ export const SeleniumSupportedLanguage = () => {
     const languages = [
         {
             name: "Java",
-            icon: "/support/assets/images/getting-started/Java.png",
+            icon: "/assets/images/getting-started/Java.png",
             links: [
                 { title: "Java", url: "/support/docs/java-with-selenium-running-java-automation-scripts-on-testmu-selenium-grid/" },
                 { title: "Selenide", url: "/support/docs/selenide-tests-with-lambdatest-online-selenium-grid-for-automated-cross-browser-testing/" },
@@ -16,7 +16,7 @@ export const SeleniumSupportedLanguage = () => {
         },
         {
             name: "PHP",
-            icon: "/support/assets/images/getting-started/Php.png",
+            icon: "/assets/images/getting-started/Php.png",
             links: [
                 { title: "PHP", url: "/support/docs/php-with-selenium-running-php-automation-scripts-on-testmu-selenium-grid" },
                 { title: "Laravel", url: "/support/docs/laravel-dusk-with-selenium-running-laravel-dusk-automation-scripts-on-testmu-selenium-grid" },
@@ -27,7 +27,7 @@ export const SeleniumSupportedLanguage = () => {
         },
         {
             name: "Ruby",
-            icon: "/support/assets/images/getting-started/Ruby.png",
+            icon: "/assets/images/getting-started/Ruby.png",
             links: [
                 { title: "Ruby", url: "/support/docs/ruby-with-selenium-running-ruby-automation-scripts-on-testmu-selenium-grid" },
                 { title: "RSpec", url: "/support/docs/rspec-with-selenium-running-rspec-automation-scripts-on-testmu-selenium-grid" },
@@ -37,7 +37,7 @@ export const SeleniumSupportedLanguage = () => {
         },
         {
             name: "C#",
-            icon: "/support/assets/images/getting-started/C-Sharp.png",
+            icon: "/assets/images/getting-started/C-Sharp.png",
             links: [
                 { title: "C#", url: "/support/docs/c-with-selenium-running-c-automation-scripts-on-lambdatest-selenium-grid/" },
                 { title: "SpecFlow", url: "/support/docs/specflow-with-selenium-running-specflow-automation-scripts-on-lambdatest-selenium-grid/" },
@@ -48,7 +48,7 @@ export const SeleniumSupportedLanguage = () => {
         },
         {
             name: "Python",
-            icon: "/support/assets/images/getting-started/Python.png",
+            icon: "/assets/images/getting-started/Python.png",
             links: [
                 { title: "Python", url: "/support/docs/python-with-selenium-running-python-automation-scripts-on-lambdatest-selenium-grid/" },
                 { title: "Pytest", url: "/support/docs/pytest-with-selenium-running-pytest-automation-script-on-testmu-selenium-grid" },
@@ -60,7 +60,7 @@ export const SeleniumSupportedLanguage = () => {
         },
         {
             name: "JavaScript",
-            icon: "/support/assets/images/getting-started/Node-JS.png",
+            icon: "/assets/images/getting-started/Node-JS.png",
             links: [
                 { title: "JavaScript", url: "/support/docs/javascript-with-selenium-running-javascript-automation-scripts-on-lambdatest-selenium-grid/" },
                 { title: "WebDriverIO 5.6.2", url: "/support/docs/webdriverio-5-6-2-with-selenium-running-automation-scripts-on-lambdatest-selenium-grid/" },

--- a/support/docs/accessibility-android-rules.mdx
+++ b/support/docs/accessibility-android-rules.mdx
@@ -8,29 +8,178 @@ keywords: ['TestMu AI', 'Accessibility', 'Testing', 'Manual', 'Accessibility Tes
 
 import { BrandName } from "/snippets/BrandName.mdx";
 
----
+<AccordionGroup>
+  <Accordion title="Missing Image Alt" icon="image">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.1.1 |
+    | **Level** | A |
+    | **Impact** | Critical |
 
-| Rule Name | WCAG | Level | Impact | Description |
-|-----------|------|-------|--------|-------------|
-| Missing Image Alt | 1.1.1 | A | Critical | Images lack alternative text descriptions that screen readers can announce to users. Add `android:contentDescription` to meaningful images or set to empty string for decorative images to ensure proper accessibility support. |
-| Missing View Accessibility | 4.1.2 | A | Serious | Interactive elements like buttons, clickable views, or custom controls lack proper accessibility labels that describe their purpose. Ensure all interactive Views have clear `android:contentDescription` or associated labels for screen readers. |
-| Unlabeled Checkbox Element | 4.1.2 | A | Serious | Checkbox controls are missing accessible names that describe their purpose or current state. Provide descriptive labels using `android:text`, `android:contentDescription`, or associated TextView labels so users understand what they're selecting. |
-| Insufficient Color Ratio | 1.4.3 | AA | Serious | Text elements don't meet minimum contrast ratio requirements making them difficult to read for users with visual impairments. Maintain 4.5:1 ratio for normal text and 3:1 for large text by adjusting colors or background. |
-| Missing Field Label | 3.3.2 | A | Serious | Input fields like EditText lack descriptive labels that identify their purpose to users. Provide clear labels using `android:hint`, associated TextView with `android:labelFor`, or TextInputLayout to describe expected input. |
-| Non-accessible Interaction | 4.1.2 | A | Serious | Custom interactive elements, buttons, or gesture-based controls cannot be accessed or activated through assistive technology. Ensure all interactive elements have proper focus handling, role definition, and descriptive labels. |
-| Missing Screen Title | 2.4.2 | A | Serious | Activities or screens lack descriptive titles that help users understand their current location in the app. Set meaningful titles using `setTitle()` or `supportActionBar?.title` for proper navigation context. |
-| Unlabeled Toggle Control | 4.1.2 | A | Serious | Switch, toggle, or similar controls are missing accessible names that explain what they control and their current state. Provide descriptive labels that clearly indicate what the toggle affects (e.g., "Wi-Fi enabled"). |
-| Mismatched Label Text | 2.5.3 | A | Serious | The visible text label on a control differs from the programmatically accessible name, causing confusion for screen reader users. Ensure the accessible name includes or matches the visible text exactly. |
-| Missing Input Value | 4.1.2 | A | Moderate | Text fields are missing programmatic values that assistive technology can read, making it difficult for users to understand current input state. Ensure EditText values are properly exposed and announced by screen readers. |
-| Inaccessible Text Focus | 4.1.2 | A | Moderate | Text elements that receive focus lack proper accessibility properties, confusing screen reader users about their purpose. Either provide clear interactive roles and descriptions or remove focus capability for non-interactive text. |
-| Misplaced Field Label | 3.3.2 | A | Moderate | Form labels are not positioned correctly relative to their controls or lack proper programmatic association. Ensure labels appear visually before controls and use `android:labelFor` for proper screen reader announcement order. |
-| Nested Control Issues | 4.1.2 | A | Moderate | Interactive elements are incorrectly nested inside other interactive elements, creating focus traps and navigation confusion. Separate interactive elements into distinct, non-nested components to ensure proper accessibility navigation. |
-| Unnamed Nested Element | 4.1.2 | A | Moderate | Elements within containers lack their own accessible names when they should be independently accessible. Provide distinct labels for nested interactive elements or mark decorative elements as non-focusable. |
-| Fixed Orientation Lock | 1.3.4 | AA | Moderate | App restricts viewing to only portrait or landscape orientation without accessibility justification. Support both orientations or provide alternative access methods for users who cannot rotate their devices due to physical constraints. |
-| Undersized Touch Target | 2.5.5 | AAA | Moderate | Interactive elements are smaller than the recommended minimum touch target size, making them difficult to activate for users with motor impairments. Ensure all touch targets are at least 48dp x 48dp. |
-| Insufficient Target Spacing | 2.5.5 | AAA | Moderate | Interactive elements are placed too close together without adequate spacing, increasing risk of accidental activation. Provide sufficient spacing between adjacent touch targets to prevent targeting errors for users with limited dexterity. |
+    Images lack alternative text descriptions that screen readers can announce to users. Add `android:contentDescription` to meaningful images or set to empty string for decorative images to ensure proper accessibility support.
+  </Accordion>
+
+  <Accordion title="Missing View Accessibility" icon="eye">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Serious |
+
+    Interactive elements like buttons, clickable views, or custom controls lack proper accessibility labels that describe their purpose. Ensure all interactive Views have clear `android:contentDescription` or associated labels for screen readers.
+  </Accordion>
+
+  <Accordion title="Unlabeled Checkbox Element" icon="square-check">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Serious |
+
+    Checkbox controls are missing accessible names that describe their purpose or current state. Provide descriptive labels using `android:text`, `android:contentDescription`, or associated TextView labels so users understand what they're selecting.
+  </Accordion>
+
+  <Accordion title="Insufficient Color Ratio" icon="palette">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.4.3 |
+    | **Level** | AA |
+    | **Impact** | Serious |
+
+    Text elements don't meet minimum contrast ratio requirements making them difficult to read for users with visual impairments. Maintain 4.5:1 ratio for normal text and 3:1 for large text by adjusting colors or background.
+  </Accordion>
+
+  <Accordion title="Missing Field Label" icon="tag">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 3.3.2 |
+    | **Level** | A |
+    | **Impact** | Serious |
+
+    Input fields like EditText lack descriptive labels that identify their purpose to users. Provide clear labels using `android:hint`, associated TextView with `android:labelFor`, or TextInputLayout to describe expected input.
+  </Accordion>
+
+  <Accordion title="Non-accessible Interaction" icon="hand-pointer">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Serious |
+
+    Custom interactive elements, buttons, or gesture-based controls cannot be accessed or activated through assistive technology. Ensure all interactive elements have proper focus handling, role definition, and descriptive labels.
+  </Accordion>
+
+  <Accordion title="Missing Screen Title" icon="heading">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 2.4.2 |
+    | **Level** | A |
+    | **Impact** | Serious |
+
+    Activities or screens lack descriptive titles that help users understand their current location in the app. Set meaningful titles using `setTitle()` or `supportActionBar?.title` for proper navigation context.
+  </Accordion>
+
+  <Accordion title="Unlabeled Toggle Control" icon="toggle-on">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Serious |
+
+    Switch, toggle, or similar controls are missing accessible names that explain what they control and their current state. Provide descriptive labels that clearly indicate what the toggle affects (e.g., "Wi-Fi enabled").
+  </Accordion>
+
+  <Accordion title="Mismatched Label Text" icon="not-equal">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 2.5.3 |
+    | **Level** | A |
+    | **Impact** | Serious |
+
+    The visible text label on a control differs from the programmatically accessible name, causing confusion for screen reader users. Ensure the accessible name includes or matches the visible text exactly.
+  </Accordion>
+
+  <Accordion title="Missing Input Value" icon="keyboard">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Moderate |
+
+    Text fields are missing programmatic values that assistive technology can read, making it difficult for users to understand current input state. Ensure EditText values are properly exposed and announced by screen readers.
+  </Accordion>
+
+  <Accordion title="Inaccessible Text Focus" icon="crosshairs">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Moderate |
+
+    Text elements that receive focus lack proper accessibility properties, confusing screen reader users about their purpose. Either provide clear interactive roles and descriptions or remove focus capability for non-interactive text.
+  </Accordion>
+
+  <Accordion title="Misplaced Field Label" icon="arrows-up-down">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 3.3.2 |
+    | **Level** | A |
+    | **Impact** | Moderate |
+
+    Form labels are not positioned correctly relative to their controls or lack proper programmatic association. Ensure labels appear visually before controls and use `android:labelFor` for proper screen reader announcement order.
+  </Accordion>
+
+  <Accordion title="Nested Control Issues" icon="layer-group">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Moderate |
+
+    Interactive elements are incorrectly nested inside other interactive elements, creating focus traps and navigation confusion. Separate interactive elements into distinct, non-nested components to ensure proper accessibility navigation.
+  </Accordion>
+
+  <Accordion title="Unnamed Nested Element" icon="sitemap">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Moderate |
+
+    Elements within containers lack their own accessible names when they should be independently accessible. Provide distinct labels for nested interactive elements or mark decorative elements as non-focusable.
+  </Accordion>
+
+  <Accordion title="Fixed Orientation Lock" icon="mobile-screen">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.3.4 |
+    | **Level** | AA |
+    | **Impact** | Moderate |
+
+    App restricts viewing to only portrait or landscape orientation without accessibility justification. Support both orientations or provide alternative access methods for users who cannot rotate their devices due to physical constraints.
+  </Accordion>
+
+  <Accordion title="Undersized Touch Target" icon="up-down-left-right">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 2.5.5 |
+    | **Level** | AAA |
+    | **Impact** | Moderate |
+
+    Interactive elements are smaller than the recommended minimum touch target size, making them difficult to activate for users with motor impairments. Ensure all touch targets are at least 48dp x 48dp.
+  </Accordion>
+
+  <Accordion title="Insufficient Target Spacing" icon="arrows-left-right">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 2.5.5 |
+    | **Level** | AAA |
+    | **Impact** | Moderate |
+
+    Interactive elements are placed too close together without adequate spacing, increasing risk of accidental activation. Provide sufficient spacing between adjacent touch targets to prevent targeting errors for users with limited dexterity.
+  </Accordion>
+</AccordionGroup>
 
 <Warning>
 We are continuously expanding our App Accessibility guidelines. Visit this page for the latest updates and new requirements.
 </Warning>
-

--- a/support/docs/accessibility-ios-rules.mdx
+++ b/support/docs/accessibility-ios-rules.mdx
@@ -9,26 +9,174 @@ keywords: ['TestMu AI', 'Accessibility', 'Testing', 'Manual', 'Accessibility Tes
 import { BrandName } from "/snippets/BrandName.mdx";
 import { NewTag } from "/snippets/NewTag.mdx";
 
+<AccordionGroup>
+  <Accordion title="Missing Accessibility Labels" icon="tag">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Serious |
 
-| Rule Name                          | WCAG   | Level | Impact  | Description |  
-|-------------------------------------|--------|-------|---------|-------------|  
-| Missing Accessibility Labels        | 4.1.2  | A     | Serious | Interactive UI elements lack proper accessibility labels, hints, or descriptions that VoiceOver can announce to users. Set `accessibilityLabel` for meaningful descriptions and `accessibilityHint` for usage guidance. In SwiftUI use `.accessibilityLabel()` and `.accessibilityHint()`. For images, provide descriptive text. For buttons, ensure labels describe the action, not just visual appearance. |  
-| Color Contrast Issues               | 1.4.3  | AA    | Serious | Text and background color combinations fail to meet WCAG minimum contrast ratios for visual accessibility. Use Apple's Color Contrast Calculator or online tools to verify 4.5:1 ratio for normal text, 3:1 for large text. Implement system colors that adapt to accessibility settings and test in high contrast mode. Consider using semantic colors like `UIColor.label` and `UIColor.systemBackground`. |  
-| Touch Target Sizing                 | 2.5.5  | AAA   | Moderate | Touch target areas are smaller than Apple's recommended 44pt minimum size or lack adequate spacing from adjacent elements. Ensure interactive elements are at least 44x44 points by increasing button frame size or adding transparent padding. Use constraints to maintain minimum spacing between adjacent touchable elements. In SwiftUI, use `.frame(minWidth: 44, minHeight: 44)` and test on actual devices. |  
-| Assistive Technology Access         | 4.1.2  | A     | Serious | UI components cannot be properly detected, focused, or activated by VoiceOver and other assistive technologies. Set `isAccessibilityElement = true` for custom views, ensure proper view hierarchy, and avoid blocking accessibility elements. Implement `accessibilityActivate()` for custom interactions and use `accessibilityElements` array to define focus order. Test navigation with VoiceOver gestures. |  
-| Text Truncation Issues              | 1.4.4  | AA    | Serious | Text content becomes truncated or cut off when users increase font sizes through iOS Dynamic Type settings. Use `adjustsFontForContentSizeCategory = true` on text elements and implement flexible layouts with priority constraints. Use `UIFont.preferredFont(forTextStyle:)` for scalable system fonts. Test with largest accessibility text sizes and avoid fixed height constraints on text containers. |  
-| Accessibility Role Definition       | 4.1.2  | A     | Moderate | UI elements lack appropriate accessibility traits that define their role, state, or behavior for assistive technology interaction. Set correct `accessibilityTraits` (.button, .link, .header, .selected, .disabled) and combine traits when needed. Update traits dynamically based on state changes. In SwiftUI, use `.accessibilityAddTraits()` and `.accessibilityRemoveTraits()` to ensure custom controls communicate their purpose clearly. |  
-| Dynamic Type Support                | 1.4.4  | AA    | Serious | App interface fails to properly scale or adapt when users enable larger text sizes in iOS accessibility settings. Enable Dynamic Type support using `traitCollectionDidChange` to respond to size changes and use Auto Layout with flexible constraints. Implement `adjustsFontForContentSizeCategory` on text elements. Test with Settings > Accessibility > Display & Text Size > Larger Text and design layouts that reflow gracefully. |  
-| Accessibility Label Not Punctuated  <NewTag  value="New" /> | 3.3.2  | A     | Critical | Accessibility labels should not contain punctuation or formatting that may affect screen reader output. End accessibility labels with proper punctuation (period, exclamation, or question mark) to ensure natural screen reader pauses and pronunciation. This helps VoiceOver users understand where one element ends and another begins, improving the overall navigation experience. |  
-| Missing Image Element Label  <NewTag  value="New" /> | 1.1.1  | A     | Critical | An accessibility label is an attribute assigned to UIImageView or UIButton elements that convey information graphically. This label gives a textual description of the graphic, making it accessible to users relying on screen readers. Add the `accessibilityLabel` property to all non-decorative UIImageView and UIButton elements containing images. For decorative images, set `isAccessibilityElement = false` to prevent unnecessary screen reader announcements. |  
-| Missing Button Element Label  <NewTag  value="New" /> | 1.3.1  | A     | Critical | Button elements within your app must be properly labeled and fully accessible to users relying on assistive technologies like screen readers. Add `accessibilityLabel` or button title text to all buttons so screen reader users understand what action each button performs. Ensure labels describe the action (e.g., "Submit form", "Close dialog") rather than just the visual appearance. |  
-| Button Element Capitalisation Check  <NewTag  value="New" /> | 3.1.6  | AAA   | Minor   | Button accessibility labels should begin with an uppercase letter and follow proper capitalization standards to improve readability and screen reader pronunciation. Use sentence case (e.g., "Save changes") instead of all caps or inconsistent capitalization. Avoid ALL CAPS as it may cause screen readers to read each letter individually. Follow iOS Human Interface Guidelines for consistent text formatting. |  
-| Missing Checkbox Element Label  <NewTag  value="New" /> | 1.3.1  | A     | Critical | Checkbox elements within your app must be properly labeled and fully accessible to users relying on assistive technologies like screen readers. Add `accessibilityLabel` to checkbox elements to describe what option is being selected or deselected. Combine with appropriate `accessibilityTraits` (.button, .selected) and update traits dynamically when state changes to communicate current selection status. |  
-| Missing Editable Element Label  <NewTag  value="New" /> | 1.3.1  | A     | Critical | Editable elements such as UITextField or UITextView should have both name and value available to screen readers. Add `accessibilityLabel` or associate with a UILabel to describe what information should be entered in text fields. Use `placeholder` text for additional guidance but never rely on it alone for accessibility. Ensure labels remain visible when fields are focused or filled. |  
-| Missing Switch Element Label  <NewTag  value="New" /> | 1.3.1  | A     | Critical | Switch controls (UISwitch) in an app must have both their name and value available to screen readers. Add `accessibilityLabel` to switch controls to describe what setting or feature is being toggled on or off (e.g., "Enable notifications", "Dark mode"). The switch state (On/Off) is automatically announced by VoiceOver, so focus the label on describing the setting being controlled. |  
-| Duplicate Accessibility Label  <NewTag  value="New" /> | 4.1.2  | A     | Critical | Multiple UI elements on the same screen share the same accessibility label, causing confusion for screen reader users who cannot distinguish between different controls. Ensure each interactive element has a unique `accessibilityLabel` to prevent confusion. For similar elements (like multiple "Delete" buttons), add context such as "Delete photo 1", "Delete photo 2" or reference the item being acted upon. |  
+    Interactive UI elements lack proper accessibility labels, hints, or descriptions that VoiceOver can announce to users. Set `accessibilityLabel` for meaningful descriptions and `accessibilityHint` for usage guidance. In SwiftUI use `.accessibilityLabel()` and `.accessibilityHint()`. For images, provide descriptive text. For buttons, ensure labels describe the action, not just visual appearance.
+  </Accordion>
+
+  <Accordion title="Color Contrast Issues" icon="palette">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.4.3 |
+    | **Level** | AA |
+    | **Impact** | Serious |
+
+    Text and background color combinations fail to meet WCAG minimum contrast ratios for visual accessibility. Use Apple's Color Contrast Calculator or online tools to verify 4.5:1 ratio for normal text, 3:1 for large text. Implement system colors that adapt to accessibility settings and test in high contrast mode. Consider using semantic colors like `UIColor.label` and `UIColor.systemBackground`.
+  </Accordion>
+
+  <Accordion title="Touch Target Sizing" icon="hand-pointer">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 2.5.5 |
+    | **Level** | AAA |
+    | **Impact** | Moderate |
+
+    Touch target areas are smaller than Apple's recommended 44pt minimum size or lack adequate spacing from adjacent elements. Ensure interactive elements are at least 44x44 points by increasing button frame size or adding transparent padding. Use constraints to maintain minimum spacing between adjacent touchable elements. In SwiftUI, use `.frame(minWidth: 44, minHeight: 44)` and test on actual devices.
+  </Accordion>
+
+  <Accordion title="Assistive Technology Access" icon="universal-access">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Serious |
+
+    UI components cannot be properly detected, focused, or activated by VoiceOver and other assistive technologies. Set `isAccessibilityElement = true` for custom views, ensure proper view hierarchy, and avoid blocking accessibility elements. Implement `accessibilityActivate()` for custom interactions and use `accessibilityElements` array to define focus order. Test navigation with VoiceOver gestures.
+  </Accordion>
+
+  <Accordion title="Text Truncation Issues" icon="text-size">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.4.4 |
+    | **Level** | AA |
+    | **Impact** | Serious |
+
+    Text content becomes truncated or cut off when users increase font sizes through iOS Dynamic Type settings. Use `adjustsFontForContentSizeCategory = true` on text elements and implement flexible layouts with priority constraints. Use `UIFont.preferredFont(forTextStyle:)` for scalable system fonts. Test with largest accessibility text sizes and avoid fixed height constraints on text containers.
+  </Accordion>
+
+  <Accordion title="Accessibility Role Definition" icon="sitemap">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Moderate |
+
+    UI elements lack appropriate accessibility traits that define their role, state, or behavior for assistive technology interaction. Set correct `accessibilityTraits` (.button, .link, .header, .selected, .disabled) and combine traits when needed. Update traits dynamically based on state changes. In SwiftUI, use `.accessibilityAddTraits()` and `.accessibilityRemoveTraits()` to ensure custom controls communicate their purpose clearly.
+  </Accordion>
+
+  <Accordion title="Dynamic Type Support" icon="font">
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.4.4 |
+    | **Level** | AA |
+    | **Impact** | Serious |
+
+    App interface fails to properly scale or adapt when users enable larger text sizes in iOS accessibility settings. Enable Dynamic Type support using `traitCollectionDidChange` to respond to size changes and use Auto Layout with flexible constraints. Implement `adjustsFontForContentSizeCategory` on text elements. Test with Settings > Accessibility > Display & Text Size > Larger Text and design layouts that reflow gracefully.
+  </Accordion>
+
+  <Accordion title="Accessibility Label Not Punctuated" icon="circle-exclamation">
+    <NewTag value="New" />
+
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 3.3.2 |
+    | **Level** | A |
+    | **Impact** | Critical |
+
+    Accessibility labels should not contain punctuation or formatting that may affect screen reader output. End accessibility labels with proper punctuation (period, exclamation, or question mark) to ensure natural screen reader pauses and pronunciation. This helps VoiceOver users understand where one element ends and another begins, improving the overall navigation experience.
+  </Accordion>
+
+  <Accordion title="Missing Image Element Label" icon="image">
+    <NewTag value="New" />
+
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.1.1 |
+    | **Level** | A |
+    | **Impact** | Critical |
+
+    An accessibility label is an attribute assigned to UIImageView or UIButton elements that convey information graphically. This label gives a textual description of the graphic, making it accessible to users relying on screen readers. Add the `accessibilityLabel` property to all non-decorative UIImageView and UIButton elements containing images. For decorative images, set `isAccessibilityElement = false` to prevent unnecessary screen reader announcements.
+  </Accordion>
+
+  <Accordion title="Missing Button Element Label" icon="square">
+    <NewTag value="New" />
+
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.3.1 |
+    | **Level** | A |
+    | **Impact** | Critical |
+
+    Button elements within your app must be properly labeled and fully accessible to users relying on assistive technologies like screen readers. Add `accessibilityLabel` or button title text to all buttons so screen reader users understand what action each button performs. Ensure labels describe the action (e.g., "Submit form", "Close dialog") rather than just the visual appearance.
+  </Accordion>
+
+  <Accordion title="Button Element Capitalisation Check" icon="font-case">
+    <NewTag value="New" />
+
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 3.1.6 |
+    | **Level** | AAA |
+    | **Impact** | Minor |
+
+    Button accessibility labels should begin with an uppercase letter and follow proper capitalization standards to improve readability and screen reader pronunciation. Use sentence case (e.g., "Save changes") instead of all caps or inconsistent capitalization. Avoid ALL CAPS as it may cause screen readers to read each letter individually. Follow iOS Human Interface Guidelines for consistent text formatting.
+  </Accordion>
+
+  <Accordion title="Missing Checkbox Element Label" icon="square-check">
+    <NewTag value="New" />
+
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.3.1 |
+    | **Level** | A |
+    | **Impact** | Critical |
+
+    Checkbox elements within your app must be properly labeled and fully accessible to users relying on assistive technologies like screen readers. Add `accessibilityLabel` to checkbox elements to describe what option is being selected or deselected. Combine with appropriate `accessibilityTraits` (.button, .selected) and update traits dynamically when state changes to communicate current selection status.
+  </Accordion>
+
+  <Accordion title="Missing Editable Element Label" icon="pen-to-square">
+    <NewTag value="New" />
+
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.3.1 |
+    | **Level** | A |
+    | **Impact** | Critical |
+
+    Editable elements such as UITextField or UITextView should have both name and value available to screen readers. Add `accessibilityLabel` or associate with a UILabel to describe what information should be entered in text fields. Use `placeholder` text for additional guidance but never rely on it alone for accessibility. Ensure labels remain visible when fields are focused or filled.
+  </Accordion>
+
+  <Accordion title="Missing Switch Element Label" icon="toggle-on">
+    <NewTag value="New" />
+
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 1.3.1 |
+    | **Level** | A |
+    | **Impact** | Critical |
+
+    Switch controls (UISwitch) in an app must have both their name and value available to screen readers. Add `accessibilityLabel` to switch controls to describe what setting or feature is being toggled on or off (e.g., "Enable notifications", "Dark mode"). The switch state (On/Off) is automatically announced by VoiceOver, so focus the label on describing the setting being controlled.
+  </Accordion>
+
+  <Accordion title="Duplicate Accessibility Label" icon="clone">
+    <NewTag value="New" />
+
+    | Property | Value |
+    |----------|-------|
+    | **WCAG** | 4.1.2 |
+    | **Level** | A |
+    | **Impact** | Critical |
+
+    Multiple UI elements on the same screen share the same accessibility label, causing confusion for screen reader users who cannot distinguish between different controls. Ensure each interactive element has a unique `accessibilityLabel` to prevent confusion. For similar elements (like multiple "Delete" buttons), add context such as "Delete photo 1", "Delete photo 2" or reference the item being acted upon.
+  </Accordion>
+</AccordionGroup>
 
 <Warning>
 We are continuously expanding our App Accessibility guidelines. Visit this page for the latest updates and new requirements.
 </Warning>
-

--- a/support/docs/analytics-allure-api-widgets.mdx
+++ b/support/docs/analytics-allure-api-widgets.mdx
@@ -12,7 +12,7 @@ import { BrandName } from "/snippets/BrandName.mdx";
 
 The `Allure Test Insights` module helps you to get an overview of the test execution results using the Allure. This widget provides insights into the test execution results, test status, and test duration.
 
-<iframe width="800" height="450" src="https://www.youtube.com/embed/21XtN5PSMNI?si=4oVmKO88mzVlLVW1" title="Integrate Allure Test Insights with HyperExecute" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="100%" height="450" src="https://www.youtube.com/embed/21XtN5PSMNI?si=4oVmKO88mzVlLVW1" title="Integrate Allure Test Insights with HyperExecute" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## How To Use Allure Test Insights?
 

--- a/support/docs/analytics-dashboard-copilot.mdx
+++ b/support/docs/analytics-dashboard-copilot.mdx
@@ -12,7 +12,7 @@ import { BrandName } from "/snippets/BrandName.mdx";
 
 The AI CoPilot Dashboard is an innovative feature designed to revolutionize the way you analyze and gain insights from your data. By leveraging the power of artificial intelligence, the dashboard provides intelligent recommendations, insights, and predictions tailored to your specific data, enabling you to make data-driven decisions faster than ever before.
 
-<iframe width="800" height="450" src="https://www.youtube.com/embed/0CwsyCZOzYU?si=3YMIA6hb5mAu50ba" title="Exploring the CoPilot" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="100%" height="450" src="https://www.youtube.com/embed/0CwsyCZOzYU?si=3YMIA6hb5mAu50ba" title="Exploring the CoPilot" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Prerequisites
 

--- a/support/docs/analytics-modules-test-intelligence-flaky-test-analytics.mdx
+++ b/support/docs/analytics-modules-test-intelligence-flaky-test-analytics.mdx
@@ -9,7 +9,7 @@ import { BrandName } from "/snippets/BrandName.mdx";
 
 The best way to analyze your flaky tests is to use Test Intelligence. Test Intelligence is a machine learning-based algorithm that helps you identify flaky tests and get insights on the flaky tests that are causing your test runs to fail. By observing the historical test runs, Test Intelligence can identify the flaky tests and provide you with the insights to help you fix them.
 
-<iframe width="800" height="450" src="https://www.youtube.com/embed/h_A4KRo2V8Q?si=k_acrR-06_FO0N7q" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="100%" height="450" src="https://www.youtube.com/embed/h_A4KRo2V8Q?si=k_acrR-06_FO0N7q" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Flakiness Trends
 The Flakiness Trends widget allows the QA teams to analyze the trends of the flaky tests executed on the platform categorized into Passed, Failed, and Flaky which can easily be filtered with the legends added at the top of the graph.

--- a/support/docs/app-testing-on-real-devices.mdx
+++ b/support/docs/app-testing-on-real-devices.mdx
@@ -12,9 +12,9 @@ import { BrandName } from "/snippets/BrandName.mdx";
 
 Real device app testing is the process of testing a mobile application to ensure that their functionality and usability is not comprised when installed across multiple Android and iOS devices. With <BrandName />, you can test mobile applications manually to ensure they perform seamlessly across 3000 + real mobile devices.
 
-<iframe 
-  width="560" 
-  height="315" 
+<iframe
+  width="100%"
+  height="400"
   src="https://www.youtube.com/embed/k-DgcPraWns" 
   title="YouTube video player" 
   frameborder="0" 

--- a/support/docs/hyperexecute-mcp-server-release-notes-1-0-0.mdx
+++ b/support/docs/hyperexecute-mcp-server-release-notes-1-0-0.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Version 1.0.0"
+title: "MCP TestMu AI Release Notes"
 sidebarTitle: "Version 1.0.0"
 description: "Check out the release notes for HyperExecute MCP Server 1.0.0, introducing new features, improvements, and bug fixes for streamlined testing."
 keywords: ['TestMu AI Hyperexecute', 'TestMu AI Hyperexecute help', 'TestMu AI Hyperexecute documentation', 'FAQs']
@@ -9,8 +9,6 @@ keywords: ['TestMu AI Hyperexecute', 'TestMu AI Hyperexecute help', 'TestMu AI H
 import { BrandName } from "/snippets/BrandName.mdx";
 
 ---
-
-# MCP TestMu AI Release Notes
 
 ## Version 1.0.0 - Major Release
 

--- a/support/docs/hyperexecute-mcp-server.mdx
+++ b/support/docs/hyperexecute-mcp-server.mdx
@@ -16,9 +16,9 @@ HyperExecute MCP Server is an AI-native test orchestration platform that dramati
 
 Get a comprehensive overview of HyperExecute's capabilities by watching our introductory video.
 
-<iframe 
-  width="560" 
-  height="315" 
+<iframe
+  width="100%"
+  height="400"
   src="https://www.youtube.com/embed/tLe5VPcGDxs" 
   title="YouTube video player" 
   frameborder="0" 

--- a/support/docs/integration-with-hyperexecute.mdx
+++ b/support/docs/integration-with-hyperexecute.mdx
@@ -13,7 +13,7 @@ Integrate HyperExecute with your favourite CI/CD tools, products and <BrandName 
 <CardGroup cols={1}>
   <Card title="Integration With Products" href="/support/docs/hyperexecute-integration-with-products/" />
   <Card title="Integration With CI/CD Tools" href="/support/docs/hyperexecute-integration-with-ci-cd-tools/" />
-  <Card title="Integration With <BrandName /> Products" href="/support/docs/he-integration-with-testmu-products/" />
+  <Card title="Integration With TestMu AI Products" href="/support/docs/he-integration-with-testmu-products/" />
 </CardGroup>
 
 ***

--- a/support/docs/kaneai-edit-test-steps.mdx
+++ b/support/docs/kaneai-edit-test-steps.mdx
@@ -9,4 +9,4 @@ import { BrandName } from "/snippets/BrandName.mdx";
 
 In this tutorial, learn how with KaneAI, you can efficiently update and edit test steps using automation.
 
-<iframe src="https://www.loom.com/embed/4607b26d957a483ead52722d54e92605?sid=567670c4-f1c4-4e54-99c0-32a3be5ae70b" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen height="400" width="800"></iframe>
+<iframe src="https://www.loom.com/embed/4607b26d957a483ead52722d54e92605?sid=567670c4-f1c4-4e54-99c0-32a3be5ae70b" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen height="400" width="100%"></iframe>

--- a/support/docs/kaneai-kb-knowledge-base-index.mdx
+++ b/support/docs/kaneai-kb-knowledge-base-index.mdx
@@ -11,142 +11,78 @@ The KaneAI Knowledge Base is your go-to resource for writing effective test case
 
 Start here to learn how to write reliable test instructions for any scenario — from finding elements on the page to handling complex form interactions.
 
-<div className="support_main">
-  <a href="/support/docs/kaneai-kb-finding-and-interacting-with-elements/">
-    <div className="support_inners">
-      <h3>Element Interactions</h3>
-      <p>Target elements precisely using text, type, position, and context cues. Covers scrolling, tab management, hover, and drag-and-drop.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kaneai-kb-forms-inputs-and-data-entry/">
-    <div className="support_inners">
-      <h3>Forms & Inputs</h3>
-      <p>Handle text inputs, dropdowns, date pickers, checkboxes, file uploads, OTP fields, sliders, autocomplete, and multi-step form wizards.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kaneai-kb-assertions-and-validation/">
-    <div className="support_inners">
-      <h3>Assertions Guide</h3>
-      <p>Write reliable assertions for text, visual elements, URLs, layout, and math. Includes do's and don'ts, variable-based assertions, and failure configuration.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kaneai-kb-dynamic-content-waits-and-page-state/">
-    <div className="support_inners">
-      <h3>Waits & Timing</h3>
-      <p>Handle loading spinners, toast notifications, modals, infinite scroll, lazy loading, and async content with the right wait strategy.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kaneai-kb-mobile-app-testing-patterns/">
-    <div className="support_inners">
-      <h3>Mobile Patterns</h3>
-      <p>Android & iOS specific patterns — keyboard handling, OTP fields, native pickers, gestures, deep links, permission dialogs, and spannable text.</p>
-    </div>
-  </a>
-</div>
+<CardGroup cols={2}>
+  <Card title="Element Interactions" href="/support/docs/kaneai-kb-finding-and-interacting-with-elements/">
+    Target elements precisely using text, type, position, and context cues. Covers scrolling, tab management, hover, and drag-and-drop.
+  </Card>
+  <Card title="Forms & Inputs" href="/support/docs/kaneai-kb-forms-inputs-and-data-entry/">
+    Handle text inputs, dropdowns, date pickers, checkboxes, file uploads, OTP fields, sliders, autocomplete, and multi-step form wizards.
+  </Card>
+  <Card title="Assertions Guide" href="/support/docs/kaneai-kb-assertions-and-validation/">
+    Write reliable assertions for text, visual elements, URLs, layout, and math. Includes do's and don'ts, variable-based assertions, and failure configuration.
+  </Card>
+  <Card title="Waits & Timing" href="/support/docs/kaneai-kb-dynamic-content-waits-and-page-state/">
+    Handle loading spinners, toast notifications, modals, infinite scroll, lazy loading, and async content with the right wait strategy.
+  </Card>
+  <Card title="Mobile Patterns" href="/support/docs/kaneai-kb-mobile-app-testing-patterns/">
+    Android & iOS specific patterns — keyboard handling, OTP fields, native pickers, gestures, deep links, permission dialogs, and spannable text.
+  </Card>
+</CardGroup>
 
 ## Advanced Testing
 
 Guides for complex testing scenarios involving authentication, API validation, and workarounds for natural language limitations.
 
-<div className="support_main">
-  <a href="/support/docs/kaneai-kb-authentication-and-session-management/">
-    <div className="support_inners">
-      <h3>Authentication & Sessions</h3>
-      <p>Test login flows, TOTP/MFA with native smart variables, session persistence, logout, and timeout handling. Includes reusable login modules.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kaneai-kb-api-testing-and-network-assertions/">
-    <div className="support_inners">
-      <h3>API & Network</h3>
-      <p>Make API calls via curl, validate responses with JSON variables, assert network logs, and combine API + UI testing in a single flow.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kaneai-kb-js-snippets-and-workarounds/">
-    <div className="support_inners">
-      <h3>JS Workarounds</h3>
-      <p>When natural language isn't enough — JS snippets for date pickers, CSS validation, string manipulation, table cells, and more.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kaneai-failure-conditions/">
-    <div className="support_inners">
-      <h3>Failure Conditions</h3>
-      <p>Configure how assertion failures behave — fail immediately, fail and continue, or warn and continue. Set defaults at organization or step level.</p>
-    </div>
-  </a>
-</div>
+<CardGroup cols={2}>
+  <Card title="Authentication & Sessions" href="/support/docs/kaneai-kb-authentication-and-session-management/">
+    Test login flows, TOTP/MFA with native smart variables, session persistence, logout, and timeout handling. Includes reusable login modules.
+  </Card>
+  <Card title="API & Network" href="/support/docs/kaneai-kb-api-testing-and-network-assertions/">
+    Make API calls via curl, validate responses with JSON variables, assert network logs, and combine API + UI testing in a single flow.
+  </Card>
+  <Card title="JS Workarounds" href="/support/docs/kaneai-kb-js-snippets-and-workarounds/">
+    When natural language isn't enough — JS snippets for date pickers, CSS validation, string manipulation, table cells, and more.
+  </Card>
+  <Card title="Failure Conditions" href="/support/docs/kaneai-failure-conditions/">
+    Configure how assertion failures behave — fail immediately, fail and continue, or warn and continue. Set defaults at organization or step level.
+  </Card>
+</CardGroup>
 
 ## Variables and Parameters
 
 Manage dynamic data, secrets, and parameterized test inputs.
 
-<div className="support_main">
-  <a href="/support/docs/kane-ai-using-variables/">
-    <div className="support_inners">
-      <h3>Variables</h3>
-      <p>Create and use local, global, and environment variables. Store values from the application and reuse them across test steps and executions.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kane-ai-secrets/">
-    <div className="support_inners">
-      <h3>Secrets</h3>
-      <p>Securely stored sensitive data (e.g., passwords, API tokens) encrypted via HashiCorp Vault. Never exposed in logs or generated code.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kane-ai-smart-variables/">
-    <div className="support_inners">
-      <h3>Smart Variables</h3>
-      <p>Predefined dynamic variables for dates, randomization, device info, and system details. Use `{{smart.current_date}}`, `{{smart.random_email}}`, and more.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kane-ai-using-parameters/">
-    <div className="support_inners">
-      <h3>Parameters</h3>
-      <p>Values passed into test cases at runtime to customize test execution for different configurations or environments.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kane-ai-using-datasets/">
-    <div className="support_inners">
-      <h3>Datasets</h3>
-      <p>Collections of test data used for data-driven testing, allowing you to run the same test with different inputs.</p>
-    </div>
-  </a>
-</div>
+<CardGroup cols={2}>
+  <Card title="Variables" href="/support/docs/kane-ai-using-variables/">
+    Create and use local, global, and environment variables. Store values from the application and reuse them across test steps and executions.
+  </Card>
+  <Card title="Secrets" href="/support/docs/kane-ai-secrets/">
+    Securely stored sensitive data (e.g., passwords, API tokens) encrypted via HashiCorp Vault. Never exposed in logs or generated code.
+  </Card>
+  <Card title="Smart Variables" href="/support/docs/kane-ai-smart-variables/">
+    Predefined dynamic variables for dates, randomization, device info, and system details. Use `{{smart.current_date}}`, `{{smart.random_email}}`, and more.
+  </Card>
+  <Card title="Parameters" href="/support/docs/kane-ai-using-parameters/">
+    Values passed into test cases at runtime to customize test execution for different configurations or environments.
+  </Card>
+  <Card title="Datasets" href="/support/docs/kane-ai-using-datasets/">
+    Collections of test data used for data-driven testing, allowing you to run the same test with different inputs.
+  </Card>
+</CardGroup>
 
 ## Reference
 
-<div className="support_main">
-  <a href="/support/docs/kane-ai-command-guide/">
-    <div className="support_inners">
-      <h3>Command Types</h3>
-      <p>Complete reference of all supported KaneAI commands — navigation, clicks, typing, waits, tab management, scrolling, assertions, conditional logic, and queries.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/kane-ai-automation-code-generation/">
-    <div className="support_inners">
-      <h3>Code Generation</h3>
-      <p>Generate automation scripts from KaneAI tests in multiple frameworks and languages including Selenium (Python), Appium (Python), and more.</p>
-    </div>
-  </a>
-
-  <a href="/support/docs/error-handling-kaneai/">
-    <div className="support_inners">
-      <h3>Error Handling</h3>
-      <p>Understand error messages in KaneAI, what they mean, and how to resolve common issues during test authoring and execution.</p>
-    </div>
-  </a>
-</div>
+<CardGroup cols={2}>
+  <Card title="Command Types" href="/support/docs/kane-ai-command-guide/">
+    Complete reference of all supported KaneAI commands — navigation, clicks, typing, waits, tab management, scrolling, assertions, conditional logic, and queries.
+  </Card>
+  <Card title="Code Generation" href="/support/docs/kane-ai-automation-code-generation/">
+    Generate automation scripts from KaneAI tests in multiple frameworks and languages including Selenium (Python), Appium (Python), and more.
+  </Card>
+  <Card title="Error Handling" href="/support/docs/error-handling-kaneai/">
+    Understand error messages in KaneAI, what they mean, and how to resolve common issues during test authoring and execution.
+  </Card>
+</CardGroup>
 
 ## Quick Start Guide
 

--- a/support/docs/nightwatch-with-selenium-running-nightwatch-automation-scripts-on-testmu-selenium-grid.mdx
+++ b/support/docs/nightwatch-with-selenium-running-nightwatch-automation-scripts-on-testmu-selenium-grid.mdx
@@ -13,7 +13,7 @@ import { BrandName } from "/snippets/BrandName.mdx";
 
 In this topic, you will learn how to configure and run your JavaScript automation testing scripts on [<BrandName /> Selenium cloud platform](https://www.lambdatest.com/selenium-automation) using **JavaScript** framework **Nightwatch**.
 
-<iframe width="800" height="450" src="https://www.youtube.com/embed/gYfRDCCFTZI" title="How to Run NightwatchJS Browser Automation Tests on <BrandName />" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="100%" height="450" src="https://www.youtube.com/embed/gYfRDCCFTZI" title="How to Run NightwatchJS Browser Automation Tests on <BrandName />" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Objective
 ---

--- a/support/docs/smart-ui-build-options.mdx
+++ b/support/docs/smart-ui-build-options.mdx
@@ -84,8 +84,6 @@ const capabilities = {
 </Tab>
 </Tabs>
 
----
-
 ## Enabling build as a baseline
 
 If you want to mark your build as a baseline from your test suite while executing tests then you have to enable the below mentioned capability configuration needs to be enabled.
@@ -148,7 +146,6 @@ const capabilities = {
 ```
 </Tab>
 </Tabs>
----
 
 ## Build Features
 
@@ -164,7 +161,6 @@ INFO
 
 We currently only support one baseline for one project in our current version. We recommend you to create a new project for multiple baseline builds
 </Info>
----
 
 ## Build Status Information
 

--- a/support/docs/tosca-integration-with-hyperexecute.mdx
+++ b/support/docs/tosca-integration-with-hyperexecute.mdx
@@ -14,30 +14,17 @@ Tricentis Tosca is a tool that optimizes and accelerates end-to-end testing for 
 
 HyperExecute seamlessly integrates with Tosca, providing a Just-in-Time Tosca Environment for both Tosca **Commander** and **DEX**. This ensures a smooth and efficient testing experience for users.
 
-<div className="support_main">
-  
-  <a href = "/support/docs/tosca-integration-with-hyperexecute-using-commander/">
-  <div className="support_inners">
-    <h3>Integration using Commander</h3>
-    <p>Use Tosca Commander to integrate with HyperExecute.</p>
-  </div>
-  </a>
-  
-  <a href = "/support/docs/tosca-integration-with-hyperexecute-using-dex/">
-  <div className="support_inners">
-    <h3>Integration using DEX</h3>
-    <p>Use Tosca DEX Server to integrate with HyperExecute.</p>
-  </div>
-  </a>
-
-  <a href = "/support/docs/tosca-integration-with-hyperexecute-for-sap/">
-  <div className="support_inners">
-    <h3>Integration for SAP</h3>
-    <p>Use Tosca for SAP to integrate with HyperExecute.</p>
-  </div>
-  </a>
-
-</div>
+<CardGroup cols={2}>
+  <Card title="Integration using Commander" href="/support/docs/tosca-integration-with-hyperexecute-using-commander/">
+    Use Tosca Commander to integrate with HyperExecute.
+  </Card>
+  <Card title="Integration using DEX" href="/support/docs/tosca-integration-with-hyperexecute-using-dex/">
+    Use Tosca DEX Server to integrate with HyperExecute.
+  </Card>
+  <Card title="Integration for SAP" href="/support/docs/tosca-integration-with-hyperexecute-for-sap/">
+    Use Tosca for SAP to integrate with HyperExecute.
+  </Card>
+</CardGroup>
 
 <Note>
 This is currently in the **Beta** version of the **Project** section in HyperExecute. To enable it for your organization, please contact our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24×7 chat support**</span> or our [Customer Support](mailto:support@testmuai.com) team.


### PR DESCRIPTION
## Summary
- Fix `<BrandName />` appearing literally in titles and Card components (replaced with plain text "TestMu AI")
- Fix responsive video iframes (changed fixed widths to `width="100%"`)
- Fix blank space issues caused by extra dividers
- Convert Docusaurus components to Mintlify equivalents:
  - `<div className="support_main">` and `DocCard` → `<CardGroup>` and `<Card>`
  - Tables with long content → `<AccordionGroup>` and `<Accordion>`
- Update page titles for clarity
- Fix icon paths in snippet files (changed `/support/assets/` to `/assets/`)

## Files Changed

### Snippet Files (Icon Path Fixes)
- `snippets/FrameworkGrid.mdx`
- `snippets/FrameworkGridHyperexecute.mdx`
- `snippets/HyperExecuteSupportedLanguageRepos.mdx`
- `snippets/SeleniumSupportedLanguage.mdx`

### Documentation Files
- `tosca-integration-with-hyperexecute.mdx` - Converted to CardGroup layout
- `accessibility-android-rules.mdx` - Converted table to Accordion layout
- `accessibility-ios-rules.mdx` - Converted table to Accordion layout
- `kaneai-kb-knowledge-base-index.mdx` - Converted to CardGroup/Card components
- `hyperexecute-mcp-server-release-notes-1-0-0.mdx` - Updated title
- `smart-ui-build-options.mdx` - Removed extra dividers
- `integration-with-hyperexecute.mdx` - Fixed BrandName in Card title
- Multiple video iframe files - Made responsive

## Test plan
- [ ] Verify pages render correctly on staging
- [ ] Check that icons load properly (may require asset deployment fix)
- [ ] Verify CardGroup/Card components display as expected
- [ ] Verify Accordion components expand/collapse properly
- [ ] Check video iframes are responsive on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)