### PR TITLE
Fix back-to-back admonitions in group-management and team-management docs

### DIFF
--- a/docs/group-management.md
+++ b/docs/group-management.md
@@ -47,9 +47,10 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 This feature is available exclusively on the **Enterprise plan**. To enable it for your organization, please reach out to your account manager.
 :::
 
-:::tip
-All steps below assume you are signed in to your <BrandName /> account. Open the **Profile** icon in the top-right corner and select **Organization Settings** to access the **Groups** tab.
-:::
+## Before You Begin
+---
+
+Sign in to your <BrandName /> account. Open the **Profile** icon in the top-right corner and select **Organization Settings** to access the **Groups** tab. All steps below assume you have this page open.
 
 ## Create a New Group
 ---

--- a/docs/team-management.md
+++ b/docs/team-management.md
@@ -117,9 +117,7 @@ This section explains who can see which test results based on team membership.
 
 :::info
 Test visibility within teams is independent of user roles (Admin, User, Guest).
-:::
 
-:::tip
 - To restrict a user from accessing all tests, add the user to a team.
 - A user can belong to multiple teams.
 :::


### PR DESCRIPTION
## Summary

Two small follow-ups to recent doc cleanups (PRs #3009 and #3010) where the rendered page ended up with two admonition callouts stacked back-to-back with nothing between them — visually noisy.

### `docs/group-management.md`
The Enterprise plan `:::note` and the prerequisite `:::tip` were adjacent. The `:::tip` is promoted to a proper `## Before You Begin` section, so a heading now separates the two callouts. Matches the doc-structure guidance in `CLAUDE.md`.

### `docs/team-management.md`
The Access Rules section had a `:::info` (test visibility independent of roles) immediately followed by a `:::tip` (two access-restriction bullets). Folded the bullets into the same `:::info` block so the section reads as one callout.

## Test plan
- [x] `npm start -- --port 3900` boots without errors
- [x] `/support/docs/group-management/` shows the `## Before You Begin` heading between NOTE and the first step section
- [x] `/support/docs/team-management/` shows a single INFO admonition containing the visibility statement and the two bullets
- [ ] Reviewer to verify CI build (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)