### PR TITLE
Add ALM Octane docs, update test case linking, add API proxy

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -24,6 +24,11 @@
       "family": "SF Pro, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif"
     }
   },
+  "api": {
+    "proxy": {
+      "url": "https://api.lambdatest.com"
+    }
+  },
   "openapi": [
     "support-openapi.yaml",
     "mobile_automation.yaml",

--- a/support/docs/alm-octane-integration.mdx
+++ b/support/docs/alm-octane-integration.mdx
@@ -1,0 +1,118 @@
+---
+title: "ALM Octane Integration"
+sidebarTitle: "ALM Octane"
+description: "Learn how to integrate ALM Octane with TestMu AI for seamless test management and reporting while running your automated tests on the cloud."
+keywords: ['TestMu AI integration', 'ALM Octane integration', 'Micro Focus ALM Octane', 'test management integration']
+"og:description": "Learn how to integrate ALM Octane with TestMu AI for seamless test management and reporting while running your automated tests on the cloud."
+---
+
+import { BrandName } from "/snippets/BrandName.mdx";
+
+---
+
+[ALM Octane](https://www.microfocus.com/en-us/products/alm-octane/overview) is an enterprise-grade Application Lifecycle Management (ALM) platform from Micro Focus. It provides comprehensive test management capabilities including test planning, test case management, defect tracking, and detailed analytics for your software development lifecycle.
+
+<BrandName /> supports seamless integration with ALM Octane through your test automation scripts. If you already have ALM Octane configured in your test framework, your tests will work seamlessly when executed on <BrandName />'s cloud infrastructure.
+
+## How ALM Octane Integration Works
+
+ALM Octane integration is implemented directly within your test automation scripts using ALM Octane's SDK or REST API. When you run your automated tests on <BrandName />'s Selenium Grid or HyperExecute, the test results are automatically reported to your ALM Octane instance based on your script configuration.
+
+This script-based approach offers several advantages:
+
+- **Flexibility**: Configure exactly what data gets sent to ALM Octane
+- **Customization**: Map test results to specific ALM Octane entities (test runs, test suites, etc.)
+- **Seamless Execution**: No additional configuration required on <BrandName /> platform
+
+## Prerequisites
+
+- An active [<BrandName /> account](https://accounts.lambdatest.com/register)
+- An ALM Octane instance with API access
+- ALM Octane credentials (Client ID and Client Secret)
+- Your test automation framework configured with ALM Octane SDK/API
+
+## Configuring ALM Octane in Your Test Scripts
+
+### Step 1: Set Up ALM Octane API Credentials
+
+In your ALM Octane instance, generate API credentials:
+
+1. Navigate to **Settings** > **Spaces** > **API Access**
+2. Create a new API client with appropriate permissions
+3. Note down the **Client ID** and **Client Secret**
+
+### Step 2: Install ALM Octane SDK
+
+For Java-based projects using Maven, add the ALM Octane SDK dependency:
+
+```xml
+<dependency>
+    <groupId>com.microfocus.adm.almoctane.sdk</groupId>
+    <artifactId>sdk-src</artifactId>
+    <version>16.1.100</version>
+</dependency>
+```
+
+For other languages, refer to the [ALM Octane API documentation](https://admhelp.microfocus.com/octane/en/latest/Online/Content/API/API_Authentication.htm).
+
+### Step 3: Configure Test Result Reporting
+
+Here's an example of how to configure your test framework to report results to ALM Octane:
+
+**Java (TestNG) Example:**
+
+```java
+import com.hp.octane.integrations.OctaneSDK;
+
+public class ALMOctaneReporter {
+
+    private static final String OCTANE_URL = "https://your-octane-instance.com";
+    private static final String SHARED_SPACE_ID = "your-shared-space-id";
+    private static final String WORKSPACE_ID = "your-workspace-id";
+    private static final String CLIENT_ID = "your-client-id";
+    private static final String CLIENT_SECRET = "your-client-secret";
+
+    public void reportTestResult(String testName, String status) {
+        // Initialize Octane SDK and report results
+        // Refer to ALM Octane SDK documentation for detailed implementation
+    }
+}
+```
+
+### Step 4: Run Tests on <BrandName />
+
+Once your test scripts are configured with ALM Octane reporting, run them on <BrandName />:
+
+**Using Selenium Grid:**
+
+```java
+DesiredCapabilities capabilities = new DesiredCapabilities();
+capabilities.setCapability("browserName", "Chrome");
+capabilities.setCapability("version", "latest");
+capabilities.setCapability("platform", "Windows 10");
+capabilities.setCapability("build", "ALM Octane Integration Build");
+capabilities.setCapability("name", "ALM Octane Test");
+
+WebDriver driver = new RemoteWebDriver(
+    new URL("https://" + username + ":" + accessKey + "@hub.lambdatest.com/wd/hub"),
+    capabilities
+);
+
+// Your test code here
+// ALM Octane reporting happens automatically based on your script configuration
+```
+
+**Using HyperExecute:**
+
+Create your `hyperexecute.yaml` configuration and run tests as usual. The ALM Octane reporting configured in your scripts will work seamlessly.
+
+## Best Practices
+
+1. **Environment Variables**: Store ALM Octane credentials as environment variables rather than hardcoding them in scripts
+2. **Error Handling**: Implement proper error handling for ALM Octane API calls to prevent test failures due to reporting issues
+3. **Batch Reporting**: For large test suites, consider batch reporting to optimize API calls
+4. **Test Mapping**: Maintain a clear mapping between your automated tests and ALM Octane test entities
+
+## Support
+
+If you encounter any issues with ALM Octane integration while running tests on <BrandName />, feel free to reach out to our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24/7 chat support**</span> or email us at [support@testmuai.com](mailto:support@testmuai.com).

--- a/support/docs/automated-test-cases-linked-using-capability.mdx
+++ b/support/docs/automated-test-cases-linked-using-capability.mdx
@@ -23,16 +23,43 @@ To link an automated test run with a specific test case, add the `tms.tc_id` key
 ```javascript
 const capabilities = {
   "lt:Options": {
+      "project": "Your Project Name", // Specify the project where the test run should be created
       "tms.tc_id": "TC-1470" // Link the test execution to the Test Case ID 'TC-1470'
   }
 };
 ```
 
 - `lt:Options` : A JSON object containing additional options for <BrandName /> configurations.
+- `project` : The name of the project in Test Manager where the test run should be created. If not specified, the test run will be created under **LambdaTest Default Project**.
 - `tms.tc_id` : The key used to link a test case in Test Manager. Replace "TC-1470" with your desired Test Case ID.
 
+## Specifying Target Project
+
+When you link a test case using `tms.tc_id`, a test run is automatically created with your build name. By default, this test run is created under **LambdaTest Default Project**.
+
+To ensure the test run is created in the correct project, use the `project` capability along with `tms.tc_id`:
+
+```javascript
+const capabilities = {
+  "browserName": "Chrome",
+  "browserVersion": "latest",
+  "lt:Options": {
+      "platform": "Windows 10",
+      "build": "Playwright Build",
+      "name": "Sample Test",
+      "project": "Demo-Project", // Target project name
+      "tms.tc_id": "TC-95668" // Test case ID from the target project
+  }
+};
+```
+
+<Warning>
+The `project` name must match exactly as it appears in Test Manager. If the project name is incorrect or doesn't exist, the test run will be created under **LambdaTest Default Project**.
+</Warning>
+
 <Info>
-- Ensure the Test Case ID exists in Test Manager before linking.  
+- Ensure the Test Case ID exists in Test Manager before linking.
 - The Test Case ID format should match exactly as shown in Test Manager
 - Each automated test run can be linked to one test case at a time
+- The test case specified in `tms.tc_id` should belong to the project specified in `project` capability
 </Info>


### PR DESCRIPTION
## Summary
- Add new ALM Octane integration documentation (script-based integration)
- Update `automated-test-cases-linked-using-capability` with `project` capability
- Document that test runs default to "LambdaTest Default Project"
- Add API proxy config in docs.json to fix CORS issues on hosted domain

## Test plan
- [ ] Verify ALM Octane doc renders correctly
- [ ] Verify project capability section appears in test case linking doc
- [ ] Test API "Run" button on stage to confirm CORS fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)