### PR TITLE
TE-12682: Document + / %2B handling in form-encoded API bodies

### DIFF
--- a/docs/kane-ai-api-testing.md
+++ b/docs/kane-ai-api-testing.md
@@ -64,7 +64,43 @@ Within the API module, you can input the curl command to configure the API setti
   <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/api-testing/image2.jpg').default} alt="kenai-jira integration" className="doc_img"/>
   
 
-## 3. Validating API Response on KaneAI
+## 3. Handling + in Form-Encoded Bodies
+
+When the request `Content-Type` is `application/x-www-form-urlencoded`, a `+` character in the encoded payload is interpreted as a space unless it is encoded as `%2B`.
+
+### Manual entry in KaneAI
+
+When typing values directly into the request body editor, KaneAI correctly preserves `+` characters.
+
+| You type            | Server receives    |
+| ------------------- | ------------------ |
+| `+917777711791`     | `+917777711791`    |
+| `%2B917777711791`   | `+917777711791`    |
+
+After execution, the response/echo panel displays the resolved value, so you can visually confirm the value received by the server.
+
+### Pasting cURL commands
+
+For pasted cURL commands, raw `+` characters inside form-urlencoded bodies are resolved as spaces during processing.
+
+| cURL body                          | Server receives           |
+| ---------------------------------- | ------------------------- |
+| `-d 'phone=+917777711791'`         | `phone= 917777711791`     |
+| `-d 'phone=%2B917777711791'`       | `phone=+917777711791`     |
+
+To send a literal plus sign from a pasted cURL request, encode it as `%2B`.
+
+**Example:**
+
+```bash
+curl -X POST 'https://api.example.com/update-user' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'phone=%2B917777711791'
+```
+
+This request sends `phone=+917777711791` to the server.
+
+## 4. Validating API Response on KaneAI
 
 To ensure the API works as expected, use the validation feature. This step confirms that the API responds correctly and can be added to test steps.
 
@@ -73,7 +109,7 @@ To ensure the API works as expected, use the validation feature. This step confi
   <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/api-testing/image3.jpg').default} alt="kenai-jira integration" className="doc_img"/>
   
 
-## 4. Adding Non-Success APIs in Test Steps
+## 5. Adding Non-Success APIs in Test Steps
 
 For APIs that do not return a 200 status, you can review the response body and manually add them to the test steps as required.
 
@@ -82,7 +118,7 @@ For APIs that do not return a 200 status, you can review the response body and m
   <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/api-testing/image8.jpg').default} alt="kenai-jira integration" className="doc_img"/>
   
 
-## 5. Adding Multiple APIs in One Go
+## 6. Adding Multiple APIs in One Go
 
 KaneAI allows batch processing of multiple APIs to streamline testing. This feature is helpful for scenarios requiring the execution of several API calls in succession.
 
@@ -91,7 +127,7 @@ KaneAI allows batch processing of multiple APIs to streamline testing. This feat
   <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/api-testing/image10.jpg').default} alt="kenai-jira integration" className="doc_img"/>
   
 
-## 6. Handling Different HTTP Methods
+## 7. Handling Different HTTP Methods
 
 KaneAI supports various HTTP methods like POST, PUT, GET, and DELETE, allowing you to test diverse API interactions.
 
@@ -102,7 +138,7 @@ KaneAI supports various HTTP methods like POST, PUT, GET, and DELETE, allowing y
   
     <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/api-testing/image9.jpg').default} alt="kenai-jira integration" className="doc_img"/>
 
-## 7. Executing and Reviewing Test Steps
+## 8. Executing and Reviewing Test Steps
 
 Once all APIs are added, KaneAI enables simultaneous execution, with details available on methods used, response statuses, and execution times.
 


### PR DESCRIPTION
## Summary

Adds a new section to **KaneAI - API Testing** explaining how `+` and `%2B` are processed differently between manual entry in the request body editor and pasted cURL commands. This closes the documentation gap flagged on TE-12682, where customer phone-number values like `+917777711791` were being decoded to a space on the wire (form-urlencoded spec behavior) and producing "Invalid Phone number" responses.

The new content covers:

- **Manual entry** — both `+917777711791` and `%2B917777711791` are accepted; the response panel shows the resolved value.
- **cURL paste** — raw `+` in `-d` is decoded to space (spec-correct); to send a literal `+`, encode as `%2B`.
- A working example using `%2B` for a phone-number value.

No other content is modified; existing sections after the new one are simply renumbered (3→4, 4→5, …, 7→8).

## Test plan

- [x] Reviewed locally via `pnpm start` — new section renders correctly between **Adding a Curl Command** and **Validating API Response on KaneAI**, tables display cleanly, and the code block renders.
- [ ] Reviewer to verify wording matches the shipped KaneAI behavior on stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)