### PR TITLE
Fix: API Try It double-slash URL causing 404 errors

### DIFF
--- a/src/component/ApiReference/TryItModal.js
+++ b/src/component/ApiReference/TryItModal.js
@@ -76,7 +76,7 @@ function CodeHighlight({ code, language }) {
 }
 
 function buildCurl(endpoint, username, password, params, baseUrl) {
-  let url = `${baseUrl || endpoint.baseUrl}${endpoint.path}`;
+  let url = `${(baseUrl || endpoint.baseUrl).replace(/\/+$/, '')}${endpoint.path}`;
   if (endpoint.pathParams) {
     endpoint.pathParams.forEach((p) => {
       url = url.replace(`{${p.name}}`, params[p.name] || `{${p.name}}`);
@@ -332,7 +332,7 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
     setLoading(true);
     setResponse(null);
 
-    let url = `${selectedServer}${endpoint.path}`;
+    let url = `${selectedServer.replace(/\/+$/, '')}${endpoint.path}`;
     if (endpoint.pathParams) {
       endpoint.pathParams.forEach((p) => {
         url = url.replace(`{${p.name}}`, params[p.name] || '');


### PR DESCRIPTION
## Summary
- **Bug**: The "Send" button on API documentation pages (Try It feature) was producing malformed URLs with double slashes (e.g. `test-manager-api.lambdatest.com//api/v1/...`), resulting in 404 errors that surfaced as CORS / "Failed to fetch" errors in the browser.
- **Root cause**: OpenAPI specs for Test Manager, User Management, and Audit Logs have a trailing `/` in their server URL. When concatenated with endpoint paths (which start with `/`), this produced `//` in the URL.
- **Fix**: Strip trailing slashes from the server base URL before concatenating with the endpoint path in both `handleSend()` and `buildCurl()` in `TryItModal.js`.

## Affected APIs
| API | Before (broken) | After (fixed) |
|-----|-----------------|---------------|
| Test Manager | `https://test-manager-api.lambdatest.com//api/v1/...` → 404 | `https://test-manager-api.lambdatest.com/api/v1/...` → ✅ |
| User Management | `https://auth.lambdatest.com//api/...` → 404 | `https://auth.lambdatest.com/api/...` → ✅ |
| Audit Logs | `https://audit-logs.lambdatest.com//api/...` → 404 | `https://audit-logs.lambdatest.com/api/...` → ✅ |

Other 9 APIs (Selenium, Screenshots, App Automation, SmartUI, Cypress, HyperExecute, Accessibility, Analytics, Performance) are unaffected — their server URLs had no trailing slash.

## Test plan
- [ ] Open Test Manager API page → Try It → Send → verify single slash in URL and successful response
- [ ] Open User Management API page → Try It → Send → verify same
- [ ] Open Selenium Automation API page → Try It → Send → verify still works as before
- [ ] Check generated cURL commands also have correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)