### PR TITLE
docs(kane-cli): link Checkpoints from the Writing Objectives patterns table

### DIFF
--- a/docs/kane-cli-writing-objectives.md
+++ b/docs/kane-cli-writing-objectives.md
@@ -55,6 +55,10 @@ The objective string is the most important input to Kane CLI. How you phrase it 
 | ✅ **Assertion** | assert, verify, confirm, check that, ensure | Validates a condition: produces pass/fail |
 | 📦 **Extraction** | store X as 'name' | Reads a value from the page, persists in output |
 
+:::note
+**Assertions** and **extractions** are evaluated as [Checkpoints](/support/docs/kane-cli-checkpoints/). See the reference for all analyze methods (Visual, Textual, URL, Title, DevTools) and comparison operators.
+:::
+
 ### Actions
 
 Use imperative verbs to describe what the agent should do:


### PR DESCRIPTION
## Summary
Adds a note under the **Three Patterns** table in the Kane CLI *Writing Objectives* page, pointing readers to the **Checkpoints** reference for the Assertion and Extraction patterns.

## Change
`docs/kane-cli-writing-objectives.md` — one `:::note` admonition below the table:

> **Assertions** and **extractions** are evaluated as [Checkpoints](/support/docs/kane-cli-checkpoints/). See the reference for all analyze methods (Visual, Textual, URL, Title, DevTools) and comparison operators.

## Notes
- Uses a site-relative link (valid in prod, passes the `onBrokenLinks: 'throw'` build check). The Checkpoints page already exists on `stage` (merged via #3037).
- Single file, +4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)