### PR TITLE
Fix API docs server mapping and add MDX files for App Automation, Smart UI, Accessibility APIs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2639,11 +2639,83 @@
           },
           {
             "group": "App Automation API (Real Devices)",
-            "openapi": "mobile_automation.yaml"
+            "pages": [
+              {
+                "group": "App Management",
+                "pages": [
+                  "support/api-doc/app-automation/upload-framework",
+                  "support/api-doc/app-automation/upload-app-real-device",
+                  "support/api-doc/app-automation/fetch-all-uploaded-apps",
+                  "support/api-doc/app-automation/get-app-by-custom-id",
+                  "support/api-doc/app-automation/delete-uploaded-apps",
+                  "support/api-doc/app-automation/delete-single-app"
+                ]
+              },
+              {
+                "group": "Media Management",
+                "pages": [
+                  "support/api-doc/app-automation/fetch-media-list",
+                  "support/api-doc/app-automation/delete-media-asset",
+                  "support/api-doc/app-automation/upload-media-file"
+                ]
+              },
+              {
+                "group": "Device & Concurrency",
+                "pages": [
+                  "support/api-doc/app-automation/fetch-available-devices",
+                  "support/api-doc/app-automation/get-concurrency-details"
+                ]
+              },
+              {
+                "group": "Framework Execution",
+                "pages": [
+                  "support/api-doc/app-automation/fetch-patched-apk-url",
+                  "support/api-doc/app-automation/execute-espresso-test",
+                  "support/api-doc/app-automation/execute-xcui-test"
+                ]
+              },
+              {
+                "group": "Build",
+                "pages": [
+                  "support/api-doc/app-automation/fetch-all-builds",
+                  "support/api-doc/app-automation/fetch-build-details",
+                  "support/api-doc/app-automation/delete-build",
+                  "support/api-doc/app-automation/update-build-name",
+                  "support/api-doc/app-automation/stop-running-build"
+                ]
+              },
+              {
+                "group": "Session",
+                "pages": [
+                  "support/api-doc/app-automation/fetch-all-sessions",
+                  "support/api-doc/app-automation/get-session-info",
+                  "support/api-doc/app-automation/delete-session",
+                  "support/api-doc/app-automation/update-session",
+                  "support/api-doc/app-automation/fetch-session-video",
+                  "support/api-doc/app-automation/fetch-session-app-url",
+                  "support/api-doc/app-automation/stop-running-session"
+                ]
+              },
+              {
+                "group": "Session Logs",
+                "pages": [
+                  "support/api-doc/app-automation/get-command-logs",
+                  "support/api-doc/app-automation/get-appium-logs",
+                  "support/api-doc/app-automation/get-network-logs",
+                  "support/api-doc/app-automation/get-device-logs",
+                  "support/api-doc/app-automation/get-device-logs-zip"
+                ]
+              }
+            ]
           },
           {
             "group": "Smart UI",
-            "openapi": "Smart-UI.yaml"
+            "pages": [
+              "support/api-doc/smart-ui/upload-screenshot",
+              "support/api-doc/smart-ui/get-build-status",
+              "support/api-doc/smart-ui/get-screenshot-build-status",
+              "support/api-doc/smart-ui/get-build-screenshots"
+            ]
           },
           
           {
@@ -2925,7 +2997,9 @@
           },
           {
             "group": "Accessibility Testing",
-            "openapi": "accessibility-testing.yaml"
+            "pages": [
+              "support/api-doc/accessibility/get-test-issues"
+            ]
           },
           {
             "group": "Performance Testing",

--- a/mobile_automation.yaml
+++ b/mobile_automation.yaml
@@ -30,9 +30,14 @@ servers:
 paths:
   /app/uploadFramework:
     post:
+      servers:
+        - url: 'https://manual-api.lambdatest.com'
+          description: 'Manual API (US)'
+        - url: 'https://eu-manual-api.lambdatest.com'
+          description: 'Manual API (EU)'
       tags:
         - Application (Espresso/XCUI)
-      summary: Upload a framework file for testing(Espresso/XCUI) (Server 1)
+      summary: Upload a framework file for testing(Espresso/XCUI)
       description: Upload a framework file for testing purposes. Supports Espresso for Android and XCUITest for iOS.
       requestBody:
         required: true
@@ -85,9 +90,14 @@ paths:
 
   /app/upload/realDevice:
     post:
+      servers:
+        - url: 'https://manual-api.lambdatest.com'
+          description: 'Manual API (US)'
+        - url: 'https://eu-manual-api.lambdatest.com'
+          description: 'Manual API (EU)'
       tags:
         - Application (Appium)
-      summary: Upload Application to a Real Device (Server 1)
+      summary: Upload Application to a Real Device
       description: Upload an application (.ipa,.apk,.aab) for testing on a real device.
       operationId: uploadAppRealDevice
       requestBody:
@@ -153,9 +163,14 @@ paths:
 
   /app/data:
     get:
+      servers:
+        - url: 'https://manual-api.lambdatest.com'
+          description: 'Manual API (US)'
+        - url: 'https://eu-manual-api.lambdatest.com'
+          description: 'Manual API (EU)'
       tags:
         - Application (Appium)
-      summary: Fetch all uploaded applications (Server 1)
+      summary: Fetch all uploaded applications
       description: Fetch all applications based on the provided type (android/iOS) and access level (user/organization).
       operationId: fetchApplications
       parameters:
@@ -235,9 +250,14 @@ paths:
 
   /app/custom_id/{customId}:
     get:
+      servers:
+        - url: 'https://manual-api.lambdatest.com'
+          description: 'Manual API (US)'
+        - url: 'https://eu-manual-api.lambdatest.com'
+          description: 'Manual API (EU)'
       tags:
         - Application (Appium)
-      summary: Get data by Custom ID (Server 1)
+      summary: Get data by Custom ID
       description: Retrieve data by custom ID from LambdaTest.
       operationId: getDataByCustomId
       parameters:
@@ -296,9 +316,14 @@ paths:
 
   /app/delete:
     delete:
+      servers:
+        - url: 'https://manual-api.lambdatest.com'
+          description: 'Manual API (US)'
+        - url: 'https://eu-manual-api.lambdatest.com'
+          description: 'Manual API (EU)'
       tags:
         - Application (Appium)
-      summary: Delete your uploaded applications (Server 1)
+      summary: Delete your uploaded applications
       description: Delete the uploaded applications based on the provided appIds.
       operationId: deleteApplications
       requestBody:
@@ -337,9 +362,14 @@ paths:
 
   /app/{appId}:
     delete:
+      servers:
+        - url: 'https://manual-api.lambdatest.com'
+          description: 'Manual API (US)'
+        - url: 'https://eu-manual-api.lambdatest.com'
+          description: 'Manual API (EU)'
       tags:
         - Application (Appium)
-      summary: Delete a single uploaded application (Server 1)
+      summary: Delete a single uploaded application
       description: Deletes an uploaded application using its unique `appId`.
       operationId: deleteApplication
       parameters:
@@ -376,9 +406,12 @@ paths:
 
   /mfs/v1.0/media/list:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com'
+          description: 'General API (US)'
       tags:
         - Media
-      summary: Fetch media list for an organization (server 4)
+      summary: Fetch media list for an organization
       description: Retrieve a list of uploaded media files (images, videos, etc.) associated with an organization.
       parameters:
         - name: custom_id
@@ -435,9 +468,12 @@ paths:
 
   /mfs/v1.0/media/{media_id}:
     delete:
+      servers:
+        - url: 'https://api.lambdatest.com'
+          description: 'General API (US)'
       tags:
         - Media
-      summary: Delete a media asset (server 4)
+      summary: Delete a media asset
       description: Deletes the media files associated with the given `media_id`.
       operationId: deleteMediaByMediaId
       parameters:
@@ -470,9 +506,12 @@ paths:
 
   /mfs/v1.0/media/upload/:
     post:
+      servers:
+        - url: 'https://api.lambdatest.com'
+          description: 'General API (US)'
       tags:
         - Media
-      summary: Upload Media File (Image/Video/Document/Certificate) (Server 4)
+      summary: Upload Media File (Image/Video/Document/Certificate)
       description: Upload a media file (.jpg, .png, .mp4, .pdf, etc.) for use.
       operationId: uploadMediaFile
       requestBody:
@@ -536,9 +575,14 @@ paths:
 
   /list:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
         - Devices List
-      summary: Fetch available devices for running tests (Server 2)
+      summary: Fetch available devices for running tests
       description: Retrieves the list of devices available for running tests. You can filter the devices based on the region.
       operationId: getDevices
       parameters:
@@ -585,9 +629,14 @@ paths:
 
   /org/concurrency:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
         - Concurrency Details
-      summary: Get your account's concurrency details (Server 2)
+      summary: Get your account's concurrency details
       description: Retrieve the concurrency details for your account.
       operationId: getConcurrencyDetails
       responses:
@@ -608,9 +657,14 @@ paths:
 
   /mobile-automation/api/v1/fetchpatchedapkurl:
     post:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com'
+          description: 'Mobile API (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com'
+          description: 'Mobile API (EU)'
       tags:
         - Application Processing (Appium)
-      summary: Fetch patched APK URL (Server 3)
+      summary: Fetch patched APK URL
       description: |
         This endpoint facilitates the retrieval of a patched APK URL and provides information on whether the patching process is complete or not. It is essential for Appium automation and supports testing workflows.
       operationId: fetchpatchedapkurl
@@ -656,9 +710,14 @@ paths:
 
   /framework/v1/espresso/build:
     post:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com'
+          description: 'Mobile API (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com'
+          description: 'Mobile API (EU)'
       tags:
         - Execute Test (Espresso/XCUI)
-      summary: Execute espresso test on the LambdaTest platform (Server 3)
+      summary: Execute espresso test on the LambdaTest platform
       description: |
         This endpoint enables you to execute automated tests using the LambdaTest platform.
       operationId: executeWindowsTest
@@ -765,9 +824,14 @@ paths:
 
   /framework/v1/xcui/build:
     post:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com'
+          description: 'Mobile API (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com'
+          description: 'Mobile API (EU)'
       tags:
         - Execute Test (Espresso/XCUI)
-      summary: Execute XCUI test on the LambdaTest platform (Server 3)
+      summary: Execute XCUI test on the LambdaTest platform
       description: Execute the automation tests on Lambdatest platform using the provided parameters.
       operationId: executeTest
       requestBody:
@@ -870,9 +934,14 @@ paths:
 
   /metadata/{session_id}/details:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
         - Session
-      summary: Fetch the app URL for a particular session (Server 2)
+      summary: Fetch the app URL for a particular session
       description: Retrieve the app URL being used for a specific session.
       operationId: getAppUrlForSession
       parameters:
@@ -902,9 +971,14 @@ paths:
 
   /builds:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Build
-      summary: Fetch all builds of an account. (Server 2)
+      summary: Fetch all builds of an account.
       description: Fetch all builds of an account. You can limit the number of records and apply filter on status,build date range and sort by users,start date and end date in asc and desc order. You can apply sort on multiple columns.
       operationId: builds
       parameters:
@@ -975,9 +1049,14 @@ paths:
       - basicAuth: []
   /builds/{build_id}:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Build
-      summary: Fetch specified build details (Server 2)
+      summary: Fetch specified build details
       description: To fetch build details of the buildid specified by the user.
       operationId: singlebuild
       parameters:
@@ -1007,9 +1086,14 @@ paths:
       security:
       - basicAuth: []
     delete:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Build
-      summary: Delete Build (Server 2)
+      summary: Delete Build
       description: To delete specified Build from dashboard.
       operationId: status_ind
       parameters:
@@ -1039,9 +1123,14 @@ paths:
       security:
       - basicAuth: []
     patch:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Build
-      summary: Update Build Name (Server 2)
+      summary: Update Build Name
       description: To change build name.
       operationId: build_id
       parameters:
@@ -1080,9 +1169,14 @@ paths:
 
   /builds/{build_id}/stop:
     put:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
         - Build
-      summary: Stop a running build (server 2)
+      summary: Stop a running build
       description: Stops the execution of a running build using its `build_id`.
       parameters:
         - name: build_id
@@ -1116,9 +1210,14 @@ paths:
 
   /sessions:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: Fetch list of all sessions (Server 2)
+      summary: Fetch list of all sessions
       description: To fetch list of sessions. You can also limit the number of records, and paginate through your data using Parameters.
       operationId: sessions
       parameters:
@@ -1209,9 +1308,14 @@ paths:
       - basicAuth: []
   /sessions/{session_id}:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: session specific information (Server 2)
+      summary: session specific information
       description: To fetch specified session details such as name, status,os,browser,version and all generated logs endpoint.
       parameters:
       - name: session_id
@@ -1244,9 +1348,14 @@ paths:
       security:
       - basicAuth: []
     delete:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: Delete test session (Server 2)
+      summary: Delete test session
       description: Delete a session.
       parameters:
       - name: session_id
@@ -1285,9 +1394,14 @@ paths:
       security:
       - basicAuth: []
     patch:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: Update session name and status. (Server 2)
+      summary: Update session name and status.
       description: To update the test session name and status {"passed","failed"}.
       parameters:
       - name: session_id
@@ -1378,9 +1492,14 @@ paths:
   #     - basicAuth: []
   /sessions/{session_id}/video:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: Fetch recorded video of a test session id. (Server 2)
+      summary: Fetch recorded video of a test session id.
       description: To fetch video of a recorded test session.
       parameters:
       - name: session_id
@@ -1415,9 +1534,14 @@ paths:
 
   /sessions/{session_id}/log/command:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: command logs of a test session (Server 2)
+      summary: command logs of a test session
       description: To fetch the all executed commands of a test session in plain json text.
       operationId: session
       parameters:
@@ -1469,9 +1593,14 @@ paths:
 
   /sessions/{session_id}/log/appium:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: appium log of a test session (Server 2)
+      summary: appium log of a test session
       description: To fetch appium log that contains grid requests and reponses of a test session in plain json text.
       operationId: session1
       parameters:
@@ -1509,9 +1638,14 @@ paths:
 
   /sessions/{session_id}/log/network:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: Network log of a test session (Server 2)
+      summary: Network log of a test session
       description: To fetch Network log that contains all the requested urls of a test session in plain json text.
       operationId: session2
       parameters:
@@ -1546,9 +1680,14 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/log/devicelog:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: devicelog log of a test session (Server 2)
+      summary: devicelog log of a test session
       description: To fetch devicelog log that contains devicelog errors thrown by application during a test session in plain json text.
       operationId: session3
       parameters:
@@ -1589,9 +1728,14 @@ paths:
 
   /sessions/{session_id}/log/devicelogzip:
     get:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
       - Session
-      summary: devicelog custom logs of a test session in .zip file (Server 2)
+      summary: devicelog custom logs of a test session in .zip file
       description: To fetch devicelog in zipped format that contains all device logs including custom logs generated during a test session.
       operationId: getDeviceLogZip
       parameters:
@@ -1628,9 +1772,14 @@ paths:
 
   /sessions/{test_id}/stop:
     put:
+      servers:
+        - url: 'https://mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (US)'
+        - url: 'https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1'
+          description: 'Mobile Automation v1 (EU)'
       tags:
         - Session
-      summary: Stop a running test session (server 2)
+      summary: Stop a running test session
       description: Stops a running test session using its `test_id`
       parameters:
         - name: test_id

--- a/support-openapi.yaml
+++ b/support-openapi.yaml
@@ -13,6 +13,11 @@ servers:
 paths:
   /builds:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Build
       summary: Fetch all builds of an account.
@@ -105,6 +110,11 @@ paths:
       - basicAuth: []
   /builds/{build_id}:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Build
       summary: Fetch specified build details
@@ -145,6 +155,11 @@ paths:
       security:
       - basicAuth: []
     delete:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Build
       summary: Delete Build
@@ -177,6 +192,11 @@ paths:
       security:
       - basicAuth: []
     patch:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Build
       summary: Update Build Name or Status
@@ -217,6 +237,11 @@ paths:
       - basicAuth: []
   /build/stop:
     put:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Build
       summary: Stop tests by BuildID
@@ -265,6 +290,11 @@ paths:
       - basicAuth: []
   /sessions:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: Fetch list of all sessions
@@ -374,6 +404,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: session specific information
@@ -417,6 +452,11 @@ paths:
       security:
       - basicAuth: []
     delete:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: Delete test session
@@ -458,6 +498,11 @@ paths:
       security:
       - basicAuth: []
     patch:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: Update test session details.
@@ -513,6 +558,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/stop:
     put:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: Stop session by sessionID
@@ -555,6 +605,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/screenshots:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: To fetch all step by step screenshots
@@ -591,6 +646,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/video:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: Fetch recorded video of a test session id.
@@ -633,6 +693,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/log/command:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: command logs of a test session
@@ -670,6 +735,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/log/selenium:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: selenium log of a test session
@@ -707,6 +777,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/log/network:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: Network log of a test session
@@ -744,6 +819,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/log/console:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: console log of a test session
@@ -781,6 +861,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/log/network.har:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Session
       summary: Network har log of a test session
@@ -856,6 +941,11 @@ paths:
               -   basicAuth: [ ]
   /sessions/{session_id}/terminal-logs:
     post:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - Session
       summary: Upload terminal logs to our lambda storage
@@ -903,6 +993,11 @@ paths:
 
   /sessions/{session_id}/exceptions:
     post:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - Session
       summary: Upload assertion logs to our lambda storage
@@ -948,6 +1043,11 @@ paths:
         - basicAuth: []
   /sessions/{session_id}/v2/log/command:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v2'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v2'
+          description: 'EU'
       tags:
       - Session Logs (V2)
       summary: command logs of a test session
@@ -985,6 +1085,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/v2/log/selenium:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v2'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v2'
+          description: 'EU'
       tags:
       - Session Logs (V2)
       summary: selenium/appium log of a test session
@@ -1022,6 +1127,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/v2/log/network:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v2'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v2'
+          description: 'EU'
       tags:
       - Session Logs (V2)
       summary: Network log of a test session
@@ -1059,6 +1169,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/v2/log/console:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v2'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v2'
+          description: 'EU'
       tags:
       - Session Logs (V2)
       summary: console/browser log of a test session
@@ -1096,6 +1211,11 @@ paths:
       - basicAuth: []
   /sessions/{session_id}/v2/log/network.har:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v2'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v2'
+          description: 'EU'
       tags:
       - Session Logs (V2)
       summary: Network har log of a test session
@@ -1170,6 +1290,11 @@ paths:
               -   basicAuth: [ ]
   /tests/{test_id}/exceptions:
     post:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - Test
       summary: Upload assertion logs to our lambda storage
@@ -1216,6 +1341,11 @@ paths:
 
   /test/{test_id}/video:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Test
       summary: Fetch recorded video of a test id.
@@ -1259,6 +1389,11 @@ paths:
 
   /tunnels:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - tunnel
       summary: Fetch running tunnels of your account.
@@ -1286,6 +1421,11 @@ paths:
       - basicAuth: []
   /tunnels/{tunnel_id}:
     delete:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - tunnel
       summary: Stop a running tunnel
@@ -1328,6 +1468,11 @@ paths:
       - basicAuth: []
   /platforms:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - platforms
       summary: Fetch platforms
@@ -1347,6 +1492,11 @@ paths:
 #                $ref: '#/components/schemas/PageNotFound'
   /files:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - prerun
       summary: Fetch all pre run files uploaded by the user
@@ -1368,6 +1518,11 @@ paths:
       security:
         - basicAuth: []
     post:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - prerun
       summary: Upload pre run executable file to our lambda storage
@@ -1517,6 +1672,11 @@ paths:
 
   /user-files:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - user-files
       summary: Fetch all user files uploaded by the user
@@ -1538,6 +1698,11 @@ paths:
       security:
         - basicAuth: []
     post:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - user-files
       summary: Upload files to our lambda storage
@@ -1646,6 +1811,11 @@ paths:
 
   /lighthouse/report/{session_id}:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Lighthouse
       summary: To fetch the Lighthouse performance report data.
@@ -1735,6 +1905,11 @@ paths:
 
   /files/extensions:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - extensions
       summary: Fetch all extensions uploaded by the user
@@ -1756,6 +1931,11 @@ paths:
       security:
         - basicAuth: [ ]
     post:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - extensions
       summary: Upload new extensions in zip format to our lambda storage
@@ -1792,6 +1972,11 @@ paths:
 
   /files/extensions/delete:
     delete:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
         - extensions
       summary: Delete extension from our lambda storage
@@ -1998,6 +2183,11 @@ paths:
 
   /autoheal/test/{test_id}:
     get:
+      servers:
+        - url: 'https://api.lambdatest.com/automation/api/v1'
+          description: 'US'
+        - url: 'https://eu-api.lambdatest.com/automation/api/v1'
+          description: 'EU'
       tags:
       - Autoheal Command Logs
       summary: Fetch autohealed commands data for a test

--- a/support/api-doc/accessibility/get-test-issues.mdx
+++ b/support/api-doc/accessibility/get-test-issues.mdx
@@ -1,0 +1,3 @@
+---
+openapi: accessibility-testing.yaml get /api/v1/test-issue/{testId}
+---

--- a/support/api-doc/app-automation/delete-build.mdx
+++ b/support/api-doc/app-automation/delete-build.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml delete /builds/{build_id}
+---

--- a/support/api-doc/app-automation/delete-media-asset.mdx
+++ b/support/api-doc/app-automation/delete-media-asset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml delete /mfs/v1.0/media/{media_id}
+---

--- a/support/api-doc/app-automation/delete-session.mdx
+++ b/support/api-doc/app-automation/delete-session.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml delete /sessions/{session_id}
+---

--- a/support/api-doc/app-automation/delete-single-app.mdx
+++ b/support/api-doc/app-automation/delete-single-app.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml delete /app/{appId}
+---

--- a/support/api-doc/app-automation/delete-uploaded-apps.mdx
+++ b/support/api-doc/app-automation/delete-uploaded-apps.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml delete /app/delete
+---

--- a/support/api-doc/app-automation/execute-espresso-test.mdx
+++ b/support/api-doc/app-automation/execute-espresso-test.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml post /framework/v1/espresso/build
+---

--- a/support/api-doc/app-automation/execute-xcui-test.mdx
+++ b/support/api-doc/app-automation/execute-xcui-test.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml post /framework/v1/xcui/build
+---

--- a/support/api-doc/app-automation/fetch-all-builds.mdx
+++ b/support/api-doc/app-automation/fetch-all-builds.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /builds
+---

--- a/support/api-doc/app-automation/fetch-all-sessions.mdx
+++ b/support/api-doc/app-automation/fetch-all-sessions.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /sessions
+---

--- a/support/api-doc/app-automation/fetch-all-uploaded-apps.mdx
+++ b/support/api-doc/app-automation/fetch-all-uploaded-apps.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /app/data
+---

--- a/support/api-doc/app-automation/fetch-available-devices.mdx
+++ b/support/api-doc/app-automation/fetch-available-devices.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /list
+---

--- a/support/api-doc/app-automation/fetch-build-details.mdx
+++ b/support/api-doc/app-automation/fetch-build-details.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /builds/{build_id}
+---

--- a/support/api-doc/app-automation/fetch-media-list.mdx
+++ b/support/api-doc/app-automation/fetch-media-list.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /mfs/v1.0/media/list
+---

--- a/support/api-doc/app-automation/fetch-patched-apk-url.mdx
+++ b/support/api-doc/app-automation/fetch-patched-apk-url.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml post /mobile-automation/api/v1/fetchpatchedapkurl
+---

--- a/support/api-doc/app-automation/fetch-session-app-url.mdx
+++ b/support/api-doc/app-automation/fetch-session-app-url.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /metadata/{session_id}/details
+---

--- a/support/api-doc/app-automation/fetch-session-video.mdx
+++ b/support/api-doc/app-automation/fetch-session-video.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /sessions/{session_id}/video
+---

--- a/support/api-doc/app-automation/get-app-by-custom-id.mdx
+++ b/support/api-doc/app-automation/get-app-by-custom-id.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /app/custom_id/{customId}
+---

--- a/support/api-doc/app-automation/get-appium-logs.mdx
+++ b/support/api-doc/app-automation/get-appium-logs.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /sessions/{session_id}/log/appium
+---

--- a/support/api-doc/app-automation/get-command-logs.mdx
+++ b/support/api-doc/app-automation/get-command-logs.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /sessions/{session_id}/log/command
+---

--- a/support/api-doc/app-automation/get-concurrency-details.mdx
+++ b/support/api-doc/app-automation/get-concurrency-details.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /org/concurrency
+---

--- a/support/api-doc/app-automation/get-device-logs-zip.mdx
+++ b/support/api-doc/app-automation/get-device-logs-zip.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /sessions/{session_id}/log/devicelogzip
+---

--- a/support/api-doc/app-automation/get-device-logs.mdx
+++ b/support/api-doc/app-automation/get-device-logs.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /sessions/{session_id}/log/devicelog
+---

--- a/support/api-doc/app-automation/get-network-logs.mdx
+++ b/support/api-doc/app-automation/get-network-logs.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /sessions/{session_id}/log/network
+---

--- a/support/api-doc/app-automation/get-session-info.mdx
+++ b/support/api-doc/app-automation/get-session-info.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml get /sessions/{session_id}
+---

--- a/support/api-doc/app-automation/stop-running-build.mdx
+++ b/support/api-doc/app-automation/stop-running-build.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml put /builds/{build_id}/stop
+---

--- a/support/api-doc/app-automation/stop-running-session.mdx
+++ b/support/api-doc/app-automation/stop-running-session.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml put /sessions/{test_id}/stop
+---

--- a/support/api-doc/app-automation/update-build-name.mdx
+++ b/support/api-doc/app-automation/update-build-name.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml patch /builds/{build_id}
+---

--- a/support/api-doc/app-automation/update-session.mdx
+++ b/support/api-doc/app-automation/update-session.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml patch /sessions/{session_id}
+---

--- a/support/api-doc/app-automation/upload-app-real-device.mdx
+++ b/support/api-doc/app-automation/upload-app-real-device.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml post /app/upload/realDevice
+---

--- a/support/api-doc/app-automation/upload-framework.mdx
+++ b/support/api-doc/app-automation/upload-framework.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml post /app/uploadFramework
+---

--- a/support/api-doc/app-automation/upload-media-file.mdx
+++ b/support/api-doc/app-automation/upload-media-file.mdx
@@ -1,0 +1,3 @@
+---
+openapi: mobile_automation.yaml post /mfs/v1.0/media/upload/
+---

--- a/support/api-doc/build/delete-build.mdx
+++ b/support/api-doc/build/delete-build.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: delete /builds/{build_id}
+openapi: support-openapi.yaml delete /builds/{build_id}
 ---

--- a/support/api-doc/build/fetch-all-builds-of-an-account.mdx
+++ b/support/api-doc/build/fetch-all-builds-of-an-account.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /builds
+openapi: support-openapi.yaml get /builds
 ---

--- a/support/api-doc/build/fetch-specified-build-details.mdx
+++ b/support/api-doc/build/fetch-specified-build-details.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /builds/{build_id}
+openapi: support-openapi.yaml get /builds/{build_id}
 ---

--- a/support/api-doc/build/stop-tests-by-buildid.mdx
+++ b/support/api-doc/build/stop-tests-by-buildid.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: put /build/stop
+openapi: support-openapi.yaml put /build/stop
 ---

--- a/support/api-doc/build/update-build-name-or-status.mdx
+++ b/support/api-doc/build/update-build-name-or-status.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: patch /builds/{build_id}
+openapi: support-openapi.yaml patch /builds/{build_id}
 ---

--- a/support/api-doc/session/command-logs-of-a-test-session.mdx
+++ b/support/api-doc/session/command-logs-of-a-test-session.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions/{session_id}/log/command
+openapi: support-openapi.yaml get /sessions/{session_id}/log/command
 ---

--- a/support/api-doc/session/console-log-of-a-test-session.mdx
+++ b/support/api-doc/session/console-log-of-a-test-session.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions/{session_id}/log/console
+openapi: support-openapi.yaml get /sessions/{session_id}/log/console
 ---

--- a/support/api-doc/session/delete-test-session.mdx
+++ b/support/api-doc/session/delete-test-session.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: delete /sessions/{session_id}
+openapi: support-openapi.yaml delete /sessions/{session_id}
 ---

--- a/support/api-doc/session/fetch-list-of-all-sessions.mdx
+++ b/support/api-doc/session/fetch-list-of-all-sessions.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions
+openapi: support-openapi.yaml get /sessions
 ---

--- a/support/api-doc/session/fetch-recorded-video-of-a-test-session-id.mdx
+++ b/support/api-doc/session/fetch-recorded-video-of-a-test-session-id.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions/{session_id}/video
+openapi: support-openapi.yaml get /sessions/{session_id}/video
 ---

--- a/support/api-doc/session/full-har-log-of-a-test-session.mdx
+++ b/support/api-doc/session/full-har-log-of-a-test-session.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions/{session_id}/log/full-har
+openapi: support-openapi.yaml get /sessions/{session_id}/log/full-har
 ---

--- a/support/api-doc/session/network-har-log-of-a-test-session.mdx
+++ b/support/api-doc/session/network-har-log-of-a-test-session.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions/{session_id}/log/network.har
+openapi: support-openapi.yaml get /sessions/{session_id}/log/network.har
 ---

--- a/support/api-doc/session/network-log-of-a-test-session.mdx
+++ b/support/api-doc/session/network-log-of-a-test-session.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions/{session_id}/log/network
+openapi: support-openapi.yaml get /sessions/{session_id}/log/network
 ---

--- a/support/api-doc/session/selenium-log-of-a-test-session.mdx
+++ b/support/api-doc/session/selenium-log-of-a-test-session.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions/{session_id}/log/selenium
+openapi: support-openapi.yaml get /sessions/{session_id}/log/selenium
 ---

--- a/support/api-doc/session/session-specific-information.mdx
+++ b/support/api-doc/session/session-specific-information.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions/{session_id}
+openapi: support-openapi.yaml get /sessions/{session_id}
 ---

--- a/support/api-doc/session/stop-session-by-sessionid.mdx
+++ b/support/api-doc/session/stop-session-by-sessionid.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: put /sessions/{session_id}/stop
+openapi: support-openapi.yaml put /sessions/{session_id}/stop
 ---

--- a/support/api-doc/session/to-fetch-all-step-by-step-screenshots.mdx
+++ b/support/api-doc/session/to-fetch-all-step-by-step-screenshots.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: get /sessions/{session_id}/screenshots
+openapi: support-openapi.yaml get /sessions/{session_id}/screenshots
 ---

--- a/support/api-doc/session/update-test-session-details.mdx
+++ b/support/api-doc/session/update-test-session-details.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: patch /sessions/{session_id}
+openapi: support-openapi.yaml patch /sessions/{session_id}
 ---

--- a/support/api-doc/session/upload-assertion-logs-to-our-lambda-storage.mdx
+++ b/support/api-doc/session/upload-assertion-logs-to-our-lambda-storage.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: post /sessions/{session_id}/exceptions
+openapi: support-openapi.yaml post /sessions/{session_id}/exceptions
 ---

--- a/support/api-doc/session/upload-terminal-logs-to-our-lambda-storage.mdx
+++ b/support/api-doc/session/upload-terminal-logs-to-our-lambda-storage.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: post /sessions/{session_id}/terminal-logs
+openapi: support-openapi.yaml post /sessions/{session_id}/terminal-logs
 ---

--- a/support/api-doc/smart-ui/get-build-screenshots.mdx
+++ b/support/api-doc/smart-ui/get-build-screenshots.mdx
@@ -1,0 +1,3 @@
+---
+openapi: Smart-UI.yaml get /build/screenshots
+---

--- a/support/api-doc/smart-ui/get-build-status.mdx
+++ b/support/api-doc/smart-ui/get-build-status.mdx
@@ -1,0 +1,3 @@
+---
+openapi: Smart-UI.yaml get /build/status
+---

--- a/support/api-doc/smart-ui/get-screenshot-build-status.mdx
+++ b/support/api-doc/smart-ui/get-screenshot-build-status.mdx
@@ -1,0 +1,3 @@
+---
+openapi: Smart-UI.yaml get /screenshot/build/status
+---

--- a/support/api-doc/smart-ui/upload-screenshot.mdx
+++ b/support/api-doc/smart-ui/upload-screenshot.mdx
@@ -1,0 +1,3 @@
+---
+openapi: Smart-UI.yaml post /v2/upload
+---


### PR DESCRIPTION
## Summary

- **Fix API server mapping**: Added path-level server overrides so each API endpoint shows only its supported servers in the dropdown
  - Mobile Automation API: Different servers for app uploads, builds/sessions, framework execution, and media uploads
  - Selenium API: V1 servers for standard endpoints, V2 servers only for `/v2/log/*` endpoints
  - Removed "(Server X)" from API summary titles

- **Add MDX files for three APIs**: Created page-based structure for better control
  - App Automation API (Real Devices): 31 MDX files organized into 7 groups
  - Smart UI: 4 MDX files
  - Accessibility Testing: 1 MDX file

- **Update docs.json**: Changed from direct `openapi:` references to page-based structure

## Test plan

- [ ] Verify Selenium API endpoints show only V1 servers (US/EU) in dropdown
- [ ] Verify Selenium `/v2/log/*` endpoints show only V2 servers in dropdown
- [ ] Verify Mobile Automation API endpoints show correct servers per endpoint
- [ ] Verify App Automation, Smart UI, and Accessibility API pages render correctly
- [ ] Test navigation structure in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)