### PR TITLE
Fix Kane CLI skill install URLs and add npx installer

### DIFF
--- a/docs/kane-cli-skills.mdx
+++ b/docs/kane-cli-skills.mdx
@@ -20,6 +20,18 @@ Skills are plain markdown files. Review and customize them by editing the instal
 
 ---
 
+## Install
+
+The quickest way to install the Kane CLI skill globally for all supported agents (Claude Code, Codex CLI, and Gemini CLI) in one command:
+
+```bash
+npx @testmuai/kane-cli-skill
+```
+
+If you prefer to install manually for a specific agent, follow the instructions below.
+
+---
+
 ## Install by Agent
 
 <Tabs>
@@ -32,7 +44,7 @@ The Kane CLI skill for Claude Code is a `SKILL.md` file placed in your skills di
 ```bash
 mkdir -p ~/.claude/skills/kane-cli
 curl -o ~/.claude/skills/kane-cli/SKILL.md \
-  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skills/claude/SKILL.md
+  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skill-installer/skills/SKILL.md
 ```
 
 **Project-level install** (available only in this project):
@@ -40,7 +52,7 @@ curl -o ~/.claude/skills/kane-cli/SKILL.md \
 ```bash
 mkdir -p .claude/skills/kane-cli
 curl -o .claude/skills/kane-cli/SKILL.md \
-  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skills/claude/SKILL.md
+  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skill-installer/skills/SKILL.md
 ```
 
 After installing, Claude Code automatically loads the skill. No restart required.
@@ -72,7 +84,7 @@ The Kane CLI skill for Codex CLI is appended to your `AGENTS.md` file. Codex rea
 
 ```bash
 curl -o /tmp/kane-cli-agents.md \
-  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skills/codex/AGENTS.md
+  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skill-installer/skills/SKILL.md
 
 # Append to global AGENTS.md (creates the file if it doesn't exist)
 cat /tmp/kane-cli-agents.md >> ~/.codex/AGENTS.md
@@ -82,7 +94,7 @@ cat /tmp/kane-cli-agents.md >> ~/.codex/AGENTS.md
 
 ```bash
 curl -o /tmp/kane-cli-agents.md \
-  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skills/codex/AGENTS.md
+  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skill-installer/skills/SKILL.md
 
 cat /tmp/kane-cli-agents.md >> AGENTS.md
 ```
@@ -112,7 +124,7 @@ The Kane CLI skill for Gemini CLI is a `SKILL.md` file placed in your Gemini ski
 ```bash
 mkdir -p ~/.gemini/skills/kane-cli
 curl -o ~/.gemini/skills/kane-cli/SKILL.md \
-  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skills/gemini/SKILL.md
+  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skill-installer/skills/SKILL.md
 ```
 
 **Project-level install**:
@@ -120,7 +132,7 @@ curl -o ~/.gemini/skills/kane-cli/SKILL.md \
 ```bash
 mkdir -p .gemini/skills/kane-cli
 curl -o .gemini/skills/kane-cli/SKILL.md \
-  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skills/gemini/SKILL.md
+  https://raw.githubusercontent.com/LambdaTest/kane-cli/main/skill-installer/skills/SKILL.md
 ```
 
 **What Gemini can do with this skill:**


### PR DESCRIPTION
## Summary
- Fixed incorrect GitHub raw URLs for skill downloads across Claude Code, Codex CLI, and Gemini CLI install instructions
- Updated all URLs from old paths (`skills/claude/`, `skills/codex/`, `skills/gemini/`) to the correct path (`skill-installer/skills/SKILL.md`)
- Added `npx @testmuai/kane-cli-skill` as the recommended one-command global install method at the top of the page

## Test plan
- [ ] Verify the skills page renders correctly on local dev server
- [ ] Confirm the curl URLs point to valid GitHub raw content
- [ ] Test `npx @testmuai/kane-cli-skill` command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)