### PR TITLE
fix: broken links causing stage deployment failure

### DIFF
--- a/docs/accessibility-mcp-server.md
+++ b/docs/accessibility-mcp-server.md
@@ -11,7 +11,7 @@ canonical: https://www.testmuai.com/support/docs/accessibility-mcp-server/
 
 # Accessibility MCP Tool
 
-Accessibility MCP Tool enables supported AI-assisted Accessibility workflows for public URLs and selected local app analysis flows. It is a tool within the [TestMu AI MCP Server](/support/docs/lambdatest-mcp-server/).
+Accessibility MCP Tool enables supported AI-assisted Accessibility workflows for public URLs and selected local app analysis flows. It is a tool within the [TestMu AI MCP Server](/support/docs/testmu-mcp-server/).
 
 This page describes what the Accessibility MCP Tool is, when an MCP-connected, AI-assisted analysis flow makes sense, and how that surface differs from DevTools, Automation, and Web Scanner. Use it to orient prerequisites and boundaries before connecting a client or routing work into an MCP-based accessibility review.
 

--- a/docs/automation-mcp-server.md
+++ b/docs/automation-mcp-server.md
@@ -46,7 +46,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 ></script>
 
 # Getting Started with Automation MCP Tool
-Automation MCP Tool simplifies test failure triaging for all automation test cases executed on TestMu AI. It is a tool within the [TestMu AI MCP Server](/support/docs/lambdatest-mcp-server/) that enables integration between AI assistants and your test execution data — reducing triage and troubleshooting time.
+Automation MCP Tool simplifies test failure triaging for all automation test cases executed on TestMu AI. It is a tool within the [TestMu AI MCP Server](/support/docs/testmu-mcp-server/) that enables integration between AI assistants and your test execution data — reducing triage and troubleshooting time.
 
 
 <div className="ytframe"> 

--- a/docs/hyperexecute-mcp-server.md
+++ b/docs/hyperexecute-mcp-server.md
@@ -45,7 +45,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 ></script>
 
 # Getting Started with HyperExecute MCP Tool
-HyperExecute MCP Tool is an AI-native test orchestration tool within the [TestMu AI MCP Server](/support/docs/lambdatest-mcp-server/) that dramatically simplifies and accelerates your automated testing workflow. By leveraging the Model Context Protocol (MCP), it enables seamless integration between AI assistants and your testing environment, reducing setup time from hours to minutes.
+HyperExecute MCP Tool is an AI-native test orchestration tool within the [TestMu AI MCP Server](/support/docs/testmu-mcp-server/) that dramatically simplifies and accelerates your automated testing workflow. By leveraging the Model Context Protocol (MCP), it enables seamless integration between AI assistants and your testing environment, reducing setup time from hours to minutes.
 
 ## Watch HyperExecute MCP Tool in Action
 

--- a/docs/smartui-mcp-server.md
+++ b/docs/smartui-mcp-server.md
@@ -51,7 +51,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # Getting Started with SmartUI MCP Tool
 ***
-The SmartUI MCP Tool allows you to debug visual regressions using SmartUI comparison runs, returning natural-language insights such as human-like summaries, visual change detection, and root cause analysis. It is a tool within the [TestMu AI MCP Server](/support/docs/lambdatest-mcp-server/) built on [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) and connects to the <BrandName /> SmartUI infrastructure via `comparisonId`.
+The SmartUI MCP Tool allows you to debug visual regressions using SmartUI comparison runs, returning natural-language insights such as human-like summaries, visual change detection, and root cause analysis. It is a tool within the [TestMu AI MCP Server](/support/docs/testmu-mcp-server/) built on [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) and connects to the <BrandName /> SmartUI infrastructure via `comparisonId`.
 
 <div className="ytframe"> 
 <div className="youtube" data-embed="2Z5F52XxSxQ" data-loading-attribute="eager">


### PR DESCRIPTION
## Summary
Stage deployments are failing due to broken links in MCP docs.

## Fix
- `/support/docs/lambdatest-mcp-server/` → `/support/docs/testmu-mcp-server/` in all 4 MCP tool docs

## Files
- `docs/hyperexecute-mcp-server.md`
- `docs/automation-mcp-server.md`
- `docs/smartui-mcp-server.md`
- `docs/accessibility-mcp-server.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)