### PR TITLE
docs(kane-cli): add Checkpoints section + Kane CLI home-page card

### DIFF
--- a/docs/kane-cli-checkpoint-devtools-console.md
+++ b/docs/kane-cli-checkpoint-devtools-console.md
@@ -1,0 +1,115 @@
+---
+id: kane-cli-checkpoint-devtools-console
+title: Console Assertions
+sidebar_label: Console
+description: "Verify browser console output — errors, warnings, log messages, and JavaScript exceptions captured during test execution."
+keywords:
+  - console assertion
+  - javascript errors
+  - console log
+  - kane cli
+  - devtools
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-console/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-devtools-console/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-console/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Console Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-console/"
+        }]
+      }) }}
+></script>
+
+Console assertions let you verify browser console output — error messages, warnings, log messages, and uncaught JavaScript exceptions.
+
+## How Capture Works
+
+KaneAI captures all browser console output automatically during each test step:
+
+- **Continuous capture**: Every `console.log()`, `console.warn()`, `console.error()`, and uncaught JS exception is recorded
+- **Per-step scope**: Each test step starts with a fresh capture. Console messages from previous steps are not carried over
+- **Limits**: Up to 50,000 messages are stored per step. When the limit is reached, the oldest 10% are dropped
+- **No truncation**: Message text is stored in full — unlike network response bodies, console messages are never truncated
+- **Object resolution**: When JavaScript logs an object (`console.log({status: "ok"})`), KaneAI resolves it to the actual value instead of storing "JSHandle@object"
+- **Multi-tab support**: Console messages from new tabs and popups are also captured
+- **Top-frame only**: Messages from embedded iframes (payment widgets, third-party components) are not captured
+
+### Planning for Multi-Step Tests
+
+Because console data resets each step, plan accordingly:
+
+- If you need to verify a console message **later**, extract and store it in the same step it appears
+- Console output from step 1 won't be visible in step 3's console log
+
+### Level Normalization
+
+Console message levels are normalized to 5 values:
+
+| Level | What triggers it |
+|-------|-----------------|
+| `log` | `console.log()`, `console.dir()`, `console.table()`, and other info-level calls |
+| `warning` | `console.warn()` |
+| `error` | `console.error()` and uncaught exceptions |
+| `info` | `console.info()` |
+| `debug` | `console.debug()` |
+
+## What You Can Query
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `level` | string | Message level: "log", "warning", "error", "info", "debug" |
+| `text` | string | Full message text (not truncated) |
+| `url` | string | Source file URL |
+| `line_number` | int | Source line number |
+| `is_exception` | bool | True for uncaught JS exceptions (pageerror events) |
+| `stack_trace` | string | Stack trace (exceptions only) |
+
+### Errors vs Exceptions
+
+- **`errors`** includes ALL error-level messages: both `console.error()` calls AND uncaught exceptions
+- **`exceptions`** is a subset of errors — only uncaught JavaScript exceptions
+- To check for app-level errors without exceptions: query errors where `is_exception` is false
+
+## Example Assertions
+
+```
+Assert: no console errors on the page
+Assert: no uncaught JavaScript exceptions
+Assert: console contains "Amplitude SDK triggered"
+Assert: no console warnings
+Assert: no JS errors after clicking Submit
+```
+
+## Example Extractions
+
+```
+Store all console error messages
+Extract the first console error text
+Store all console log output
+```
+
+## Example If/Else
+
+```
+If console contains "feature_flag_enabled" then use new flow, else use legacy flow
+```

--- a/docs/kane-cli-checkpoint-devtools-cookies.md
+++ b/docs/kane-cli-checkpoint-devtools-cookies.md
@@ -1,0 +1,99 @@
+---
+id: kane-cli-checkpoint-devtools-cookies
+title: Cookies Assertions
+sidebar_label: Cookies
+description: "Verify browser cookies — names, values, and flags such as httpOnly, secure, and sameSite — set during test execution."
+keywords:
+  - cookies assertion
+  - session cookie
+  - httponly
+  - secure cookie
+  - kane cli
+  - devtools
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-cookies/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-devtools-cookies/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-cookies/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Cookies Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-cookies/"
+        }]
+      }) }}
+></script>
+
+Cookie assertions let you verify browser cookies — check existence, values, and security attributes like httpOnly, secure, and sameSite.
+
+## How Capture Works
+
+Cookies are captured as a **point-in-time snapshot** when the checkpoint triggers:
+
+- **On-demand capture**: Cookies are read from the browser context at the moment the assertion runs — not accumulated over time
+- **Current state only**: You see exactly what cookies exist right now, including any set by the page's JavaScript or server responses
+- **All cookies visible**: Unlike `document.cookie` in JavaScript, KaneAI can see httpOnly cookies too
+- **Domain-scoped**: Cookies are captured for all domains the browser has visited in this session
+
+### Planning for Multi-Step Tests
+
+Because cookies are captured at assertion time:
+
+- If you need to check cookies set by a specific page, assert on the **same page** or **after** you've visited it
+- If cookies are needed in a later step (e.g., after navigating away), extract and store them first
+- Cookies persist in the browser across steps (unlike network/console which reset) — but asserting on a different domain may show different cookies
+
+## What You Can Query
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Cookie name (e.g., "session_id") |
+| `value` | string | Cookie value |
+| `domain` | string | Domain (e.g., ".example.com") |
+| `path` | string | Cookie path (e.g., "/") |
+| `expires` | float | Expiry as epoch seconds (-1 for session cookies) |
+| `http_only` | bool | True if HttpOnly flag is set |
+| `secure` | bool | True if Secure flag is set |
+| `same_site` | string | "Strict", "Lax", or "None" |
+
+## Example Assertions
+
+```
+Assert: a cookie named "session_id" exists
+Assert: the session cookie is httpOnly
+Assert: no cookies are set without the Secure flag
+Assert: at least 3 cookies are set on the page
+Assert: the auth cookie has sameSite set to "Strict"
+```
+
+## Example Extractions
+
+```
+Store all cookies
+Extract the value of the "session_id" cookie
+Store all cookie names
+Get all cookies for the example.com domain
+```
+
+## Example If/Else
+
+```
+If a cookie named "auth_token" exists then go to dashboard, else go to login
+```

--- a/docs/kane-cli-checkpoint-devtools-localstorage.md
+++ b/docs/kane-cli-checkpoint-devtools-localstorage.md
@@ -1,0 +1,110 @@
+---
+id: kane-cli-checkpoint-devtools-localstorage
+title: localStorage Assertions
+sidebar_label: localStorage
+description: "Verify key-value pairs stored in the browser localStorage during test execution — auth tokens, feature flags, cached data."
+keywords:
+  - localstorage assertion
+  - browser storage
+  - auth token
+  - kane cli
+  - devtools
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-localstorage/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-devtools-localstorage/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-localstorage/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "localStorage Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-localstorage/"
+        }]
+      }) }}
+></script>
+
+localStorage assertions let you verify data stored in the browser's `window.localStorage` — check key existence, values, and item counts.
+
+## How Capture Works
+
+localStorage is captured as a **point-in-time snapshot** when the checkpoint triggers:
+
+- **On-demand capture**: localStorage is read from the current page at the moment the assertion runs
+- **Current state only**: You see exactly what's in localStorage right now
+- **Domain-scoped**: localStorage is per-origin (protocol + domain + port). You only see data for the current page's origin
+- **String values**: All localStorage values are strings. If the application stores JSON objects, they're stored as JSON strings
+
+### Planning for Multi-Step Tests
+
+Because localStorage is captured at assertion time:
+
+- Assert on localStorage while you're **on the page** that set the values — navigating to a different domain means a different localStorage
+- If values are needed later, extract and store them before navigating away
+- localStorage persists across steps (unlike network/console) as long as you stay on the same origin
+
+### JSON Values
+
+Applications often store structured data in localStorage as JSON strings:
+
+```javascript
+// Application code
+localStorage.setItem("user_prefs", JSON.stringify({theme: "dark", lang: "en"}));
+```
+
+In assertions, the value is the raw JSON string. You can parse it to check individual fields:
+
+```
+Assert: the "theme" field in the user_prefs localStorage item is "dark"
+```
+
+KaneAI will parse the JSON and drill into the value automatically.
+
+## What You Can Query
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `storage.all()` | dict | All key-value pairs |
+| `storage.get(key)` | string or None | Value for a specific key |
+| `storage.keys()` | list of strings | All key names |
+| `storage.has(key)` | bool | Whether a key exists |
+
+## Example Assertions
+
+```
+Assert: auth_token exists in localStorage
+Assert: the theme preference in localStorage is "dark"
+Assert: localStorage has fewer than 10 items
+Assert: the user_id value in localStorage is not empty
+```
+
+## Example Extractions
+
+```
+Store all localStorage items
+Extract the auth_token from localStorage
+Store the user preferences from localStorage
+Get all localStorage keys
+```
+
+## Example If/Else
+
+```
+If localStorage has "onboarding_complete" then show dashboard, else start onboarding
+```

--- a/docs/kane-cli-checkpoint-devtools-network.md
+++ b/docs/kane-cli-checkpoint-devtools-network.md
@@ -1,0 +1,105 @@
+---
+id: kane-cli-checkpoint-devtools-network
+title: Network Assertions
+sidebar_label: Network
+description: "Verify HTTP traffic — API responses, status codes, headers, response bodies, and request timing — captured by KaneAI in the background."
+keywords:
+  - network assertion
+  - http response
+  - api status code
+  - kane cli
+  - devtools
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-network/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-devtools-network/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-network/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Network Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-network/"
+        }]
+      }) }}
+></script>
+
+Network assertions let you verify HTTP traffic — API responses, status codes, headers, response bodies, and request timing.
+
+## How Capture Works
+
+KaneAI captures all HTTP network traffic automatically during each test step:
+
+- **Continuous capture**: Every HTTP request and response is recorded as it happens
+- **Per-step scope**: Each test step starts with a fresh capture. Traffic from previous steps is not carried over
+- **Limits**: Up to 5,000 requests are stored per step. When the limit is reached, the oldest 10% of entries are dropped to make room. Response bodies are capped at 64KB per entry
+- **Text bodies only**: Response bodies are captured for text-based content types (JSON, HTML, XML, CSS, JavaScript). Binary content (images, fonts, videos) is skipped
+- **Multi-tab support**: Traffic from new tabs and popups is also captured
+
+### Planning for Multi-Step Tests
+
+Because network data resets each step, plan accordingly:
+
+- If you need to assert on an API response **later**, extract and store it in the same step the request happens
+- Navigation and API calls in step 1 won't be visible in step 3's network log
+- Use extraction checkpoints to save values across steps
+
+## What You Can Query
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | string | HTTP method (GET, POST, PUT, DELETE, ...) |
+| `url` | string | Full request URL |
+| `domain` | string | Domain (e.g., "api.example.com") |
+| `path` | string | URL path without query string |
+| `query_params` | dict | Query parameters |
+| `resource_type` | string | xhr, fetch, document, script, image, ... |
+| `request_headers` | dict | Request headers |
+| `request_body` | string | Request body (may be truncated) |
+| `response_status` | int | HTTP status code (200, 404, 500, ...) |
+| `response_headers` | dict | Response headers |
+| `response_body` | string | Response body (text types only, may be truncated) |
+| `timing.duration_ms` | float | Total request duration in milliseconds |
+| `timing.ttfb_ms` | float | Time to first byte in milliseconds |
+| `failed` | bool | True if request failed at network level |
+| `failure_reason` | string | Error reason (e.g., "net::ERR_CONNECTION_REFUSED") |
+
+## Example Assertions
+
+```
+Assert: no API calls returned 5xx status codes
+Assert: the POST /api/login returned HTTP status 200
+Assert: all API responses completed in under 2 seconds
+Assert: no network requests failed with connection errors
+Assert: the /posts endpoint returned at least 10 items in the response body
+```
+
+## Example Extractions
+
+```
+Store the response body of the POST /api/login request
+Extract the status code of the last API call to /api/users
+Store all API request URLs
+```
+
+## Example If/Else
+
+```
+If the /api/auth returned 200 then proceed to dashboard, else show error message
+```

--- a/docs/kane-cli-checkpoint-devtools-performance.md
+++ b/docs/kane-cli-checkpoint-devtools-performance.md
@@ -1,0 +1,101 @@
+---
+id: kane-cli-checkpoint-devtools-performance
+title: Performance Assertions
+sidebar_label: Performance
+description: "Verify Core Web Vitals and other performance metrics — LCP, CLS, INP, FCP, TTFB — captured during test execution."
+keywords:
+  - performance assertion
+  - core web vitals
+  - lcp
+  - cls
+  - inp
+  - kane cli
+  - devtools
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-performance/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-devtools-performance/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-performance/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Performance Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-performance/"
+        }]
+      }) }}
+></script>
+
+Performance assertions let you verify [Core Web Vitals](https://web.dev/articles/vitals) and other key performance metrics for the current page.
+
+## How Capture Works
+
+Performance data is **navigation-based** — metrics are measured for the most recent page navigation:
+
+- **Automatic measurement**: KaneAI uses the [web-vitals](https://github.com/GoogleChrome/web-vitals) library to capture metrics
+- **Per-navigation scope**: Metrics reflect the last full page load. If you navigate to a new page, the metrics reset for that navigation
+- **Point-in-time snapshot**: When a performance checkpoint triggers, KaneAI captures the current metrics at that moment
+
+### What This Means for Your Tests
+
+- Performance metrics describe the **last navigation** — if you navigate to Page A then Page B, the metrics reflect Page B
+- Place performance assertions **after** the page you want to measure has fully loaded
+- Use a wait step if the page needs time to settle before measuring
+
+## Available Metrics
+
+| Metric | What It Measures | Good Threshold | Learn More |
+|--------|-----------------|----------------|------------|
+| **LCP** | Largest Contentful Paint — when the largest visible element finishes rendering | < 2,500ms | [web.dev/lcp](https://web.dev/articles/lcp) |
+| **CLS** | Cumulative Layout Shift — visual stability, how much the page layout shifts | < 0.1 | [web.dev/cls](https://web.dev/articles/cls) |
+| **INP** | Interaction to Next Paint — responsiveness to user input | < 200ms | [web.dev/inp](https://web.dev/articles/inp) |
+| **FCP** | First Contentful Paint — when the first content appears on screen | < 1,800ms | [web.dev/fcp](https://web.dev/articles/fcp) |
+| **TTFB** | Time to First Byte — server response time | < 800ms | [web.dev/ttfb](https://web.dev/articles/ttfb) |
+
+> **Note**: Not all metrics are available for every page. INP requires user interaction to trigger. Some metrics may be `null` if the browser hasn't measured them yet.
+
+## Example Assertions
+
+```
+Assert: page LCP is under 2500ms
+Assert: CLS is below 0.1
+Assert: TTFB is under 800ms
+Assert: FCP is less than 1800ms
+Assert: page performance meets Core Web Vitals thresholds
+```
+
+## Example Extractions
+
+```
+Store the page LCP value
+Extract all web vitals metrics
+Store the TTFB for this page
+```
+
+## Example If/Else
+
+```
+If LCP is under 2500ms then continue, else report performance issue
+```
+
+## Tips
+
+- **Wait for load**: Place a wait step before performance assertions to ensure the page has fully loaded and metrics are available
+- **Navigate first**: Metrics are per-navigation — make sure you've navigated to the target page before asserting
+- **Not all metrics are instant**: CLS accumulates over time, INP requires interaction. LCP and FCP are typically available after the page visually completes loading

--- a/docs/kane-cli-checkpoint-devtools.md
+++ b/docs/kane-cli-checkpoint-devtools.md
@@ -1,0 +1,90 @@
+---
+id: kane-cli-checkpoint-devtools
+title: DevTools Assertions
+sidebar_label: Overview
+description: "Verify data that is not visible on the page — HTTP network traffic, console output, performance metrics, cookies, and localStorage."
+keywords:
+  - devtools assertion
+  - network
+  - console
+  - performance
+  - cookies
+  - localstorage
+  - kane cli
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-devtools/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "DevTools Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools/"
+        }]
+      }) }}
+></script>
+
+DevTools assertions let you verify data that isn't visible on the page — HTTP network traffic, browser console output, performance metrics, cookies, and localStorage. KaneAI captures this data automatically in the background; you just write what to check.
+
+## Available Domains
+
+| Domain | What It Captures | Documentation |
+|--------|-----------------|---------------|
+| [Network](/support/docs/kane-cli-checkpoint-devtools-network/) | HTTP requests and responses | Status codes, headers, response bodies, timing |
+| [Console](/support/docs/kane-cli-checkpoint-devtools-console/) | Browser console messages | Errors, warnings, log messages, JS exceptions |
+| [Performance](/support/docs/kane-cli-checkpoint-devtools-performance/) | Core Web Vitals | LCP, CLS, INP, FCP, TTFB |
+| [Cookies](/support/docs/kane-cli-checkpoint-devtools-cookies/) | Browser cookies | Names, values, flags (httpOnly, secure, sameSite) |
+| [localStorage](/support/docs/kane-cli-checkpoint-devtools-localstorage/) | Browser localStorage | Key-value pairs stored in the browser |
+
+## How It Works
+
+Each DevTools domain follows the same pattern:
+
+1. **Capture** — KaneAI captures the data automatically during your test run
+2. **Generate** — When a checkpoint triggers, the AI generates code to query the captured data
+3. **Execute** — The code runs in an isolated sandbox and returns a result
+4. **Assert** — The result is compared against your expected value
+
+You don't write code — you write natural language objectives, and KaneAI handles the rest.
+
+## Examples
+
+```
+Assert: no API calls returned 5xx
+Assert: no console errors on the page
+Assert: page LCP is under 2500ms
+Assert: session cookie exists and is httpOnly
+Assert: auth_token is stored in localStorage
+```
+
+## All Checkpoint Types Work
+
+DevTools assertions support all three checkpoint types:
+
+- **Assert**: "Assert: no console errors" — fails the test if there are errors
+- **Extract**: "Store all cookies" — saves the data for later steps
+- **If/Else**: "If the API returned 200 then proceed, else retry" — branch on the result
+
+## Important Notes
+
+- DevTools data is **not visible in a screenshot** — KaneAI will never try to open the browser DevTools panel
+- Each domain captures data differently — see individual pages for details on timing and scope
+- All assertions run in an isolated sandbox — generated code cannot access the file system or network

--- a/docs/kane-cli-checkpoint-textual.md
+++ b/docs/kane-cli-checkpoint-textual.md
@@ -1,0 +1,82 @@
+---
+id: kane-cli-checkpoint-textual
+title: Textual (DOM) Assertions
+sidebar_label: Textual (DOM)
+description: "Extract data from the DOM — element states, attributes, and computed styles — and assert on values that may not be visible in a screenshot."
+keywords:
+  - dom assertion
+  - textual assertion
+  - element state
+  - kane cli
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-textual/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-textual/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-textual/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Textual (DOM) Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-textual/"
+        }]
+      }) }}
+></script>
+
+Textual assertions extract data from the page's DOM — element states, attributes, and computed styles that aren't always visible in a screenshot.
+
+## When It's Used
+
+- Element states: disabled, enabled, checked, readonly, expanded
+- CSS properties with exact values: `font-size: 16px`, `opacity: 0.5`, `display: none`
+- HTML attributes: `placeholder`, `aria-*`, `data-*`, `class`, `id`, `href`, `src`, `type`, `value`
+- Attribute existence: "has placeholder", "has aria-label"
+- Exact CSS color values: `rgb(255,0,0)`, `#ff0000`
+
+## Examples
+
+### Assertions
+
+```
+Assert: the submit button is disabled
+Assert: the checkbox is checked
+Assert: the input field has placeholder "Enter email"
+Assert: the element has aria-label "Close dialog"
+Assert: the font-size of the heading is 24px
+```
+
+### Extractions
+
+```
+Extract the href of the first link
+Store the value attribute of the email input
+Get the class of the error message element
+```
+
+## When NOT to Use
+
+- For visible text content (prices, labels) → use [Visual](/support/docs/kane-cli-checkpoint-visual/)
+- For color names like "red background" → use [Visual](/support/docs/kane-cli-checkpoint-visual/) (DOM may return `transparent` or inherited values)
+- For network/console/cookie data → use [DevTools](/support/docs/kane-cli-checkpoint-devtools/)
+
+## How It Works
+
+1. KaneAI captures the DOM snapshot of the page
+2. The AI model identifies the target element and extracts the requested property
+3. The value is compared against the expected value

--- a/docs/kane-cli-checkpoint-title.md
+++ b/docs/kane-cli-checkpoint-title.md
@@ -1,0 +1,67 @@
+---
+id: kane-cli-checkpoint-title
+title: Title Assertions
+sidebar_label: Title
+description: "Verify the browser tab document.title — useful for confirming navigation reached the expected page."
+keywords:
+  - page title assertion
+  - document.title
+  - kane cli
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-title/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-title/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-title/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Title Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-title/"
+        }]
+      }) }}
+></script>
+
+Title assertions check the browser tab's document title (`document.title`).
+
+## When It's Used
+
+- Page title verification: "title contains Dashboard"
+- Navigation confirmation: "title is Home Page"
+
+## Examples
+
+### Assertions
+
+```
+Assert: page title contains "Dashboard"
+Assert: title is "My Account - Settings"
+```
+
+### Extractions
+
+```
+Store the page title
+```
+
+## How It Works
+
+1. KaneAI reads `page.title()` directly
+2. The title string is compared against the expected value
+3. No screenshot or DOM analysis needed — this is a direct read

--- a/docs/kane-cli-checkpoint-url.md
+++ b/docs/kane-cli-checkpoint-url.md
@@ -1,0 +1,77 @@
+---
+id: kane-cli-checkpoint-url
+title: URL Assertions
+sidebar_label: URL
+description: "Check values in the browser address bar — current URL path, query parameters, fragments, and redirect targets."
+keywords:
+  - url assertion
+  - query parameter assertion
+  - kane cli
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-url/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-url/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-url/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "URL Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-url/"
+        }]
+      }) }}
+></script>
+
+URL assertions check values in the browser's address bar — the current URL path, query parameters, fragments, and redirect targets.
+
+## When It's Used
+
+- URL path: "URL contains /checkout"
+- Query parameters: "URL has param `sort=price`"
+- Redirect verification: "redirected to /login"
+- Fragment/hash: "URL hash is #section-2"
+
+## Examples
+
+### Assertions
+
+```
+Assert: URL contains /checkout
+Assert: the page redirected to /dashboard
+Assert: URL path is /products/42
+```
+
+### Extractions
+
+```
+Store the current URL
+Extract the URL path
+```
+
+### If/Else
+
+```
+If URL contains /login then enter credentials, else go to profile
+```
+
+## How It Works
+
+1. KaneAI reads the current `page.url` value directly
+2. The URL string is compared against the expected value using the specified operator
+3. No screenshot or DOM analysis needed — this is a direct read

--- a/docs/kane-cli-checkpoint-visual.md
+++ b/docs/kane-cli-checkpoint-visual.md
@@ -1,0 +1,87 @@
+---
+id: kane-cli-checkpoint-visual
+title: Visual Assertions
+sidebar_label: Visual
+description: "Verify what is visible on the screen by analyzing the current screenshot. Visual is the default analyze method KaneAI uses for assertions."
+keywords:
+  - visual assertion
+  - screenshot assertion
+  - kane cli
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-visual/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-visual/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-visual/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Visual Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-visual/"
+        }]
+      }) }}
+></script>
+
+Visual assertions verify what's visible on screen by analyzing the current screenshot. This is the default method — when in doubt, KaneAI uses visual analysis.
+
+## When It's Used
+
+- Text content: prices, labels, headings, counts, messages
+- Visibility: "is the login button visible", "are search results displayed"
+- Color checks using color names: "has red background", "blue text"
+- Any content that appears visually on the page
+
+## Examples
+
+### Assertions
+
+```
+Assert: the product price is $29.99
+Assert: the search results show at least 5 items
+Assert: the error message is visible
+Assert: the hero section displays "Welcome back"
+```
+
+### Extractions
+
+```
+Store the product price
+Extract the heading text
+Get the number of items in the cart
+```
+
+### If/Else
+
+```
+If the login button is visible then click it, else click Sign Up
+```
+
+## How It Works
+
+1. KaneAI takes a screenshot of the current page
+2. The AI model analyzes the screenshot to find the requested information
+3. The extracted value is compared against the expected value using the specified operator
+
+## Best Practices
+
+- Use visual assertions for any text or content you can see on screen
+- Be specific about what to look for: "the price in the cart summary" not just "the price"
+- For exact CSS values (like `rgb(255,0,0)` or `#ff0000`), use [Textual (DOM)](/support/docs/kane-cli-checkpoint-textual/) instead
+- For element states (disabled, checked), use [Textual (DOM)](/support/docs/kane-cli-checkpoint-textual/) instead

--- a/docs/kane-cli-checkpoints.md
+++ b/docs/kane-cli-checkpoints.md
@@ -1,0 +1,111 @@
+---
+id: kane-cli-checkpoints
+title: Checkpoints
+sidebar_label: Overview
+description: "Checkpoints are verification points KaneAI evaluates during test execution — assert conditions, branch on results, or extract values for later use."
+keywords:
+  - kane cli checkpoints
+  - assertions
+  - extractions
+  - testmu ai
+  - kaneai
+  - browser automation
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoints/
+site_name: TestMu AI
+slug: kane-cli-checkpoints/
+displayed_sidebar: KaneCLISidebar
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoints/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Checkpoints",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoints/"
+        }]
+      }) }}
+></script>
+
+Checkpoints are verification points that KaneAI evaluates during test execution. They let you assert conditions, branch on results, or extract values for later use.
+
+## Checkpoint Types
+
+| Type | What it does |
+|------|-------------|
+| **Assertion** | Verify a condition is true — fails the test if not |
+| **If/Else** | Branch execution based on a condition |
+| **Extraction** | Store a value for use in later steps |
+
+All three types work with every analyze method below.
+
+## Analyze Methods
+
+Each checkpoint uses an analyze method to determine *where* to look for the data:
+
+| Method | Data Source | When to Use |
+|--------|-----------|-------------|
+| [Visual](/support/docs/kane-cli-checkpoint-visual/) | Screenshot (what you see on screen) | Text, labels, prices, counts, colors, visibility checks |
+| [Textual (DOM)](/support/docs/kane-cli-checkpoint-textual/) | Page DOM elements | Element states (disabled, checked), CSS properties, HTML attributes |
+| [URL](/support/docs/kane-cli-checkpoint-url/) | Browser URL bar | URL path, query params, redirects |
+| [Title](/support/docs/kane-cli-checkpoint-title/) | Page title | Document title verification |
+| [DevTools](/support/docs/kane-cli-checkpoint-devtools/) | Browser internals | Network traffic, console logs, performance, cookies, localStorage |
+
+## How to Use
+
+Write your assertions naturally in the objective. KaneAI automatically picks the right analyze method:
+
+```
+Assert: the price is $29.99                    → Visual
+Assert: the submit button is disabled          → Textual (DOM)
+Assert: URL contains /checkout                 → URL
+Assert: page title contains "Dashboard"        → Title
+Assert: no API calls returned 5xx              → DevTools (Network)
+Assert: no console errors                      → DevTools (Console)
+Assert: page LCP is under 2500ms               → DevTools (Performance)
+Assert: session cookie exists                  → DevTools (Cookies)
+Assert: auth_token exists in localStorage      → DevTools (localStorage)
+```
+
+Extractions work the same way:
+
+```
+Store the product price                        → Visual
+Store the current URL                          → URL
+Store all cookies                              → DevTools (Cookies)
+Store the API response body                    → DevTools (Network)
+```
+
+## Operators
+
+Assertions support these comparison operators:
+
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| `equals` | Exact match | price equals "29.99" |
+| `contains` | Substring match | URL contains "/checkout" |
+| `not_contains` | Does not contain | title not contains "Error" |
+| `gt` / `gte` | Greater than / or equal | items greater than 5 |
+| `lt` / `lte` | Less than / or equal | LCP less than 2500 |
+| `not_equals` | Not equal | status not equals "failed" |
+
+## Learn More
+
+- [Visual Assertions](/support/docs/kane-cli-checkpoint-visual/) — screenshot-based text and visibility checks
+- [Textual (DOM) Assertions](/support/docs/kane-cli-checkpoint-textual/) — element states and attributes
+- [URL Assertions](/support/docs/kane-cli-checkpoint-url/) — URL-based checks
+- [Title Assertions](/support/docs/kane-cli-checkpoint-title/) — page title checks
+- [DevTools Assertions](/support/docs/kane-cli-checkpoint-devtools/) — network, console, performance, cookies, localStorage

--- a/sidebars.js
+++ b/sidebars.js
@@ -5021,6 +5021,75 @@ module.exports = {
       {
         type: "category",
         collapsed: true,
+        label: "Checkpoints",
+        items: [
+          {
+            type: "doc",
+            label: "Overview",
+            id: "kane-cli-checkpoints",
+          },
+          {
+            type: "doc",
+            label: "Visual",
+            id: "kane-cli-checkpoint-visual",
+          },
+          {
+            type: "doc",
+            label: "Textual (DOM)",
+            id: "kane-cli-checkpoint-textual",
+          },
+          {
+            type: "doc",
+            label: "URL",
+            id: "kane-cli-checkpoint-url",
+          },
+          {
+            type: "doc",
+            label: "Title",
+            id: "kane-cli-checkpoint-title",
+          },
+          {
+            type: "category",
+            collapsed: true,
+            label: "DevTools",
+            items: [
+              {
+                type: "doc",
+                label: "Overview",
+                id: "kane-cli-checkpoint-devtools",
+              },
+              {
+                type: "doc",
+                label: "Network",
+                id: "kane-cli-checkpoint-devtools-network",
+              },
+              {
+                type: "doc",
+                label: "Console",
+                id: "kane-cli-checkpoint-devtools-console",
+              },
+              {
+                type: "doc",
+                label: "Performance",
+                id: "kane-cli-checkpoint-devtools-performance",
+              },
+              {
+                type: "doc",
+                label: "Cookies",
+                id: "kane-cli-checkpoint-devtools-cookies",
+              },
+              {
+                type: "doc",
+                label: "localStorage",
+                id: "kane-cli-checkpoint-devtools-localstorage",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "category",
+        collapsed: true,
         label: "Agent Mode",
         items: [
           {

--- a/src/pages/docs.js
+++ b/src/pages/docs.js
@@ -94,7 +94,7 @@ export default function Home() {
       <div className="primary_main">
       <div className="container">
 
-        {/* Row 1 */}
+        {/* Product grid */}
         <div className="home_main">
           <div className="home_inners_box">
             <h2 className="homeMain_h2"><Icon light="automation-light-icon.svg" dark="automation-dark-icon.svg" alt="" />Web Automation</h2>
@@ -142,10 +142,6 @@ export default function Home() {
               <a href="/support/docs/analytics-modules-test-intelligence-command-logs-analytics/"><p className="p_home_inners">Command Logs Insights</p></a>
             </div>
           </div>
-        </div>
-
-        {/* Row 2 */}
-        <div className="home_main">
           <div className="home_inners_box">
             <h2 className="homeMain_h2"><Icon light="automation-light-icon.svg" dark="automation-dark-icon.svg" alt="" />Browser Cloud &nbsp;<NewTag value="NEW" /></h2>
             <div className="home_inners">
@@ -169,17 +165,6 @@ export default function Home() {
             </div>
           </div>
           <div className="home_inners_box">
-            <h2 className="homeMain_h2"><Icon light="webscanner-light-icon.svg" dark="webscanner-dark-icon.svg" alt="" />Web Scanner &nbsp;<NewTag value="NEW" /></h2>
-            <div className="home_inners">
-              <a href="/support/docs/web-scanner-overview/"><p className="p_home_inners">Overview</p></a>
-              <a href="/support/docs/web-scanner-getting-started/"><p className="p_home_inners">Getting Started</p></a>
-              <a href="/support/docs/web-scanner-visual-scan/"><p className="p_home_inners">Visual UI Scans</p></a>
-              <a href="/support/docs/web-scanner-accessibility-scan/"><p className="p_home_inners">Accessibility Scans</p></a>
-              <a href="/support/docs/web-scanner-adding-urls/"><p className="p_home_inners">Adding URLs</p></a>
-              <a href="/support/docs/web-scanner-scheduling-options/"><p className="p_home_inners">Scheduling Options</p></a>
-            </div>
-          </div>
-          <div className="home_inners_box">
             <h2 className="homeMain_h2"><Icon light="Realtime-light-icon.svg" dark="Realtime-dark-icon.svg" alt="" />KaneAI</h2>
             <div className="home_inners">
               <a href="/support/docs/getting-started-with-kane-ai/"><p className="p_home_inners">Getting Started</p></a>
@@ -190,10 +175,29 @@ export default function Home() {
               <a href="/support/docs/kaneai-ci-cd-automation/"><p className="p_home_inners">Test Automation with CI/CD</p></a>
             </div>
           </div>
-        </div>
-
-        {/* Row 3 */}
-        <div className="home_main">
+          <div className="home_inners_box">
+            <h2 className="homeMain_h2"><Icon light="Realtime-light-icon.svg" dark="Realtime-dark-icon.svg" alt="" />Kane CLI &nbsp;<NewTag value="NEW" /></h2>
+            <div className="home_inners">
+              <a href="/support/docs/kane-cli-introduction/"><p className="p_home_inners">Getting Started</p></a>
+              <a href="/support/docs/kane-cli-installation/"><p className="p_home_inners">Installation</p></a>
+              <a href="/support/docs/kane-cli-quickstart/"><p className="p_home_inners">Quick Start</p></a>
+              <a href="/support/docs/kane-cli-writing-objectives/"><p className="p_home_inners">Writing Objectives</p></a>
+              <a href="/support/docs/kane-cli-checkpoints/"><p className="p_home_inners">Checkpoints</p></a>
+              <a href="/support/docs/kane-cli-agent-mode/"><p className="p_home_inners">Agent Mode</p></a>
+              <a href="/support/docs/kane-cli-cli-reference/"><p className="p_home_inners">CLI Reference</p></a>
+            </div>
+          </div>
+          <div className="home_inners_box">
+            <h2 className="homeMain_h2"><Icon light="webscanner-light-icon.svg" dark="webscanner-dark-icon.svg" alt="" />Web Scanner &nbsp;<NewTag value="NEW" /></h2>
+            <div className="home_inners">
+              <a href="/support/docs/web-scanner-overview/"><p className="p_home_inners">Overview</p></a>
+              <a href="/support/docs/web-scanner-getting-started/"><p className="p_home_inners">Getting Started</p></a>
+              <a href="/support/docs/web-scanner-visual-scan/"><p className="p_home_inners">Visual UI Scans</p></a>
+              <a href="/support/docs/web-scanner-accessibility-scan/"><p className="p_home_inners">Accessibility Scans</p></a>
+              <a href="/support/docs/web-scanner-adding-urls/"><p className="p_home_inners">Adding URLs</p></a>
+              <a href="/support/docs/web-scanner-scheduling-options/"><p className="p_home_inners">Scheduling Options</p></a>
+            </div>
+          </div>
           <div className="home_inners_box">
             <h2 className="homeMain_h2"><Icon light="Realtime-light-icon.svg" dark="Realtime-dark-icon.svg" alt="" />Agent To Agent &nbsp;<NewTag value="BETA" /></h2>
             <div className="home_inners">
@@ -233,10 +237,6 @@ export default function Home() {
               <a href="/support/docs/link-jira-issues-with-test-manager/"><p className="p_home_inners">Issue Tracker Integration</p></a>
             </div>
           </div>
-        </div>
-
-        {/* Row 4 */}
-        <div className="home_main">
           <div className="home_inners_box">
             <h2 className="homeMain_h2"><Icon light="testManager-light.svg" dark="testManager-dark.svg" alt="" />TestMu AI MCP Server &nbsp;<NewTag value="NEW" /></h2>
             <div className="home_inners">
@@ -278,10 +278,6 @@ export default function Home() {
               <a href="/support/docs/charles-proxy/"><p className="p_home_inners">Charles Proxy</p></a>
             </div>
           </div>
-        </div>
-
-        {/* Row 5 */}
-        <div className="home_main">
           <div className="home_inners_box">
             <h2 className="homeMain_h2"><Icon light="settings-light-icon.svg" dark="settings-dark-icon.svg" alt="" />Settings and Security</h2>
             <div className="home_inners">


### PR DESCRIPTION
## Summary
Adds the Kane CLI **Checkpoints** documentation section and surfaces Kane CLI on the docs home page.

## Docs content (11 new pages)
Under the Kane CLI section:
- **Overview**, **Visual**, **Textual (DOM)**, **URL**, **Title**
- **DevTools**: Overview, Console, Cookies, localStorage, Network, Performance

Content ported from the kane-cli source (LambdaTest/kane-cli PR #61), adapted for Docusaurus: frontmatter (`id`/`slug`/`canonical`/etc.), breadcrumb JSON-LD, and site-relative links. Prose verified identical to source.

## Navigation (`sidebars.js`)
- New **Checkpoints** category in `KaneCLISidebar`, placed **between Core Concepts and Agent Mode**.
- DevTools nested as a sub-group.

## Home page (`src/pages/docs.js`)
- Added a **Kane CLI** product card (next to **KaneAI**).
- Merged the five separate row-grids into a single continuous 4-column grid so all product cards flow without alignment gaps.

## Notes
- Unrelated `package-lock.json` lockfile churn was intentionally excluded.
- Verified locally: dev server compiles cleanly, all 11 new routes resolve, and all home-page links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)