### PR TITLE
Fix FAQ layout alignment and add border separator

### DIFF
--- a/src/pages/faq/styles.module.css
+++ b/src/pages/faq/styles.module.css
@@ -5,17 +5,18 @@
   min-height: calc(100vh - 100px);
 }
 
-/* Stretches to fill remaining space and centers the content column */
+/* Stretches to fill remaining space */
 .faqContentWrapper {
   flex: 1;
   min-width: 0;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
+  border-left: 1px solid var(--ifm-color-emphasis-200);
 }
 
 .faqCenter {
   width: 100%;
-  max-width: 780px;
+  max-width: 900px;
   padding: 32px 40px;
   padding-bottom: 100px;
 }

--- a/src/pages/faq/styles.module.css
+++ b/src/pages/faq/styles.module.css
@@ -44,11 +44,26 @@
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
   margin-bottom: 20px;
   overflow-x: auto;
-  scrollbar-width: none;
+  scrollbar-width: thin;
+  scrollbar-color: #9ca3af transparent;
+  padding-bottom: 8px;
 }
 
 .tabBar::-webkit-scrollbar {
-  display: none;
+  height: 4px;
+}
+
+.tabBar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.tabBar::-webkit-scrollbar-thumb {
+  background-color: #9ca3af;
+  border-radius: 2px;
+}
+
+.tabBar::-webkit-scrollbar-thumb:hover {
+  background-color: #6b7280;
 }
 
 .tabBtn {
@@ -169,11 +184,26 @@
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
   margin-bottom: 16px;
   overflow-x: auto;
-  scrollbar-width: none;
+  scrollbar-width: thin;
+  scrollbar-color: #9ca3af transparent;
+  padding-bottom: 6px;
 }
 
 .subTabBar::-webkit-scrollbar {
-  display: none;
+  height: 4px;
+}
+
+.subTabBar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.subTabBar::-webkit-scrollbar-thumb {
+  background-color: #9ca3af;
+  border-radius: 2px;
+}
+
+.subTabBar::-webkit-scrollbar-thumb:hover {
+  background-color: #6b7280;
 }
 
 .subTabBtn {


### PR DESCRIPTION
## Summary
- Left-align FAQ content (changed `justify-content` from `center` to `flex-start`)
- Increase content width from 780px to 900px
- Add left border separator between sidebar and content (consistent with API/Docs pages)

## Test plan
- [ ] Verify FAQ page content is left-aligned
- [ ] Verify left border separator is visible
- [ ] Check responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)