### PR TITLE
Fix: API Try It double-slash URLs (complete) + render body fields for incomplete specs [testmuCom]

### DIFF
--- a/scripts/build-api-data.js
+++ b/scripts/build-api-data.js
@@ -147,7 +147,7 @@ function extractRequestBody(requestBody, spec) {
   }
   const props = schema.properties || {};
   const required = schema.required || [];
-  const properties = Object.entries(props).map(([name, propSchema]) => {
+  let properties = Object.entries(props).map(([name, propSchema]) => {
     let resolved = propSchema.$ref ? resolveRef(propSchema.$ref, spec) || propSchema : propSchema;
     const hasEnum = Array.isArray(resolved.enum) && resolved.enum.length > 0;
     const type = resolved.type || 'string';
@@ -155,6 +155,24 @@ function extractRequestBody(requestBody, spec) {
     const displayType = hasEnum ? `enum<${type}>` : (format ? `${type}<${format}>` : type);
     return { name, type: displayType, required: required.includes(name), description: resolved.description || '', ...(hasEnum && { enum: resolved.enum }) };
   });
+
+  // Fallback for specs that declare `type: object` without `properties`
+  // (e.g. PUT /api/v1/projects in test_management spec) — derive fields from
+  // the example block so the Try It modal can render editable inputs.
+  if (properties.length === 0) {
+    const example = bodyContent.example ?? schema.example;
+    if (example && typeof example === 'object' && !Array.isArray(example)) {
+      properties = Object.entries(example).map(([name, value]) => {
+        let type = 'string';
+        if (typeof value === 'number') type = Number.isInteger(value) ? 'integer' : 'number';
+        else if (typeof value === 'boolean') type = 'boolean';
+        else if (Array.isArray(value)) type = 'array';
+        else if (typeof value === 'object' && value !== null) type = 'object';
+        return { name, type, required: false, description: '' };
+      });
+    }
+  }
+
   return { contentType, description: requestBody.description || '', properties };
 }
 

--- a/scripts/build-api-data.js
+++ b/scripts/build-api-data.js
@@ -85,7 +85,7 @@ function flattenSpec(spec) {
       if (!['get', 'post', 'put', 'delete', 'patch'].includes(method)) continue;
       endpoints.push({
         method: method.toUpperCase(),
-        path: pth,
+        path: pth.startsWith('/') ? pth : `/${pth}`,
         summary: op.summary || '',
         description: op.description || op.summary || '',
         tags: op.tags || [],
@@ -128,7 +128,7 @@ function resolveRef(ref, spec) {
   return node || null;
 }
 
-function extractRequestBody(requestBody, spec) {
+function extractRequestBody(requestBody, spec, ctx = {}) {
   if (!requestBody) return null;
   const content = requestBody.content || {};
   const contentType = Object.keys(content)[0] || 'application/json';
@@ -156,9 +156,10 @@ function extractRequestBody(requestBody, spec) {
     return { name, type: displayType, required: required.includes(name), description: resolved.description || '', ...(hasEnum && { enum: resolved.enum }) };
   });
 
-  // Fallback for specs that declare `type: object` without `properties`
-  // (e.g. PUT /api/v1/projects in test_management spec) — derive fields from
-  // the example block so the Try It modal can render editable inputs.
+  // Fallback for specs that declare `type: object` without `properties` —
+  // derive fields from the example block so the Try It modal can render
+  // editable inputs. Inferred types and required flags are best-effort;
+  // long-term fix is for spec authors to add proper `properties`.
   if (properties.length === 0) {
     const example = bodyContent.example ?? schema.example;
     if (example && typeof example === 'object' && !Array.isArray(example)) {
@@ -170,6 +171,11 @@ function extractRequestBody(requestBody, spec) {
         else if (typeof value === 'object' && value !== null) type = 'object';
         return { name, type, required: false, description: '' };
       });
+      if (properties.length > 0) {
+        const loc = ctx.method && ctx.path ? `${ctx.method} ${ctx.path}` : '(unknown endpoint)';
+        const src = ctx.specName ? ` [${ctx.specName}]` : '';
+        console.warn(`⚠️  ${loc}${src}: requestBody has no schema.properties; derived ${properties.length} field(s) from example. Spec should declare properties for accurate types/required/descriptions.`);
+      }
     }
   }
 
@@ -317,7 +323,7 @@ async function main() {
           ...((auth.length || ep.securityAuth?.length) && { auth: [...(ep.securityAuth || []), ...auth] }),
           ...(pathParams.length && { pathParams }),
           ...(queryParams.length && { queryParams }),
-          ...(ep.requestBody && { requestBody: extractRequestBody(ep.requestBody, spec) }),
+          ...(ep.requestBody && { requestBody: extractRequestBody(ep.requestBody, spec, { specName: name, method: ep.method, path: ep.path }) }),
           responses: simplifyResponses(ep.responses, spec),
           responseSchema: extractResponseSchema(ep.responses, spec),
         };

--- a/src/component/ApiReference/EndpointDetail.js
+++ b/src/component/ApiReference/EndpointDetail.js
@@ -558,11 +558,11 @@ function UrlBar({ endpoint, onTryIt }) {
   // Fallback if no servers match (shouldn't happen, but safety net)
   const effectiveServers = servers.length > 0 ? servers : allServers.slice(0, 1);
 
-  const [selectedBase, setSelectedBase] = useState(effectiveServers[0].url);
+  const [selectedBase, setSelectedBase] = useState(effectiveServers[0].url.replace(/\/+$/, ''));
   const [copied, setCopied] = useState(false);
 
   function copyUrl() {
-    const url = `${selectedBase}${endpoint.path}`;
+    const url = `${selectedBase.replace(/\/+$/, '')}${endpoint.path}`;
     try {
       navigator.clipboard.writeText(url).catch(() => {
         const ta = document.createElement('textarea');
@@ -576,7 +576,7 @@ function UrlBar({ endpoint, onTryIt }) {
 
   // Keep selectedBase in sync when endpoint changes
   React.useEffect(() => {
-    setSelectedBase(effectiveServers[0].url);
+    setSelectedBase(effectiveServers[0].url.replace(/\/+$/, ''));
   }, [endpoint.path, endpoint.method]);
 
   const segments = parsePathSegments(endpoint.path || '');
@@ -610,9 +610,10 @@ function UrlBar({ endpoint, onTryIt }) {
               flexShrink: 0,
             }}
           >
-            {effectiveServers.map((s) => (
-              <option key={s.url} value={s.url}>{s.url}</option>
-            ))}
+            {effectiveServers.map((s) => {
+              const cleanUrl = s.url.replace(/\/+$/, '');
+              return <option key={cleanUrl} value={cleanUrl}>{cleanUrl}</option>;
+            })}
           </select>
 
           {/* Path segments */}

--- a/src/component/ApiReference/EndpointDetail.js
+++ b/src/component/ApiReference/EndpointDetail.js
@@ -558,7 +558,7 @@ function UrlBar({ endpoint, onTryIt }) {
   // Fallback if no servers match (shouldn't happen, but safety net)
   const effectiveServers = servers.length > 0 ? servers : allServers.slice(0, 1);
 
-  const [selectedBase, setSelectedBase] = useState(effectiveServers[0].url.replace(/\/+$/, ''));
+  const [selectedBase, setSelectedBase] = useState((effectiveServers[0]?.url || '').replace(/\/+$/, ''));
   const [copied, setCopied] = useState(false);
 
   function copyUrl() {
@@ -576,7 +576,7 @@ function UrlBar({ endpoint, onTryIt }) {
 
   // Keep selectedBase in sync when endpoint changes
   React.useEffect(() => {
-    setSelectedBase(effectiveServers[0].url.replace(/\/+$/, ''));
+    setSelectedBase((effectiveServers[0]?.url || '').replace(/\/+$/, ''));
   }, [endpoint.path, endpoint.method]);
 
   const segments = parsePathSegments(endpoint.path || '');

--- a/src/component/ApiReference/TryItModal.js
+++ b/src/component/ApiReference/TryItModal.js
@@ -76,7 +76,7 @@ function CodeHighlight({ code, language }) {
 }
 
 function buildCurl(endpoint, username, password, params, baseUrl) {
-  let url = `${baseUrl || endpoint.baseUrl}${endpoint.path}`;
+  let url = `${(baseUrl || endpoint.baseUrl || '').replace(/\/+$/, '')}${endpoint.path}`;
   if (endpoint.pathParams) {
     endpoint.pathParams.forEach((p) => {
       url = url.replace(`{${p.name}}`, params[p.name] || `{${p.name}}`);
@@ -292,7 +292,7 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
   const [respCopied, setRespCopied] = useState(false);
   const [liveRespCopied, setLiveRespCopied] = useState(false);
   const [localLang, setLocalLang] = useState('cURL');
-  const [selectedServer, setSelectedServer] = useState(effectiveServers[0]?.url || endpoint.baseUrl);
+  const [selectedServer, setSelectedServer] = useState((effectiveServers[0]?.url || endpoint.baseUrl || '').replace(/\/+$/, ''));
   const selectedLang = selectedLangProp !== undefined ? selectedLangProp : localLang;
   const setSelectedLang = onLangChange || setLocalLang;
   const [langDropdownOpen, setLangDropdownOpen] = useState(false);
@@ -320,7 +320,7 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
 
   // Update selected server when endpoint changes
   useEffect(() => {
-    setSelectedServer(effectiveServers[0]?.url || endpoint.baseUrl || '');
+    setSelectedServer((effectiveServers[0]?.url || endpoint.baseUrl || '').replace(/\/+$/, ''));
   }, [effectiveServers, endpoint.baseUrl]);
 
 
@@ -332,7 +332,7 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
     setLoading(true);
     setResponse(null);
 
-    let url = `${selectedServer}${endpoint.path}`;
+    let url = `${selectedServer.replace(/\/+$/, '')}${endpoint.path}`;
     if (endpoint.pathParams) {
       endpoint.pathParams.forEach((p) => {
         url = url.replace(`{${p.name}}`, params[p.name] || '');
@@ -440,9 +440,10 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
                   maxWidth: '100%',
                 }}
               >
-                {effectiveServers.map((s) => (
-                  <option key={s.url} value={s.url}>{s.url}</option>
-                ))}
+                {effectiveServers.map((s) => {
+                  const cleanUrl = s.url.replace(/\/+$/, '');
+                  return <option key={cleanUrl} value={cleanUrl}>{cleanUrl}</option>;
+                })}
               </select>
             ) : (
               <span style={{ fontSize: '13px', fontFamily: 'monospace', color: 'var(--ifm-color-emphasis-800)' }}>{selectedServer}</span>

--- a/src/component/ApiReference/langUtils.js
+++ b/src/component/ApiReference/langUtils.js
@@ -26,7 +26,7 @@ export function generateCodeExample(endpoint, language, { username, password, pa
   const methodLower = endpoint.method.toLowerCase();
 
   // Build URL with path params substituted
-  let url = `${endpoint.baseUrl}${endpoint.path}`;
+  let url = `${(endpoint.baseUrl || '').replace(/\/+$/, '')}${endpoint.path}`;
   if (endpoint.pathParams) {
     endpoint.pathParams.forEach((p) => {
       url = url.replace(`{${p.name}}`, (params && params[p.name]) || `{${p.name}}`);


### PR DESCRIPTION
## Summary

Port of [#2956](https://github.com/LambdaTest/documentation/pull/2956) (currently open against `stage`) to the `testmuCom` branch. Identical 4-file, +44/-18 change set — three cherry-picked commits, no behavioral divergence.

Two related fixes for the API Reference Try It experience:

1. **Trailing-slash double-slash fix** — covers all 10 URL-construction sites across 3 files
2. **Render body fields when OpenAPI spec omits `schema.properties`** — defensive fallback that uses the spec's `example` block to derive fields, unblocking 19 endpoints
3. **Hardening** — defensive guards on `selectedBase`, leading-slash normalization on endpoint paths, and a build-time warning when properties are derived from `example`

---

## Fix 1 — Trailing-slash double-slash (3 files, 10 sites)

Three OpenAPI specs (Test Manager, User Management, Audit Logs) declare server URLs ending with `/`. Concatenating with `endpoint.path` (which starts with `/`) produced `//api/v1/...`, surfacing as 404s / "Failed to fetch" / CORS errors in the browser.

| File | Sites |
|---|---|
| `TryItModal.js` | 5: `buildCurl`, `selectedServer` initial state, useEffect sync, send-request URL, dropdown `<option>` values |
| `EndpointDetail.js` | 4: `selectedBase` initial state, useEffect sync, `copyUrl`, dropdown `<option>` values |
| `langUtils.js` | 1: `generateCodeExample` (covers all language snippets) |

**Approach:** strip trailing slash at two layers — at the source (state + `<option>` values) so the URL bar displays cleanly, and again at concatenation sites as defense in depth. `.replace(/\/+$/, '')` is a no-op when no trailing slash exists, so APIs without the defect are unaffected.

**Affected APIs:** Test Manager (`test-manager-api.lambdatest.com/`), User Management (`auth.lambdatest.com/`), Audit logs (`audit-logs.lambdatest.com/`).

---

## Fix 2 — Render body fields for `properties`-less request bodies (1 file)

Several OpenAPI specs (e.g. `PUT /api/v1/projects`, `PUT /api/v1/folder`) define request bodies as:
```yaml
requestBody:
  content:
    application/json:
      schema:
        type: object       # no properties defined
      example:
        id: 'folder_id'
        name: ...
```

Our `extractRequestBody` only reads `schema.properties`, so the Try It modal rendered **zero body fields** for these endpoints — users couldn't construct a valid request body and got 400 errors.

**Impact: 19 endpoints affected** across Test Manager, User Management, and App Automation.

**Fix:** in `scripts/build-api-data.js`, when properties come up empty AND `bodyContent.example` (or `schema.example`) is a plain object, derive a property list from the example's keys. Type inferred from value shape (`string` / `number` / `integer` / `boolean` / `array` / `object`).

- Only triggers when properties are missing — no regression on well-defined specs
- Inferred fields have `required: false` and blank description (spec doesn't carry this when `properties` is omitted)
- Long-term fix is for backend teams to add `properties` blocks to the upstream OpenAPI specs

---

## Fix 3 — Hardening / defensive guards

No behavior change for current data; all three are defense-in-depth.

1. **`scripts/build-api-data.js` (`extractRequestBody` fallback):** emit `console.warn` naming the spec / method / path when fields are derived from `example` rather than `schema.properties`. Makes spec defects discoverable in the build log.
2. **`scripts/build-api-data.js` (`flattenSpec`):** normalize endpoint paths to always start with `/`. Pre-fix, a trailing slash on the base URL silently compensated for a missing leading slash on the path; post-fix a malformed spec would produce `https://host.comv1/foo`. None of the current 220 endpoints hit this case — purely defensive against future spec drift.
3. **`src/component/ApiReference/EndpointDetail.js` (`selectedBase`):** use `(effectiveServers[0]?.url || '').replace(...)` matching the defensive pattern already used in `TryItModal.js`. Pre-fix `useState(effectiveServers[0].url)` silently accepted undefined; post-fix `.replace()` would throw `TypeError` on the same edge case.

---

## Verified working (from #2956)

- Test Manager `PUT /api/v1/folder` and `PUT /api/v1/projects` — body fields render, URL clean, real 200 response
- All affected APIs no longer show `//` anywhere (URL bar, dropdown, copy, code examples, modal, sent request)
- APIs without trailing slashes (Selenium, Build, HyperExecute) — unchanged, no regression

## Test plan
- [ ] Dev: `npm start` boots, prebuild regenerates API data
- [ ] Visit any Test Manager / User Management / Audit Logs endpoint — verify no `//` in URL bar, dropdown, code examples, Try It modal
- [ ] Open Update Folder By ID and Update Project By ID — verify body fields are rendered (id, name, description, etc.)
- [ ] Send a real request with valid credentials — should reach the server (200/4xx based on payload), not 404
- [ ] Regression: open a Selenium or Build API endpoint — URL/fields unchanged from current production
- [ ] `npm run build` completes successfully

## Related
- Sibling PR for `stage`: #2956

🤖 Generated with [Claude Code](https://claude.com/claude-code)