### PR TITLE
seo: set global canonical to live Docusaurus docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -13,7 +13,8 @@
   },
   "seo": {
     "metatags": {
-      "robots": "noindex, nofollow"
+      "robots": "noindex, nofollow",
+      "canonical": "https://www.testmuai.com/support"
     }
   },
   "fonts": {


### PR DESCRIPTION
## What

Adds a global `seo.metatags.canonical` base in `docs.json`:

```json
"canonical": "https://www.testmuai.com/support"
```

## Why

The stage-mintlify pages currently have **no canonical** defined, so Mintlify auto-derives one from the deploy domain. This makes the staged Mintlify docs eligible to be indexed as duplicate content alongside the live Docusaurus docs.

With this base set, Mintlify appends each page's path so every page canonicalizes to its **live Docusaurus equivalent**:

| Page path | Canonical (production) |
|---|---|
| `/docs/kane-cli-installation` | `https://www.testmuai.com/support/docs/kane-cli-installation` |

Verified the target exists and loads on production (`/support/docs/kane-cli-installation` → "Installing Kane CLI").

## Notes

- Per-page `canonical:` frontmatter still overrides this global base (e.g. `hyperexecute-maven-gradle-parameters.md`).
- Canonical cannot be validated on `mintlify dev` (local builds inject a `/src/_props` artifact into the URL). **Verify on the deployed preview.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)