### PR TITLE
docs(app-profiling): rewrite Insights page for new dashboard

### DIFF
--- a/docs/analytics-insights-app-profiling.md
+++ b/docs/analytics-insights-app-profiling.md
@@ -2,14 +2,16 @@
 id: insights-app-profiling
 title: App Profiling Insights
 sidebar_label: App Profiling
-description: Discover TestMu AI's App Profiling Insights for comprehensive test cases insights. Optimize your testing efforts today.
+description: App Profiling Insights surface CPU, memory, frame rate, battery, network and startup metrics across devices, builds and page transitions, with org-level SLA thresholds and per-widget compare mode.
 keywords:
   - analytics
   - test insights
-  - App Profiling
-  - Desktop insights
-  - Desktop trends
-  - Desktop status ratio
+  - app profiling
+  - mobile app performance
+  - cpu memory fps insights
+  - device performance matrix
+  - page load time
+  - sla thresholds
 
 url: https://www.testmuai.com/support/docs/insights-app-profiling/
 site_name: TestMu AI
@@ -37,7 +39,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
         },{
           "@type": "ListItem",
           "position": 3,
-          "name": "Linear App Integration",
+          "name": "App Profiling Insights",
           "item": `${BRAND_URL}/support/docs/insights-app-profiling/`
         }]
       })
@@ -50,242 +52,145 @@ import NewTag from '../src/component/newTag';
 
 ## Overview
 
-The App Profiling dashboard provides comprehensive performance metrics to help you identify bottlenecks and optimize your application. This documentation explains each widget's purpose and how to interpret the data to improve app performance.
+The App Profiling dashboard aggregates performance telemetry from Appium tests run with the `appProfiling` capability and surfaces it as cross-test, cross-device analytics. Use it to compare CPU, memory, frame rate, battery, network and startup behaviour across devices, app builds and page transitions, with org-level SLA thresholds rendered directly on each chart.
 
-<img loading="lazy" src={require('../assets/images/analytics/app-profiling-screenshot.webp').default} alt="cmd" width="768" height="373" className="doc_img"/>
+The data on this dashboard comes from the App Profiling capability on Appium tests. To enable App Profiling on your test runs and review per-session metrics, see [App Performance Analytics](/support/docs/appium-app-performance-analytics/).
 
-## Understanding Performance Metrics Widgets
+:::note
+App Profiling Insights is available for Appium tests on iOS and Android (version 9+). Set `appProfiling: true` and `resignApp: true` in your capabilities. Battery Utilization and Battery Temperature widgets are populated for Android sessions only.
+:::
 
-### CPU Utilization Trend
+<img loading="lazy" src={require('../assets/images/analytics/app-profiling-screenshot.webp').default} alt="App Profiling dashboard" width="768" height="373" className="doc_img"/>
 
-**Widget Purpose:**
-This graph tracks CPU consumption over time, separating system-level processing from app-specific usage.
+## How to access
 
-**Metrics Explained:**
-- **CPU System (%)**: Total system CPU resources being used
-- **CPU App (%)**: CPU resources specifically consumed by your application
+1. Open the **Insights** section from the left sidebar of the <BrandName /> dashboard.
+2. Select **App Profiling**. The landing page lists every test that has App Profiling data.
+3. Click a test name to open its dashboard.
 
-**How to Analyze:**
-- Look for consistent app CPU usage above 15-20%, which may indicate inefficient algorithms or background tasks
-- Watch for correlations between high CPU usage and other performance issues
-- Identify patterns: gradual increases could signal memory leaks; sudden spikes might indicate intensive operations
+The page is always scoped to the test you opened. Use the **Test Name** filter to add more tests to the comparison without leaving the dashboard.
 
-**Optimization Strategies:**
-- Offload intensive tasks to background threads
-- Implement lazy loading for resource-heavy features
-- Use caching mechanisms for repetitive operations
-- Optimize algorithms with high computational complexity
-- Consider using more efficient data structures
+## Filter bar
 
-### Frame Rate Trends
+The filter bar at the top of the dashboard applies to every widget on the page.
 
-**Widget Purpose:**
-Visualizes rendering performance, highlighting both smooth operation and problematic frames.
+| Filter | Values | Default |
+|---|---|---|
+| **Test Name** | Multi-select, up to 25 tests | The test you opened (pre-selected) |
+| **OS** | Android, iOS | All |
+| **Device** | Specific device models recorded across the selected tests | All |
+| **App Build Version** | Build versions captured during the sessions | All |
+| **Page Label** | Page transition labels recorded by the test | All |
+| **Date Range** | Preset windows or a custom range with a time-of-day picker | Last 30 days |
 
-**Metrics Explained:**
-- **Current FPS**: Frames rendered per second (higher is better, 60+ ideal for smooth animation)
-- **Jank Frames**: Frames taking excessive time to render, causing visual stuttering
-- **Frozen Frames**: Completely dropped frames that cause noticeable pauses
+Clearing the Test Name filter and clicking Apply restores the test you opened — the dashboard is never scoped to zero tests.
 
-**How to Analyze:**
-- Identify sections where FPS consistently drops below target (60 FPS for most applications)
-- Pay attention to clusters of jank frames, which indicate UI thread blockage
-- Look for correlations between frozen frames and specific user interactions
+## Performance Overview
 
-**Optimization Strategies:**
-- Move heavy operations off the UI thread
-- Simplify complex layouts and view hierarchies
-- Reduce overdraw by flattening view layers
-- Optimize or defer expensive drawing operations
-- Implement hardware acceleration where appropriate
-- Use profiling tools to identify specific rendering bottlenecks
+A strip of KPI cards summarising the headline metrics over the selected window.
 
-### Memory Usage
+- **Avg CPU (%)** — application CPU usage averaged across sessions in scope.
+- **Avg Memory (MB)** — application memory usage averaged across sessions in scope.
+- **Avg FPS** — frames per second averaged across sessions in scope.
+- **Avg Cold Startup (ms)** — cold-start duration averaged across sessions in scope.
 
-**Widget Purpose:**
-Monitors memory allocation patterns to identify potential leaks and inefficient resource usage.
+When sessions in the selected scope record crashes or ANRs, two additional cards surface:
 
-**Metrics Explained:**
-- **App Memory (MB)**: Direct memory consumed by your application
-- **System Memory (MB)**: Overall system memory usage
+- **Avg Crashes per Crashed Session** — `avg(crash_count)` over sessions that reported at least one crash. This is the mean crash count among already-crashed sessions, not a crash rate.
+- **Avg ANRs per ANR Session** — equivalent for Application Not Responding events.
 
-**How to Analyze:**
-- Look for steadily increasing app memory over time (indicates potential leaks)
-- Identify memory spikes during specific operations
-- Pay attention to how memory behaves after screen transitions or intensive tasks
-- Watch for memory that doesn't return to baseline after operations complete
+Cards are hidden automatically when the underlying metric reports zero for the filtered scope.
 
-**Optimization Strategies:**
-- Implement proper object lifecycle management
-- Use weak references for observer patterns
-- Optimize image loading and caching
-- Dispose of resources when moving between screens
-- Consider using object pools for frequently created/destroyed objects
-- Implement memory leak detection in development builds
+## Performance Trends
 
-### Battery Utilization
+A single time-series chart that overlays selected metrics on dual Y-axes. The **KPIs** selector in the widget header controls which series are visible — CPU, FPS, Memory, Temperature, Battery, Network Upload and Network Download are available; CPU and Memory are on by default. Each visible KPI gets a Min / Max / Avg row in the stats panel below the chart.
 
-**Widget Purpose:**
-Tracks energy consumption to identify processes that may drain battery excessively.
+The X-axis bucket size is derived from the selected date range — sub-day windows render at 5-minute or 15-minute buckets, multi-week windows aggregate to hours, and multi-month windows aggregate to days.
 
-**Metrics Explained:**
-- **Battery (mAh)**: Energy consumption rate in milliampere-hours
+## Device Performance Matrix
 
-**How to Analyze:**
-- Identify patterns of high battery usage
-- Look for correlation between battery drain and specific app features
-- Compare battery usage across different app states (active, background, idle)
+A table comparing performance metrics across the devices that ran in the filtered scope. One row per device.
 
-**Optimization Strategies:**
-- Optimize network calls (batch requests, compress data)
-- Reduce location service usage when not essential
-- Implement efficient background processing
-- Optimize wake locks and sensor usage
-- Use dark mode or darker UI for OLED screens
-- Batch CPU-intensive operations
+| Column | Description |
+|---|---|
+| **Device** | Device model |
+| **CPU App (%)** | Application CPU usage, colour-coded against the configured SLA threshold |
+| **CPU System (%)** | System-level CPU usage |
+| **Memory App (MB)** | Application memory, colour-coded against the configured SLA threshold |
+| **Memory System (MB)** | System-level memory |
+| **FPS** | Frame rate, colour-coded against the configured SLA threshold |
+| **Sessions** | Session count for that device in the filtered scope |
 
-### Network Utilization
+Click any column header to sort. The dashboard-level **Device** filter intentionally does not narrow this widget — the matrix is itself the device breakdown.
 
-**Widget Purpose:**
-Monitors data transfer to identify inefficient network operations.
+## Label Page Load Time
 
-**Metrics Explained:**
-- **Network Upload (KB)**: Data sent by the application
-- **Network Download (KB)**: Data received by the application
+Duration per page transition label, captured from the `label` events recorded inside the test. The widget shows the top labels by session count by default; use the label selector inside the widget to add or remove labels from the chart.
 
-**How to Analyze:**
-- Look for unexpected or excessive data transfers
-- Identify patterns in network activity (constant polling vs. event-based)
-- Compare network usage against expected data requirements
+A horizontal SLA reference line is drawn at the configured threshold. The stats panel below the chart reports Min / Max / Avg duration per visible label.
 
-**Optimization Strategies:**
-- Implement efficient caching strategies
-- Compress network payloads
-- Use incremental data loading
-- Optimize API requests (GraphQL, partial responses)
-- Batch network requests when possible
-- Implement offline capabilities
-- Use efficient image formats and compression
+## Per-metric trend widgets
 
-### App Temperature
+Each of the eight per-metric widgets renders a time series over the selected window with the SLA threshold drawn as a coloured band, and reports Min / Max / Avg for the primary metric in the stats panel below the chart.
 
-**Widget Purpose:**
-Measures device thermal performance to identify processes causing overheating.
+| Widget | Metrics | Notes |
+|---|---|---|
+| **CPU Utilization Trend** | CPU App (%), CPU System (%) | — |
+| **Frame Rate Trends** | Current FPS, Janky Frames, Frozen Frames | — |
+| **Memory Usage** | App Memory (MB), System Memory (MB) | — |
+| **Battery Utilization** | Battery drain (mAh) | Android only |
+| **Network Utilization** | Network Upload (KB), Network Download (KB) | Separate SLA thresholds for upload and download |
+| **Battery Temperature** | Temperature (°C) | Android only |
+| **Cold Startup Time** | Cold Startup (ms) | — |
+| **Hot Startup Time** | Hot Startup (ms) | — |
 
-**Metrics Explained:**
-- **Avg. Temperature (°C)**: Current average temperature of the device
+## Compare mode
 
-**How to Analyze:**
-- Track temperature increases during specific operations
-- Identify features that consistently raise device temperature
-- Look for sustained high temperatures that could lead to thermal throttling
+Each per-metric trend widget and Label Page Load Time supports **Compare** mode. Click **Compare** in the widget header, pick a dimension, then select up to five values to overlay on the chart.
 
-**Optimization Strategies:**
-- Optimize CPU-intensive algorithms
-- Reduce sustained high CPU/GPU operations
-- Space out intensive tasks rather than running simultaneously
-- Implement adaptive performance based on device temperature
-- Consider lower quality graphics or processing when temperature is high
+Compare dimensions:
 
-### Cold Startup Time
+- **OS** — Android vs iOS
+- **Device** — for example Galaxy S23 vs Pixel 8 vs iPhone 15 Pro
+- **App Build Version** — for build-over-build comparisons
+- **Label** — for page-transition-level breakdowns
 
-**Widget Purpose:**
-Measures application launch performance from a completely shut down state.
+Compare is scoped to the widget — enabling it on one chart does not affect others. Performance Overview, Performance Trends and Device Performance Matrix do not expose Compare: the first two are summary widgets (use filters to change the data scope instead), and the matrix already breaks data down per device.
 
-**Metrics Explained:**
-- **Cold Startup (ms)**: Time taken to launch app when not in memory
+## SLA thresholds
 
-**How to Analyze:**
-- Look for consistently high startup times
-- Identify variations in startup performance
-- Compare against industry benchmarks (1-2 seconds is typically acceptable)
+SLA thresholds are configured at the **organisation level** by an admin. Once set, the same threshold is applied everywhere a metric is rendered — Performance Overview cards, Performance Trends overlays, Device Performance Matrix cells, Label Page Load Time, and the per-metric trend widgets.
 
-**Optimization Strategies:**
-- Implement lazy initialization of non-critical components
-- Defer heavy operations until after UI is visible
-- Optimize database and storage access during startup
-- Use app startup libraries to manage initialization
-- Consider using a splash screen for perceived performance
-- Reduce app dependencies and initialization chain
+Default thresholds:
 
-### Hot Startup Time
+| Metric | Green | Amber | Red |
+|---|---|---|---|
+| CPU (App) | < 15% | 15–30% | > 30% |
+| Memory (App) | < 300 MB | 300–400 MB | > 400 MB |
+| FPS | > 50 | 30–50 | < 30 |
+| Cold Startup | < 2000 ms | 2000–3000 ms | > 3000 ms |
+| Hot Startup | < 500 ms | 500–1000 ms | > 1000 ms |
+| Battery Temperature | < 40 °C | 40–45 °C | > 45 °C |
+| Label Page Load | < 2.5 s | 2.5–3.0 s | > 3.0 s |
 
-**Widget Purpose:**
-Measures application launch performance when re-opening from background.
+Thresholds render as:
 
-**Metrics Explained:**
-- **Hot Startup (ms)**: Time taken to resume app when already in memory
+- Horizontal reference lines on trend charts.
+- Coloured background bands behind the chart area.
+- Cell-level heatmap colouring on Device Performance Matrix.
+- Coloured value text on Performance Overview cards.
 
-**How to Analyze:**
-- Look for hot startup times exceeding 500ms
-- Identify inconsistency in resume performance
-- Compare against cold startup to ensure significant improvement
+Battery Utilization (mAh drain) is rendered without a threshold by default — drain varies widely by device hardware and there is no industry-standard band.
 
-**Optimization Strategies:**
-- Optimize saved state management
-- Implement efficient view restoration
-- Use lightweight persistence mechanisms
-- Consider UI state caching strategies
-- Prioritize restoring visible elements first
+:::note
+Admins can override the defaults at the organisation level. Regular users see the configured thresholds applied but cannot modify them.
+:::
 
-## Advanced Analysis Techniques
+## Sharing a dashboard
 
-### Correlation Analysis
+The URL of the dashboard preserves the test it was opened against. To share a specific view with a teammate, apply the filters you want and copy the URL — the shared dashboard opens with the same test in scope. Filter selections beyond Test Name are not round-tripped through the URL.
 
-To gain deeper insights, analyze relationships between different metrics:
+## Related
 
-1. **CPU vs. Frame Rate**: High CPU often correlates with frame drops
-2. **Memory vs. Startup Time**: Increasing memory usage may slow startup
-3. **Battery vs. Network**: Excessive network activity typically increases battery consumption
-4. **Temperature vs. Performance**: High temperatures often lead to throttling and reduced performance
-
-### Benchmark Comparison
-
-Establish baseline metrics for your application:
-
-1. **Competitor Analysis**: Compare your metrics against similar apps
-2. **Version Comparison**: Track metrics across your app versions
-3. **Device Variation**: Compare performance across different device models
-4. **User Scenario Testing**: Create specific user flows and measure performance
-
-### Performance Budgeting
-
-Set target thresholds for critical metrics:
-
-1. **Startup Budget**: Cold start < 2 seconds, hot start < 500ms
-2. **Frame Rate Budget**: Maintain 60+ FPS during animations
-3. **Memory Budget**: Keep peak memory under device-specific thresholds
-4. **Network Budget**: Limit payload sizes and request frequency
-5. **Battery Budget**: Limit battery consumption per hour of active use
-
-## Implementing Performance Improvements
-
-### Prioritization Framework
-
-When addressing performance issues:
-
-1. **User Impact**: Prioritize issues directly affecting user experience
-2. **Frequency**: Address problems that occur most frequently
-3. **Severity**: Focus on severe performance degradations first
-4. **Complexity**: Balance effort required against potential improvements
-5. **Business Impact**: Consider effects on retention, conversion, and engagement
-
-### Testing Methodology
-
-Verify improvements through rigorous testing:
-
-1. **A/B Testing**: Compare metrics between old and new implementations
-2. **Progressive Rollout**: Deploy changes to a small percentage of users first
-3. **Real-World Testing**: Test across various network conditions and devices
-4. **Automated Performance Testing**: Implement CI/CD performance checks
-
-## Continuous Monitoring
-
-For ongoing performance optimization:
-
-1. **Real User Monitoring**: Collect performance data from production users
-2. **Performance Regressions**: Set up alerts for metric degradations
-3. **Periodic Audits**: Schedule regular performance reviews
-4. **User Feedback Analysis**: Correlate performance metrics with user sentiment
-
-By leveraging these widgets and analysis techniques, you can systematically identify and address performance bottlenecks, resulting in a faster, more efficient, and battery-friendly application that provides an excellent user experience.
+- [App Performance Analytics](/support/docs/appium-app-performance-analytics/) — how to enable App Profiling on Appium tests and review per-session metrics.
+- [Analytics Overview](/support/docs/analytics-overview/) — the broader Insights module.


### PR DESCRIPTION
## Summary

Rewrites `docs/analytics-insights-app-profiling.md` for the new App Profiling dashboard shape. The existing doc was written for the prior 8-widget single-test view; the dashboard now ships four additional widgets, a dashboard-level filter bar, per-widget compare mode, and org-level SLA thresholds — none of which were covered.

## What changed

- **Frontmatter**: dropped stale Desktop keywords; added app-profiling-specific ones. `site_name` kept as `TestMu AI` to match stage convention. Other fields (`id`, `slug`, `canonical`, `url`) preserved.
- **Removed**: per-widget engineering tips ("optimization strategies", "performance budgeting", "continuous monitoring") — generic advice, not analytics documentation.
- **Added**:
  - Dashboard-level filter bar reference (Test Name, OS, Device, App Build Version, Page Label, Date Range).
  - **Performance Overview** KPI card strip (incl. honest documentation of Crash/ANR "per Crashed Session" tiles).
  - **Performance Trends** multi-KPI line chart.
  - **Device Performance Matrix** sortable per-device table with SLA heatmap.
  - **Label Page Load Time** per-label duration chart with SLA reference line.
  - **Compare mode** — per-widget OS/Device/Build/Label overlays.
  - **SLA thresholds** — default values + how each widget renders them.
- **Renamed**: "App Temperature" → "Battery Temperature" (matches UI and capability).
- **Linked**: companion doc [App Performance Analytics](/support/docs/appium-app-performance-analytics/) instead of duplicating setup/capability content.

## Out of scope

The org-admin Settings UI for SLA threshold configuration is referenced as "configured at the organisation level by an admin" without naming a specific Settings path — that admin UI lives in a different surface and should be linked from here once its own doc page lands.

Companion doc unchanged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)