### PR TITLE
fix: update kane-cli skill URL path

### DIFF
--- a/docs/kane-cli-skills.mdx
+++ b/docs/kane-cli-skills.mdx
@@ -32,7 +32,7 @@ The Kane CLI skill for Claude Code is a `SKILL.md` file placed in your skills di
 ```bash
 mkdir -p ~/.claude/skills/kane-cli
 curl -o ~/.claude/skills/kane-cli/SKILL.md \
-  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skills/claude/SKILL.md
+  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/.claude/skills/kane-cli/SKILL.md
 ```
 
 **Project-level install** (available only in this project):
@@ -40,7 +40,7 @@ curl -o ~/.claude/skills/kane-cli/SKILL.md \
 ```bash
 mkdir -p .claude/skills/kane-cli
 curl -o .claude/skills/kane-cli/SKILL.md \
-  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skills/claude/SKILL.md
+  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/.claude/skills/kane-cli/SKILL.md
 ```
 
 After installing, Claude Code automatically loads the skill. No restart required.


### PR DESCRIPTION
## Summary
- Updated Kane CLI skill URL from old path (`skills/claude/SKILL.md`) to new path (`.claude/skills/kane-cli/SKILL.md`)

## Changes
- `docs/kane-cli-skills.mdx` — 2 URL references updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)