### PR TITLE
fix: show Browser Testing and Private Cloud in Real Device sidebar

### DIFF
--- a/sidebars-unified.js
+++ b/sidebars-unified.js
@@ -69,7 +69,7 @@ const docsSidebar = [
   },
   {
     type: 'category', label: 'Real Device', collapsible: true, collapsed: true,
-    items: items(s.RealDeviceSidebar),
+    items: s.RealDeviceSidebar.slice(1).flat(),
   },
   {
     type: 'category', label: 'Test Manager', collapsible: true, collapsed: true,


### PR DESCRIPTION
## Summary
- **Browser Testing** and **Private Cloud** categories were missing from the Real Device sidebar on stage
- Root cause: `items()` helper in `sidebars-unified.js` only extracts `rest[0]` (the first nested array), but `RealDeviceSidebar` has 3 arrays — App Testing, Browser Testing, and Private Cloud
- Fix: use `.slice(1).flat()` for RealDeviceSidebar to include all categories

## Test plan
- [ ] Verify Real Device sidebar shows all 3 categories: App Testing, Browser Testing, Private Cloud
- [ ] Verify other sidebars (Integrations, VisualUI) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)