### PR TITLE
docs(TE-14711): add Slack flaky-alert note to Flaky Test Analytics page

### DIFF
--- a/docs/analytics-modules-flaky-tests.md
+++ b/docs/analytics-modules-flaky-tests.md
@@ -45,6 +45,10 @@ The best way to analyze your flaky tests is to use Test Intelligence. Test Intel
 </div>
 </div>
 
+:::note Get Flaky Alerts on Slack
+Don't want to keep checking the dashboard? If you have the [Slack Integration](/docs/slack-integration/) enabled, turn on the **Flaky Test Messages** preference to receive a Slack alert the **first time** <BrandName /> detects a test as flaky — including the test name, build, and flake rate. Alerts are opt-in and off by default.
+:::
+
 ## Flakiness Trends
 The Flakiness Trends widget allows the QA teams to analyze the trends of the flaky tests executed on the platform categorized into Passed, Failed, and Flaky which can easily be filtered with the legends added at the top of the graph.
 


### PR DESCRIPTION
## Summary

Adds a single `:::note` callout to the **Flaky Test Analytics** doc surfacing the new opt-in **Flaky Test Messages** Slack notification (TE-14711), with a link to the Slack Integration page.

Placed right after the intro/video so users discover the feature before the widget sections. No other docs touched — scoped intentionally to one note.

## Rendered note

> **Get Flaky Alerts on Slack**
> Don't want to keep checking the dashboard? If you have the [Slack Integration](/docs/slack-integration/) enabled, turn on the **Flaky Test Messages** preference to receive a Slack alert the **first time** TestMu AI detects a test as flaky — including the test name, build, and flake rate. Alerts are opt-in and off by default.

## Notes
- Single-file change: `docs/analytics-modules-flaky-tests.md`
- Link uses the `/docs/...` form to match existing cross-links in this file.
- Related feature PRs: lambda-ftd #1070, integration-backend-service (LIS consumer), lambda-integration-client #480 (toggle).