### PR TITLE
refactor: restructure KaneAI docs sidebar to STLC flow

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -52,28 +52,43 @@
           {
             "group": "KaneAI",
             "pages": [
-              "docs/getting-started-with-kane-ai",
-              "docs/author-your-first-desktop-browser-test",
               {
-                "group": "Build Smarter Tests",
+                "group": "Getting Started",
                 "pages": [
-                  "docs/kaneai-manual-interaction",
-                  "docs/kane-ai-scroll-in-feature",
-                  "docs/kaneai-conditional-logic",
-                  "docs/kaneai-failure-conditions",
-                  "docs/kane-ai-modules",
-                  "docs/kane-ai-drag-drop",
-                  "docs/kaneai-rename-instructions"
+                  "docs/getting-started-with-kane-ai",
+                  "docs/author-your-first-desktop-browser-test"
                 ]
               },
               {
-                "group": "In-Test Tools",
+                "group": "Setup & Configuration",
                 "pages": [
+                  "docs/kaneai-chrome-options",
+                  "docs/kaneai-custom-headers",
+                  "docs/kane-ai-geolocation-tunnel-proxy",
+                  "docs/kaneai-gps-location",
+                  "docs/kaneai-network-throttling",
+                  "docs/kane-ai-mobile-app-capabilities",
+                  "docs/kane-ai-secrets"
+                ]
+              },
+              {
+                "group": "Author Tests",
+                "pages": [
+                  "docs/kaneai-manual-interaction",
+                  "docs/kane-ai-scroll-in-feature",
+                  "docs/kane-ai-drag-drop",
+                  "docs/kaneai-conditional-logic",
+                  "docs/kaneai-rename-instructions",
+                  "docs/kaneai-failure-conditions",
+                  "docs/kane-ai-using-variables",
+                  "docs/kane-ai-smart-variables",
+                  "docs/kane-ai-using-parameters",
+                  "docs/kane-ai-modules",
                   "docs/kane-ai-api-testing",
                   "docs/kaneai-database",
                   "docs/kane-ai-javascript-execution",
-                  "docs/kaneai-totp",
                   "docs/kane-ai-network-assertions",
+                  "docs/kaneai-totp",
                   "docs/kaneai-smartui-visual-testing",
                   "docs/kaneai-upload-and-download-files",
                   "docs/kane-ai-deeplink-support",
@@ -81,41 +96,21 @@
                 ]
               },
               {
-                "group": "Manage Test Data",
-                "pages": [
-                  "docs/kane-ai-using-variables",
-                  "docs/kane-ai-smart-variables",
-                  "docs/kane-ai-secrets",
-                  "docs/kane-ai-using-parameters",
-                  "docs/kane-ai-using-datasets"
-                ]
-              },
-              {
-                "group": "Session Configuration",
-                "pages": [
-                  "docs/kaneai-chrome-options",
-                  "docs/kaneai-custom-headers",
-                  "docs/kane-ai-geolocation-tunnel-proxy",
-                  "docs/kaneai-gps-location",
-                  "docs/kaneai-network-throttling",
-                  "docs/kaneai-dynamic-url-replacement",
-                  "docs/kane-ai-mobile-app-capabilities"
-                ]
-              },
-              {
-                "group": "Generate Code & Run",
+                "group": "Execute & Run",
                 "pages": [
                   "docs/kane-ai-automation-code-generation",
                   "docs/kaneai-auto-heal",
                   "docs/test-runs-configurations",
                   "docs/kaneai-hyperexecute-test-run-execution",
-                  "docs/kaneai-scheduled-test-runs"
+                  "docs/kaneai-scheduled-test-runs",
+                  "docs/kaneai-ci-cd-automation",
+                  "docs/kaneai-dynamic-url-replacement",
+                  "docs/kane-ai-using-datasets"
                 ]
               },
               {
-                "group": "Integrate with Your Workflow",
+                "group": "Integrations",
                 "pages": [
-                  "docs/kaneai-ci-cd-automation",
                   "docs/kaneai-create-pr",
                   "docs/github-app-integration",
                   "docs/kane-ai-jira-integration"
@@ -136,13 +131,7 @@
                   "docs/error-handling-kaneai"
                 ]
               },
-              {
-                "group": "Release Notes",
-                "pages": [
-                  "docs/kaneai-release-notes-0-0-2",
-                  "docs/kaneai-release-notes-0-0-1"
-                ]
-              }
+              "docs/kaneai-release-notes"
             ]
           }
         ]

--- a/docs/kaneai-release-notes.mdx
+++ b/docs/kaneai-release-notes.mdx
@@ -1,0 +1,73 @@
+---
+title: "Release Notes"
+sidebarTitle: "Release Notes"
+description: "KaneAI Release Notes - Version history and changelogs"
+keywords: ['TestMu AI kaneai', 'TestMu AI kaneai release notes', 'TestMu AI kaneai changelog']
+"og:description": "KaneAI Release Notes - Version history and changelogs"
+---
+
+import { BrandName } from "/snippets/BrandName.mdx";
+
+<Tabs>
+<Tab title="Version 0.0.2">
+
+## 1. Iframe, Shadow DOM, and Canvas Support
+KaneAI now fully supports testing for:
+
+- Iframe elements
+- Shadow DOM elements
+- Canvas elements
+
+We've gone the extra mile to bring full iframe, Shadow DOM, and Canvas support in code exports. Now, KaneAI handles these intricate UI elements with precision during script generation, making your automation journey even smoother. Whether dealing with complex nested iframes or shadow-rooted elements, KaneAI has you covered!
+
+## 2. Auto-Scroll for Manual Interaction
+No more searching for the latest entries after clicking! KaneAI now automatically scrolls to the latest interaction in manual testing sessions, saving time and making testing more efficient.
+
+## 3. Screenshot Modal Fix
+We've fixed an issue where screenshots would appear outside the modal on both KaneAI and TMS. Screenshots will now stay neatly within their designated area for better viewing.
+
+## 4. URL Update with Objective Changes
+Whenever you update an objective, the URL will now update along with any other pre-filled fields. This improvement ensures that your URLs stay in sync with your updates for better tracking and organization.
+
+## 5. Label Overlap Fix in TMS
+Fixed the issue of labels overlapping other elements on the TMS UI. Now, we show a concise label such as "+12" when there's no space. Clicking it will open an overlay with all label details, improving readability and UI neatness.
+
+## 6. Test Case Name Display Issue Fixed
+Resolved an issue where test case names weren't appearing in certain situations, such as when the screen was zoomed in at 200%. This fix ensures that test case names are visible even in extreme zoom conditions.
+
+## 7. Manual Interaction Enhancements
+We've refined manual interactions to make Click actions faster and more precise, optimizing the overall experience for testers.
+
+## 8. Stable Template Support
+Our templates have been stabilized for more reliable performance during test creation and execution.
+
+## 9. Enhancements in Visual and Textual Query for Code Generation
+We've enhanced the visual and textual query capabilities in code exports, making your scripts even more accurate when handling complex UI elements.
+
+</Tab>
+<Tab title="Version 0.0.1">
+
+### Proximity-Based Hub Region Allocation for Code Generation <span className="bg-yellow-600 text-white px-4 py-1 rounded-full text-xs text-nowrap">Enhancement</span>
+We've introduced proximity-based hub region allocation to optimize code generation performance by selecting the nearest hub region to the user. This enhancement ensures faster execution and reduced latency during test script generation.
+
+### Proximity-Based VM Allocation for Web Tests <span className="bg-yellow-600 text-white px-4 py-1 rounded-full text-xs text-nowrap">Enhancement</span>
+KaneAI now allocates virtual machines (VMs) for web tests based on proximity, improving test execution speed and stability by choosing the closest VM location to the user.
+
+### Removed Auto Trigger of Code-Export on Test Failures or Queued Instructions <span className="bg-yellow-600 text-white px-4 py-1 rounded-full text-xs text-nowrap">Enhancement</span>
+The automatic triggering of code export has been removed when instructions in the test are either failed or queued. This update provides users with better control over the export process and avoids unnecessary actions during troubleshooting.
+
+### Improved Stability in Manual Interaction with Multiple XPaths <span className="bg-yellow-600 text-white px-4 py-1 rounded-full text-xs text-nowrap">Enhancement</span>
+We've enhanced manual interactions by allowing the use of multiple XPaths, providing more stability and accuracy when interacting with elements on web pages.
+
+### Code Generation <span className="bg-red-500 text-white px-4 py-1 rounded-full text-xs text-nowrap">Bug Fix</span>
+Addressed multiple issues in the code generation process, including:
+
+- Click interception problems
+- Websites failing to load correctly
+- Failures in identifying and interacting with XPaths
+
+### Document and Element Scroll Fix in Manual Interaction <span className="bg-red-500 text-white px-4 py-1 rounded-full text-xs text-nowrap">Bug Fix</span>
+Fixed a bug causing issues with scrolling documents and elements during manual interactions, ensuring smoother navigation and interaction within the testing interface.
+
+</Tab>
+</Tabs>


### PR DESCRIPTION
Reorganize KaneAI documentation navigation from feature-based grouping to an STLC lifecycle flow: Getting Started → Setup & Configuration → Author Tests → Execute & Run → Integrations → Guides & Troubleshooting.

- Merge "Build Smarter Tests", "In-Test Tools", and "Manage Test Data" into single "Author Tests" group
- Rename "Session Configuration" to "Setup & Configuration" (pre-session config only)
- Move CI/CD, dynamic URL replacement, datasets to "Execute & Run"
- Move secrets to "Setup & Configuration"
- Rename "Integrate with Your Workflow" to "Integrations"
- Combine release notes into single tabbed page (like FAQ pattern)
- Rename "Troubleshooting & Reference" to "Guides & Troubleshooting"