### PR TITLE
docs(kane-cli): update for v0.2.11 release

### DIFF
--- a/docs/kane-cli-authentication.md
+++ b/docs/kane-cli-authentication.md
@@ -70,6 +70,10 @@ Kane CLI opens your default browser to the <BrandName /> consent page. Sign in a
 
 If you run `kane-cli login` interactively without flags, Kane CLI launches a guided login wizard that walks you through choosing a method, profile, and (for basic auth) entering credentials.
 
+:::note Headless login fix
+In v0.2.11, `kane-cli login --oauth` and username/access-key headless flows exit cleanly after authentication completes. Earlier versions could hang at this step.
+:::
+
 ---
 
 ## Basic Auth
@@ -105,6 +109,10 @@ Saved basic auth is used automatically for subsequent commands run under that pr
 ### Where to Find Your Access Key
 
 Sign in to the <BrandName /> [dashboard](https://accounts.lambdatest.com/dashboard) > **Credentials** and copy your access key. Treat it like a password — anyone with your username and access key can run tests on your account.
+
+:::tip Credential validation
+As of v0.2.11, KaneAI validates your username and access key before saving them. If either is wrong you'll see an inline error and can correct it immediately — bad credentials are never written to disk.
+:::
 
 ---
 
@@ -150,6 +158,10 @@ Removes the stored credentials for that profile.
 ### Run Against a Specific Profile Without Switching
 
 A few commands accept `--profile <name>` so you can target a profile for a single invocation without changing the active one. This is supported on `kane-cli login`, `kane-cli whoami`, and `kane-cli balance`. For other commands, use `kane-cli profiles switch` first.
+
+:::note Profile isolation
+As of v0.2.11, switching to a different profile or account resets the active project and folder selection. The previous profile's project is never carried over.
+:::
 
 ---
 

--- a/docs/kane-cli-changelog.md
+++ b/docs/kane-cli-changelog.md
@@ -66,6 +66,40 @@ Check your current version:
 kane-cli --version
 ```
 
+## 0.2.11 — 2026-05-04
+
+**Setup & project/folder**
+- Project list loads instantly even on large accounts; type to search immediately.
+- KaneAI blocks test execution until a project and folder are selected, preventing lost runs.
+- Press **Esc** during setup to accept "KaneAI Generated" / "Untitled" defaults and move on immediately.
+- Switching profiles no longer carries the previous profile's project selection across.
+
+**Login**
+- Invalid username or access key is reported immediately so you can correct it before credentials are saved.
+- `kane-cli login --oauth` and username/access-key headless login no longer hang at completion.
+
+**In-browser indicator**
+- The floating badge now streams the current reasoning step (e.g. "Clicking the Add to cart button…") in real time.
+- Shows an animated "Thinking…" state between steps.
+- No longer appears in the macOS Dock or Windows/Linux taskbar.
+- Hides automatically when focus leaves Chrome and reappears when you return.
+
+**TUI / help**
+- `/help` opens a tabbed screen: Commands, Shortcuts, Setup, About.
+- Every slash command shows a confirmation box (✓ / ✗) with the outcome.
+- Breadcrumb at the bottom tracks your position in any flow.
+- Consistent keyboard-shortcut hints on every screen.
+
+**Text editing**
+- Cursor is visible even when the input box is empty.
+- **Tab** completes a slash command; **Enter** runs it (previously required two Enter presses).
+- Word-jump and word-delete shortcuts (Option/Ctrl + Arrow, Option/Ctrl + Delete) work correctly on macOS, Windows, and Linux.
+
+**New defaults**
+- Code Export is **on** by default.
+- Run mode defaults to **Testing** (uploads to TMS automatically).
+- A one-time upgrade summary is shown on first launch; use `/config` to revert any default.
+
 ---
 
 ## Reporting Issues

--- a/docs/kane-cli-cli-reference.md
+++ b/docs/kane-cli-cli-reference.md
@@ -212,6 +212,12 @@ kane-cli feedback \
 | `/clear` | | Clear chat history |
 | `/exit` | | Quit Kane CLI |
 
+:::tip Help screen (v0.2.11+)
+Type `/help` to open a tabbed help screen covering **Commands**, **Shortcuts**, **Setup**, and **About** — all in one place.
+
+Every slash command now shows a small confirmation box (✓ or ✗) after it runs, e.g. "Project switched to My Project". A breadcrumb at the bottom of the screen tracks where you are in any multi-step flow.
+:::
+
 ---
 
 ## Keyboard Shortcuts
@@ -225,6 +231,15 @@ kane-cli feedback \
 | Esc | Go back / close picker |
 | Up / Down | Navigate menu or input history |
 | Tab | Accept autocomplete |
+
+:::note Shortcut improvements in v0.2.11
+- **Tab** — auto-complete a slash command (no longer requires pressing Enter twice to run it; Tab fills, Enter runs).
+- **Word jump** — Option+Arrow (macOS) / Ctrl+Arrow (Windows, Linux) moves the cursor by word.
+- **Word delete** — Option+Delete (macOS) / Ctrl+Backspace (Windows, Linux) deletes the previous word.
+- **Esc** during setup — accepts "KaneAI Generated" / "Untitled" defaults immediately.
+
+These shortcuts work consistently across macOS, Windows, and Linux.
+:::
 
 ---
 

--- a/docs/kane-cli-configuration.md
+++ b/docs/kane-cli-configuration.md
@@ -107,6 +107,17 @@ Empty fields are shown as `(none)`. The `chrome` path is empty by default, in wh
 | `code_export.language` | `"python"` | `"python"` | Output language for generated code. Only `python` is supported. | `--code-language <lang>` |
 | `code_export.skip_validation` | boolean | `true` | Skip post-codegen worker-side validation. | TUI menu, or `--skip-code-validation` |
 
+:::note New defaults in v0.2.11
+Two settings changed their defaults in v0.2.11:
+
+| Setting | Old default | New default |
+|---|---|---|
+| `codeExport` | off | **on** |
+| `runMode` | exploration | **testing** (uploads to TMS) |
+
+On first launch after upgrading, KaneAI shows a one-time summary of these changes and explains how to revert them via `/config`.
+:::
+
 ---
 
 ## Updating Settings

--- a/docs/kane-cli-tms-integration.md
+++ b/docs/kane-cli-tms-integration.md
@@ -109,6 +109,12 @@ If you try to set a folder before choosing a project, Kane CLI asks you to pick 
 
 After a successful upload, Kane CLI prints two links to the terminal (see [Share Links at Session Exit](#share-links-at-session-exit)). Both lead into the <BrandName /> Test Manager for the test case that was just created.
 
+:::note Project and folder are required (v0.2.11+)
+KaneAI will not start a test run until both a project and a folder are selected. If neither is set you'll be taken through the setup flow first, so your results always land in the right place in TMS.
+
+During setup, press **Esc** at any prompt to instantly accept the defaults ("KaneAI Generated" project and "Untitled" folder). KaneAI confirms what it picked before continuing.
+:::
+
 ---
 
 ## Code Export
@@ -151,6 +157,10 @@ kane-cli run "Add an item to the cart" \
 Generated code is downloaded into a local directory under your session, by default `~/.testmuai/kaneai/sessions/<session-id>/code-export/`. At session exit Kane CLI prints a `CodeExport` line in the links box pointing to that directory.
 
 The same code is also available alongside the test case in Test Manager.
+
+:::note Default changed in v0.2.11
+Code Export is **on by default** starting in v0.2.11. Every test run produces Python (or JavaScript) automation code automatically. To turn it off, run `/config` and toggle the `codeExport` setting.
+:::
 
 ---
 

--- a/docs/kane-cli-troubleshooting.md
+++ b/docs/kane-cli-troubleshooting.md
@@ -155,6 +155,12 @@ Get credentials from the <BrandName /> [dashboard](https://accounts.lambdatest.c
 
 **Fix:** Verify your credentials on the <BrandName /> dashboard. Username and access key are case-sensitive. Make sure you're using the access key (not the password).
 
+**Bad credentials saved without warning**
+If you're on v0.2.10 or earlier and your username or access key was accepted silently but fails at runtime, upgrade to v0.2.11. From v0.2.11 onward, credentials are validated immediately on entry and rejected inline if incorrect.
+
+**`kane-cli login --oauth` hangs**
+This was a bug in v0.2.10 and earlier. Upgrade to v0.2.11 where headless OAuth and username/access-key login flows exit cleanly.
+
 ---
 
 ## Run Issues


### PR DESCRIPTION
## Summary

- Auto-generated docs update for kane-cli v0.2.11, produced by the docs-sync pipeline being added in [LambdatestIncPrivate/v16 PR #506](https://github.com/LambdatestIncPrivate/v16/pull/506).
- Sonnet 4.6 picked which pages to touch from the v0.2.11 release notes; a deterministic applier spliced the additions in while protecting frontmatter, imports, and JSON-LD `<script>` blocks (verified byte-identical).
- This PR is a **dry-run for review** — please flag any prose-quality or page-placement issues that should drive prompt adjustments before the pipeline goes live.

## Changes by file

| File | Section | What was added |
|---|---|---|
| `kane-cli-changelog.md` | After `## Stay Updated` (placement note below) | Full `## 0.2.11 — 2026-05-04` entry, grouped by area (Setup, Login, In-browser indicator, TUI/help, Text editing, New defaults) |
| `kane-cli-authentication.md` | `## OAuth Login` | `:::note` about the headless login hang fix |
| `kane-cli-authentication.md` | `## Basic Auth` | `:::tip` about inline credential validation |
| `kane-cli-authentication.md` | `## Profiles` | `:::note` about profile isolation for project/folder state |
| `kane-cli-cli-reference.md` | `## TUI Slash Commands` | `:::tip` about the new tabbed `/help` screen and per-command confirmation boxes |
| `kane-cli-cli-reference.md` | `## Keyboard Shortcuts` | `:::note` listing new Tab/Enter, word-jump, word-delete, and Esc-for-defaults shortcuts |
| `kane-cli-configuration.md` | `## Settings Reference` | `:::note` with a markdown table showing the `codeExport` and `runMode` default flips |
| `kane-cli-tms-integration.md` | `## Choosing Where Uploads Land` | `:::note` about project/folder enforcement + Esc-for-defaults |
| `kane-cli-tms-integration.md` | `## Code Export` | `:::note` about Code Export now being ON by default |
| `kane-cli-troubleshooting.md` | `## Authentication Issues` | Two entries for users on v0.2.10 or earlier (silent-bad-creds, hanging headless login) |

**Net**: 6 files, +88 lines, 0 deletions. All `append_to_section` — no existing prose was replaced or removed.

## One known-suboptimal placement

The `kane-cli-changelog.md` entry landed *after* the `## Stay Updated` section because that page has no pre-existing version-history anchor. The page itself is currently a stub pointing at GitHub releases. Two options for reviewer:

1. Move the new `## 0.2.11` block to the top of the page (just below the intro line)
2. Drop the changelog edit entirely and keep `kane-cli-changelog.md` as a thin pointer to GitHub releases — I'll patch the pipeline's system prompt to skip that file going forward

Either way, prefer to make this call here so the pipeline learns from the decision.

## Pipeline guarantees verified

- Frontmatter, imports block, and JSON-LD `<script>` byte-identical to `stage` in all 6 modified files
- Only `kane-cli-*.md` files touched
- No new files created, no files deleted
- Two redirect-stub pages (`kane-cli-agent-output.md`, `kane-cli-getting-started.md`) correctly skipped

## Test plan

- [ ] Build the site locally and confirm all 6 pages render without MDX errors
- [ ] Scan for prose-style mismatches vs surrounding sections
- [ ] Decide on the `kane-cli-changelog.md` placement (move vs drop — see above)
- [ ] Flag any factual inaccuracies vs the actual 0.2.11 behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)