### PR TITLE
fix: broken links in enterprise-ready.md blocking stage deployment

### DIFF
--- a/docs/enterprise-ready.md
+++ b/docs/enterprise-ready.md
@@ -82,8 +82,8 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 **Documentation:**
 - [Getting Started with SSO](/support/docs/single-sign-on/)
 - [SCIM Overview](/support/docs/scim/)
-- [Okta SCIM Integration](/support/docs/okta-scim/)
-- [Azure AD SCIM Integration](/support/docs/azure-scim/)
+- [Okta SCIM Integration](/support/docs/scim/okta/)
+- [Azure AD SCIM Integration](/support/docs/scim/azure/)
 - [PingOne SCIM Integration](/support/docs/pingone-scim/)
 - [JumpCloud SCIM Integration](/support/docs/jumpcloud-scim/)
 
@@ -166,7 +166,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 **Documentation:**
 - [HyperExecute Private Cloud Setup](/support/docs/hyperexecute-private-cloud-setup/)
 - [Network Whitelisting Guide](/support/docs/network-whitelisting-and-tunnel-guide/)
-- [Public IP Ranges](/support/docs/lambdatest-public-ip/)
+- [Public IP Ranges](/support/docs/testmu-public-ip/)
 
 ---
 


### PR DESCRIPTION
## Problem
Stage deployment is failing because `enterprise-ready.md` has 3 broken links with old slugs.

## Fix
| Broken Link | Fixed To |
|-------------|----------|
| `/support/docs/okta-scim/` | `/support/docs/scim/okta/` |
| `/support/docs/azure-scim/` | `/support/docs/scim/azure/` |
| `/support/docs/lambdatest-public-ip/` | `/support/docs/testmu-public-ip/` |

## Verified
- Checked all links in enterprise-ready.md, data-retention-policy.md, and defect-analysis-prediction.md — no other broken links remain.
- Previous MCP broken links already fixed in PR #2904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)