### PR TITLE
docs: add public URL limitation to AI Test Case Generator

### DIFF
--- a/docs/generate-test-cases.md
+++ b/docs/generate-test-cases.md
@@ -166,12 +166,6 @@ Navigate to the **Agent** page in KaneAI and select `Generate Scenarios`. This o
 ### Step 2: Enter Your Requirements
 Start by entering your product or feature requirements in the input box.
 
-:::info Public URLs Only
-Currently, the AI Test Case Generator can only access **publicly available URLs**. Websites behind a VPN, corporate proxy, firewall, or those requiring authentication to reach the landing page cannot be analyzed.
-
-**Support for private URLs is coming soon.**
-:::
-
 We support multiple input formats, including:
 - **Textual requirements**
 - **Jira/Azure DevOps links** (e.g., epics, stories, tasks)
@@ -182,6 +176,12 @@ We support multiple input formats, including:
 - **Spreadsheets** (CSV or XLSX)
 - **Documents**
 - **JSON or XML**
+
+:::info Public URLs Only
+Currently, the AI Test Case Generator can only access **publicly available URLs**. Websites behind a VPN, corporate proxy, firewall, or those requiring authentication to reach the landing page cannot be analyzed.
+
+**Support for private URLs is coming soon.**
+:::
 
 #### Add Input Requirements
 

--- a/docs/generate-test-cases.md
+++ b/docs/generate-test-cases.md
@@ -167,7 +167,7 @@ Navigate to the **Agent** page in KaneAI and select `Generate Scenarios`. This o
 Start by entering your product or feature requirements in the input box.
 
 :::info Public URLs Only
-Currently, the AI Test Case Generator can only access **publicly available URLs**. Websites behind a VPN, corporate proxy, firewall, or those requiring authentication to reach the landing page cannot be analyzed. **Support for private and authenticated URLs is coming soon.**
+Currently, the AI Test Case Generator can only access **publicly available URLs**. Websites behind a VPN, corporate proxy, firewall, or those requiring authentication to reach the landing page cannot be analyzed. **Support for private URLs is coming soon.**
 :::
 
 We support multiple input formats, including:

--- a/docs/generate-test-cases.md
+++ b/docs/generate-test-cases.md
@@ -166,6 +166,10 @@ Navigate to the **Agent** page in KaneAI and select `Generate Scenarios`. This o
 ### Step 2: Enter Your Requirements
 Start by entering your product or feature requirements in the input box.
 
+:::info Public URLs Only
+When providing URLs as input, the AI Test Case Generator can only access **publicly available URLs**. Websites behind a VPN, corporate proxy, firewall, or those requiring authentication to reach the landing page cannot be analyzed. Ensure the URL you provide is reachable from the open internet.
+:::
+
 We support multiple input formats, including:
 - **Textual requirements**
 - **Jira/Azure DevOps links** (e.g., epics, stories, tasks)

--- a/docs/generate-test-cases.md
+++ b/docs/generate-test-cases.md
@@ -167,7 +167,7 @@ Navigate to the **Agent** page in KaneAI and select `Generate Scenarios`. This o
 Start by entering your product or feature requirements in the input box.
 
 :::info Public URLs Only
-When providing URLs as input, the AI Test Case Generator can only access **publicly available URLs**. Websites behind a VPN, corporate proxy, firewall, or those requiring authentication to reach the landing page cannot be analyzed. Ensure the URL you provide is reachable from the open internet.
+Currently, the AI Test Case Generator can only access **publicly available URLs**. Websites behind a VPN, corporate proxy, firewall, or those requiring authentication to reach the landing page cannot be analyzed. **Support for private and authenticated URLs is coming soon.**
 :::
 
 We support multiple input formats, including:

--- a/docs/generate-test-cases.md
+++ b/docs/generate-test-cases.md
@@ -167,7 +167,9 @@ Navigate to the **Agent** page in KaneAI and select `Generate Scenarios`. This o
 Start by entering your product or feature requirements in the input box.
 
 :::info Public URLs Only
-Currently, the AI Test Case Generator can only access **publicly available URLs**. Websites behind a VPN, corporate proxy, firewall, or those requiring authentication to reach the landing page cannot be analyzed. **Support for private URLs is coming soon.**
+Currently, the AI Test Case Generator can only access **publicly available URLs**. Websites behind a VPN, corporate proxy, firewall, or those requiring authentication to reach the landing page cannot be analyzed.
+
+**Support for private URLs is coming soon.**
 :::
 
 We support multiple input formats, including:


### PR DESCRIPTION
## Summary
- Adds an `:::info` admonition to the AI Test Case Generator doc (`generate-test-cases-with-ai`) clarifying that only publicly accessible URLs can be analyzed
- Pages behind VPN, corporate proxy, firewall, or authentication cannot be scraped by the generator
- Emphasizes that support for private URLs is coming soon
- Placed below the supported input formats list in Step 2 for natural reading flow

## Test plan
- [x] Verified locally on Docusaurus dev server (`npm start`)
- [ ] Confirm `:::info` admonition renders correctly on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)