### PR TITLE
Fix canonical URL to testmuai.com

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,7 +3,7 @@ import { themes as prismThemes } from 'prism-react-renderer';
 module.exports = {
   title: 'TestMu AI (Formerly LambdaTest)',
   tagline: 'Ensure your web-apps work seamlessly on every desktop and mobile browsers.',
-  url: 'https://www.lambdatest.com',
+  url: 'https://www.testmuai.com',
   baseUrl: '/support/',
   onBrokenLinks: 'throw',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
## Summary
- Updates `url` in `docusaurus.config.js` from `https://www.lambdatest.com` to `https://www.testmuai.com`
- This fixes the canonical tag across all pages to point to the correct domain, matching the `testmuCom` (prod) branch

## Test plan
- [ ] Verify canonical tag in page source shows `testmuai.com` instead of `lambdatest.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)