### PR TITLE
docs(kane-cli): update for v0.3.3 release

### DIFF
--- a/docs/kane-cli-testmd.md
+++ b/docs/kane-cli-testmd.md
@@ -172,6 +172,13 @@ A one-line tweak at the top of a 20-step test re-authors all 20 steps on the nex
 | Force full re-authoring | Use `--author` flag for one run |
 | Wipe cache entirely | Run `rm -rf output-<stem>/` |
 
+:::note Replay accuracy improvements (v0.3.3)
+Two fixes make replay results more consistent with the original run:
+
+- **Variables carry through correctly** — values set earlier in a test are now passed to the runner during replay, so variable-dependent steps behave the same as they did when the flow was first recorded.
+- **AI-driven steps use AI intent** — when kane-cli interprets a step, it now uses the AI's own understanding of the intent rather than the human-written description, producing more reliable browser actions on replay.
+:::
+
 ---
 
 ## Reusing Flows with `@import`

--- a/docs/kane-cli-variables-and-context.md
+++ b/docs/kane-cli-variables-and-context.md
@@ -169,6 +169,10 @@ Secret values are masked in displayed output and logs, and are routed to the <Br
 Do not commit credential files to version control. Add `.testmuai/variables/` to your `.gitignore`, or use environment variable substitution in CI/CD.
 :::
 
+:::note v0.3.3 fix
+In replay mode, variable values set earlier in a test are now correctly passed to the runner for subsequent steps. If you observed variables resolving as empty or stale during `testmd run`, upgrading to v0.3.3 resolves this.
+:::
+
 ---
 
 ## Context Files


### PR DESCRIPTION
## Summary

Sample PR showing what the auto-docs-sync pipeline ([v16 PR #506](https://github.com/LambdatestIncPrivate/v16/pull/506)) produces for the kane-cli **0.3.3** release. Generated by running `scripts/release-notes/src/docs-pr.ts` against the [published 0.3.3 release notes](https://github.com/LambdaTest/kane-cli/releases/tag/0.3.3) + a fresh `LambdaTest/documentation:stage` clone.

This is a **dry-run for review** — please flag any prose-quality or page-placement issues. The pipeline goes live once `DOCUMENTATION_REPO_TOKEN` is provisioned in v16 secrets.

## Generation details

- Version: `0.3.3`
- Model: Claude Sonnet 4.6
- 2 ops, **both `append_to_section`** — no destructive replaces
- Protected zone (frontmatter + imports + JSON-LD `<script>`) byte-identical in both modified files
- The applier refused to touch the 2 `<Redirect/>` stub pages

## Changes by file

| File                                | Anchor section               | What was added                                                      |
| ----------------------------------- | ---------------------------- | ------------------------------------------------------------------- |
| `kane-cli-testmd.md`                | `## Replay and Cascade Rule` | `:::note` summarizing both 0.3.3 replay-accuracy fixes              |
| `kane-cli-variables-and-context.md` | `## Variables`               | `:::note` on the replay-mode variable-passing fix + upgrade pointer |

**Net**: 2 files, +11 lines, 0 deletions.

## What changed since the first sample

This regenerates after two prompt fixes landed on the [v16 #506](https://github.com/LambdatestIncPrivate/v16/pull/506) branch, both driven by review of the earlier sample:

1. **Changelog page is no longer touched.** `kane-cli-changelog.md` deliberately delegates version history to GitHub releases ("Full release notes and version history are published on GitHub"), so the pipeline now skips it instead of appending a per-version block that landed mid-page after `## Stay Updated`.
2. **Exact binary names.** The planner is now instructed to copy command/flag/binary spellings verbatim from neighboring docs — the earlier sample had written `kane --version` where every other page uses `kane-cli --version`.

## A note on determinism

The planner is LLM-driven and not byte-deterministic: a given release may land on a slightly different (but coherent) set of pages/anchors run-to-run. Both fixes here are factually accurate against the 0.3.3 notes regardless of which pages it picks; treat the _placement + prose quality_ as the thing to review, not the exact file set.

## Test plan

- [ ] Build the site locally and confirm both pages render without MDX errors
- [ ] Scan for prose-style mismatches vs surrounding sections
- [ ] Flag any factual inaccuracies vs the actual 0.3.3 behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
