### PR TITLE
docs(nav): list Kane CLI in the docs product menu

### DIFF
--- a/sidebars-unified.js
+++ b/sidebars-unified.js
@@ -49,6 +49,10 @@ const docsSidebar = [
     items: items(s.KaneAISidebar),
   },
   {
+    type: 'category', label: 'Kane CLI', collapsible: true, collapsed: true,
+    items: items(s.KaneCLISidebar),
+  },
+  {
     type: 'category', label: 'Web Scanner', collapsible: true, collapsed: true,
     items: items(s.WebScannerSidebar),
   },


### PR DESCRIPTION
## Problem

Kane CLI was added with its own `KaneCLISidebar` (and `displayed_sidebar: KaneCLISidebar` on its pages) and a home-page grid card, but it was **never added to `docsSidebar`** — the unified product menu shown in the sidebar on documentation pages. Result: opening any doc page, Kane CLI does not appear below KaneAI, so there's no way to navigate to it from that menu.

## Fix

Add a **Kane CLI** category to `docsSidebar` immediately after **KaneAI**, using `items(s.KaneCLISidebar)` — exactly how every other product is listed. This is the standard Docusaurus "doc in multiple sidebars" pattern; Kane CLI pages keep their focused `KaneCLISidebar` via `displayed_sidebar`.

## Verified locally

- Menu order is now **SmartUI → KaneAI → Kane CLI → Web Scanner**.
- Dev server compiles with no sidebar warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)