### PR TITLE
Add lambda-applepay-details hook to Apple Pay docs

### DIFF
--- a/docs/alm-octane-integration.md
+++ b/docs/alm-octane-integration.md
@@ -1,0 +1,167 @@
+---
+id: alm-octane-integration
+title: ALM Octane Integration with TestMu AI
+hide_title: true
+sidebar_label: ALM Octane
+description: Learn how to integrate ALM Octane with TestMu AI for seamless test management and reporting while running your automated tests on the cloud.
+keywords:
+  - TestMu AI integration
+  - ALM Octane integration
+  - Micro Focus ALM Octane
+  - test management integration
+  - ALM Octane test reporting
+url: https://www.testmuai.com/support/docs/alm-octane-integration/
+site_name: TestMu AI
+slug: alm-octane-integration/
+canonical: https://www.testmuai.com/support/docs/alm-octane-integration/
+---
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "TestMu AI",
+          "item": BRAND_URL
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": `${BRAND_URL}/support/docs/`
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "ALM Octane Integration",
+          "item": `${BRAND_URL}/support/docs/alm-octane-integration/`
+        }]
+      })
+    }}
+></script>
+
+# ALM Octane Integration with <BrandName />
+
+***
+
+[ALM Octane](https://www.microfocus.com/en-us/products/alm-octane/overview) is an enterprise-grade Application Lifecycle Management (ALM) platform from Micro Focus. It provides comprehensive test management capabilities including test planning, test case management, defect tracking, and detailed analytics for your software development lifecycle.
+
+<BrandName /> supports seamless integration with ALM Octane through your test automation scripts. If you already have ALM Octane configured in your test framework, your tests will work seamlessly when executed on <BrandName />'s cloud infrastructure.
+
+## How ALM Octane Integration Works
+
+ALM Octane integration is implemented directly within your test automation scripts using ALM Octane's SDK or REST API. When you run your automated tests on <BrandName />'s Selenium Grid or HyperExecute, the test results are automatically reported to your ALM Octane instance based on your script configuration.
+
+This script-based approach offers several advantages:
+
+- **Flexibility**: Configure exactly what data gets sent to ALM Octane
+- **Customization**: Map test results to specific ALM Octane entities (test runs, test suites, etc.)
+- **Seamless Execution**: No additional configuration required on <BrandName /> platform
+
+## Prerequisites
+
+- An active [<BrandName /> account](https://accounts.lambdatest.com/register)
+- An ALM Octane instance with API access
+- ALM Octane credentials (Client ID and Client Secret)
+- Your test automation framework configured with ALM Octane SDK/API
+
+## Configuring ALM Octane in Your Test Scripts
+
+### Step 1: Set Up ALM Octane API Credentials
+
+In your ALM Octane instance, generate API credentials:
+
+1. Navigate to **Settings** > **Spaces** > **API Access**
+2. Create a new API client with appropriate permissions
+3. Note down the **Client ID** and **Client Secret**
+
+### Step 2: Install ALM Octane SDK
+
+For Java-based projects using Maven, add the ALM Octane SDK dependency:
+
+```xml
+<dependency>
+    <groupId>com.microfocus.adm.almoctane.sdk</groupId>
+    <artifactId>sdk-src</artifactId>
+    <version>16.1.100</version>
+</dependency>
+```
+
+For other languages, refer to the [ALM Octane API documentation](https://admhelp.microfocus.com/octane/en/latest/Online/Content/API/API_Authentication.htm).
+
+### Step 3: Configure Test Result Reporting
+
+Here's an example of how to configure your test framework to report results to ALM Octane:
+
+**Java (TestNG) Example:**
+
+```java
+import com.hp.octane.integrations.OctaneSDK;
+
+public class ALMOctaneReporter {
+
+    private static final String OCTANE_URL = "https://your-octane-instance.com";
+    private static final String SHARED_SPACE_ID = "your-shared-space-id";
+    private static final String WORKSPACE_ID = "your-workspace-id";
+    private static final String CLIENT_ID = "your-client-id";
+    private static final String CLIENT_SECRET = "your-client-secret";
+
+    public void reportTestResult(String testName, String status) {
+        // Initialize Octane SDK and report results
+        // Refer to ALM Octane SDK documentation for detailed implementation
+    }
+}
+```
+
+### Step 4: Run Tests on <BrandName />
+
+Once your test scripts are configured with ALM Octane reporting, run them on <BrandName />:
+
+**Using Selenium Grid:**
+
+```java
+DesiredCapabilities capabilities = new DesiredCapabilities();
+capabilities.setCapability("browserName", "Chrome");
+capabilities.setCapability("version", "latest");
+capabilities.setCapability("platform", "Windows 10");
+capabilities.setCapability("build", "ALM Octane Integration Build");
+capabilities.setCapability("name", "ALM Octane Test");
+
+WebDriver driver = new RemoteWebDriver(
+    new URL("https://" + username + ":" + accessKey + "@hub.lambdatest.com/wd/hub"),
+    capabilities
+);
+
+// Your test code here
+// ALM Octane reporting happens automatically based on your script configuration
+```
+
+**Using HyperExecute:**
+
+Create your `hyperexecute.yaml` configuration and run tests as usual. The ALM Octane reporting configured in your scripts will work seamlessly.
+
+## Best Practices
+
+1. **Environment Variables**: Store ALM Octane credentials as environment variables rather than hardcoding them in scripts
+2. **Error Handling**: Implement proper error handling for ALM Octane API calls to prevent test failures due to reporting issues
+3. **Batch Reporting**: For large test suites, consider batch reporting to optimize API calls
+4. **Test Mapping**: Maintain a clear mapping between your automated tests and ALM Octane test entities
+
+## Support
+
+If you encounter any issues with ALM Octane integration while running tests on <BrandName />, feel free to reach out to our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> or email us at [support@testmuai.com](mailto:support@testmuai.com).
+
+<nav aria-label="breadcrumbs">
+  <ul className="breadcrumbs">
+    <li className="breadcrumbs__item">
+      <a className="breadcrumbs__link" href={BRAND_URL}>Home</a>
+    </li>
+    <li className="breadcrumbs__item">
+      <a className="breadcrumbs__link" target="_self" href={`${BRAND_URL}/support/docs/`}>Support</a>
+    </li>
+    <li className="breadcrumbs__item breadcrumbs__item--active">
+      <span className="breadcrumbs__link">ALM Octane Integration</span>
+    </li>
+  </ul>
+</nav>

--- a/docs/apple-pay-auto.md
+++ b/docs/apple-pay-auto.md
@@ -57,7 +57,11 @@ Currently, the Device Passcode feature in App Automation is enabled on the follo
 | Capability                  | Type       | Default | Required / Optional | Description                                                                                 |
 |----------------------------|------------|---------|---------------------|---------------------------------------------------------------------------------------------|
 | **applePay**                | Boolean    | true    | Mandatory           | Enables Apple Pay provisioning including Wallet, Sandbox card, AssistiveTouch, and Passcode on supported real iOS devices. |
-| **applePayCardType**        | Array      | None    | Optional           | Specify preferred payment networks. Currently, you can choose from four supported cards: ["amex", "visa", "master", "discover"].|
+| **applePayCardType**        | Array      | None    | Optional           | Specify preferred payment networks. Currently, you can choose from four supported cards: `["amex", "visa", "master", "discover"]`.|
+
+:::tip
+The `applePayCardType` array follows a **priority order**. The order you provide determines which card type is used first. For example, `["visa", "master"]` will prioritize Visa over MasterCard.
+:::
 
 ---
 
@@ -105,7 +109,116 @@ To enable Apple Pay automation, include the following capability in your automat
 
 ---
 
-### Step 3: Confirm Apple Pay Payment
+### Step 3: Update Shipping, Billing, and Contact Details (Optional)
+
+Before confirming the Apple Pay payment, you can optionally update the shipping details, billing details, and contact information using the `lambda-applepay-details` hook. This allows you to customize the payment information dynamically during your automation test.
+
+<Tabs>
+  <TabItem value="python" label="Python">
+    <CodeBlock className="language-python">
+{`driver.execute_script("lambda-applepay-details", {
+    "shippingDetails": {
+        "firstName": "John",
+        "lastName": "Doe",
+        "street": "221B Baker Street",
+        "city": "London",
+        "postalCode": "NW1 6XE",
+        "state": "London",
+        "country": "UK"
+    },
+    "billingDetails": {
+        "firstName": "John",
+        "lastName": "Doe",
+        "street": "221B Baker Street",
+        "city": "London",
+        "postalCode": "NW1 6XE",
+        "state": "London",
+        "country": "UK"
+    },
+    "contact": {
+        "email": "john.doe@example.com",
+        "phone": "+441234567890"
+    }
+})`}
+    </CodeBlock>
+  </TabItem>
+  <TabItem value="java" label="Java">
+    <CodeBlock className="language-java">
+{`Map<String, Object> shippingDetails = new HashMap<>();
+shippingDetails.put("firstName", "John");
+shippingDetails.put("lastName", "Doe");
+shippingDetails.put("street", "221B Baker Street");
+shippingDetails.put("city", "London");
+shippingDetails.put("postalCode", "NW1 6XE");
+shippingDetails.put("state", "London");
+shippingDetails.put("country", "UK");
+
+Map<String, Object> billingDetails = new HashMap<>();
+billingDetails.put("firstName", "John");
+billingDetails.put("lastName", "Doe");
+billingDetails.put("street", "221B Baker Street");
+billingDetails.put("city", "London");
+billingDetails.put("postalCode", "NW1 6XE");
+billingDetails.put("state", "London");
+billingDetails.put("country", "UK");
+
+Map<String, Object> contact = new HashMap<>();
+contact.put("email", "john.doe@example.com");
+contact.put("phone", "+441234567890");
+
+Map<String, Object> applePayDetails = new HashMap<>();
+applePayDetails.put("shippingDetails", shippingDetails);
+applePayDetails.put("billingDetails", billingDetails);
+applePayDetails.put("contact", contact);
+
+driver.executeScript("lambda-applepay-details", applePayDetails);`}
+    </CodeBlock>
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+    <CodeBlock className="language-javascript">
+{`await driver.executeScript("lambda-applepay-details", {
+    shippingDetails: {
+        firstName: "John",
+        lastName: "Doe",
+        street: "221B Baker Street",
+        city: "London",
+        postalCode: "NW1 6XE",
+        state: "London",
+        country: "UK"
+    },
+    billingDetails: {
+        firstName: "John",
+        lastName: "Doe",
+        street: "221B Baker Street",
+        city: "London",
+        postalCode: "NW1 6XE",
+        state: "London",
+        country: "UK"
+    },
+    contact: {
+        email: "john.doe@example.com",
+        phone: "+441234567890"
+    }
+});`}
+    </CodeBlock>
+  </TabItem>
+</Tabs>
+
+#### Hook Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **shippingDetails** | Object | Shipping address information including firstName, lastName, street, city, postalCode, state, and country. |
+| **billingDetails** | Object | Billing address information with the same fields as shippingDetails. |
+| **contact** | Object | Contact information including email and phone number. |
+
+:::note
+All parameters are optional. You can provide only the details you need to update. For example, you can update only the billing details without providing shipping or contact information.
+:::
+
+---
+
+### Step 4: Confirm Apple Pay Payment
 
 - To confirm Apple Pay payment at the payment step, add a hook to confirm and complete the payment.
 - This can be done using <BrandName /> hooks. A sample script is provided below to trigger confirmation of the Apple Pay payment step:
@@ -119,7 +232,7 @@ driver.execute_script(
 
 ---
 
-### Step 4: Enter Passcode to Complete Payment
+### Step 5: Enter Passcode to Complete Payment
 
 - After confirming the Apple Pay payment, the device will prompt for the passcode to securely authorize the transaction. Your automation script must handle this prompt by entering the passcode using Appium's keyboard input methods to simulate the user securely confirming the payment.
   

--- a/docs/automated-test-cases-linked-using-capability.md
+++ b/docs/automated-test-cases-linked-using-capability.md
@@ -52,16 +52,43 @@ To link an automated test run with a specific test case, add the `tms.tc_id` key
 ```javascript
 const capabilities = {
   "lt:Options": {
+      "project": "Your Project Name", // Specify the project where the test run should be created
       "tms.tc_id": "TC-1470" // Link the test execution to the Test Case ID 'TC-1470'
   }
 };
 ```
 
 - `lt:Options` : A JSON object containing additional options for <BrandName /> configurations.
+- `project` : The name of the project in Test Manager where the test run should be created. If not specified, the test run will be created under **LambdaTest Default Project**.
 - `tms.tc_id` : The key used to link a test case in Test Manager. Replace "TC-1470" with your desired Test Case ID.
 
+## Specifying Target Project
+
+When you link a test case using `tms.tc_id`, a test run is automatically created with your build name. By default, this test run is created under **LambdaTest Default Project**.
+
+To ensure the test run is created in the correct project, use the `project` capability along with `tms.tc_id`:
+
+```javascript
+const capabilities = {
+  "browserName": "Chrome",
+  "browserVersion": "latest",
+  "lt:Options": {
+      "platform": "Windows 10",
+      "build": "Playwright Build",
+      "name": "Sample Test",
+      "project": "Demo-Project", // Target project name
+      "tms.tc_id": "TC-95668" // Test case ID from the target project
+  }
+};
+```
+
+:::warning
+The `project` name must match exactly as it appears in Test Manager. If the project name is incorrect or doesn't exist, the test run will be created under **LambdaTest Default Project**.
+:::
+
 :::info NOTE
-- Ensure the Test Case ID exists in Test Manager before linking.  
+- Ensure the Test Case ID exists in Test Manager before linking.
 - The Test Case ID format should match exactly as shown in Test Manager
 - Each automated test run can be linked to one test case at a time
+- The test case specified in `tms.tc_id` should belong to the project specified in `project` capability
 :::

--- a/sidebars.js
+++ b/sidebars.js
@@ -1797,7 +1797,8 @@ module.exports = {
           "testrail-integration-with-lambdatest-selenium-grid",
           "zebrunner-integration",
           "zephyr-scale",
-          "testmo-integration"
+          "testmo-integration",
+          "alm-octane-integration"
         ],
       },
 


### PR DESCRIPTION
## Summary

Updates Apple Pay Automation documentation with:

- **Priority order tip**: Added `:::tip` box explaining that `applePayCardType` array follows priority order
- **New Step 3**: Update Shipping, Billing, and Contact Details (Optional)
  - Added `lambda-applepay-details` hook documentation
  - Code examples in Python, Java, JavaScript
  - Hook parameters table
- **Renumbered steps**: Confirm Payment → Step 4, Enter Passcode → Step 5

## Test plan

- [ ] Verify tip box renders correctly below capabilities table
- [ ] Verify code examples in all three languages display properly
- [ ] Verify hook parameters table is formatted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)