### PR TITLE
Update RBAC roles and permissions doc; add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+The TestMu AI (formerly LambdaTest) product documentation site, built with **Docusaurus 3.7** + React 18, styled with Tailwind, and searched via **Typesense**. The vast majority of content lives as flat Markdown/MDX files in `docs/` (1200+ files, all in a single directory — there are no nested content folders). The published site lives at `https://www.testmuai.com/support/` (note the `/support/` `baseUrl`).
+
+## Commands
+
+```bash
+npm install --legacy-peer-deps   # install (peer-dep conflicts require this flag)
+npm start                        # dev server with hot reload at localhost:3000
+npm run build                    # production build — run before every PR
+npm run serve                    # serve the production build locally
+npm run clear                    # clear the Docusaurus cache when builds act stale
+```
+
+There is **no test suite and no linter**. The production build *is* the validation step: `onBrokenLinks: 'throw'` means `npm run build` fails on any broken internal link or missing image. Always run `npm run build` to verify changes before opening a PR.
+
+`prestart`/`prebuild` hooks run automatically before `start`/`build`. Do not skip them — they generate the API reference (see below).
+
+## Branches & deployment
+
+- **`testmuCom`** is the default/production branch. **`stage`** is the staging branch.
+- **Contribution workflow (always follow this):** cut a new branch **from `stage`**, make changes there, and raise the PR **back to `stage`** — never branch from or PR directly to `testmuCom`.
+- `testmuCom` is the repo's default branch (the README describes an older `stage`/`main` flow that no longer applies).
+- Push to `testmuCom` triggers `.github/workflows/testmucom-prod-deployment.yml`: builds the site, syncs `build/` to S3, and invalidates CloudFront + Cloudflare. **A merge to `testmuCom` deploys to production.**
+- A second workflow re-runs the Typesense search crawler on push.
+- Typesense needs `HOST` and `API` env vars (from `.env`) for search to work locally; the site renders fine without them, only search breaks.
+
+## Authoring docs
+
+Each doc is a Markdown/MDX file directly under `docs/`. The filename (minus extension) is the page `id` and typically matches the `slug`. Frontmatter conventions (see any existing file, e.g. `docs/accelq-integration.md`):
+
+- `id`, `title`, `hide_title: true` (titles are usually rendered via in-page H1/JSON-LD instead), `sidebar_label`, `description`, `keywords`, `slug`, `canonical`.
+- Many docs embed JSON-LD `<script type="application/ld+json">` blocks and import shared MDX components.
+
+**A new doc is not visible until it is added to a sidebar.** Sidebars are decoupled from the file tree.
+
+### Sidebars (important — two-file system)
+
+- `sidebars.js` — a large (~140KB) file exporting **32 per-product sidebars** (e.g. `HyperExecuteSidebar`, `SeleniumTestingSidebar`, `KaneAISidebar`). Each is shaped `[backLink, [items...]]` — a "Back" link followed by the item tree. This is where you add a new page to its product's navigation.
+- `sidebars-unified.js` — the sidebar actually wired into `docusaurus.config.js`. It `require`s `sidebars.js`, strips the back-link off each one via its `items()` helper, and composes them into a single grouped tree (Web Automation, App Automation, HyperExecute, etc.). Add a *new product sidebar* here; add a *new page* in `sidebars.js`.
+
+### Shared MDX components
+
+Reusable components live in `src/component/` and are imported into MDX. The most pervasive is `BrandName` (`import BrandName, { BRAND_URL } from '@site/src/component/BrandName'`) — **always use it instead of hardcoding "TestMu AI"** so the brand name stays centrally configurable. Other common ones: tag badges (`newTag`, `featureTag`, `bugFixTag`, `enhancementTag`), `realDevice`/`virtualDevice`, `videoEmbed`, `SupportedLanguages`, `CopyPageButton`, `AskAI`.
+
+### Theme overrides
+
+`src/theme/` contains swizzled Docusaurus components (Navbar, TOC, DocItem layout, sidebar items, etc.). Edit these to change site-wide layout/chrome rather than the underlying Docusaurus internals.
+
+## Auto-generated API reference (do not hand-edit)
+
+The `/api-doc/` section is fully generated and **gitignored** — regenerated on every build by the two `scripts/`:
+
+1. `scripts/build-api-data.js` — fetches ~12 live OpenAPI YAML specs from public Swagger servers (URLs hardcoded in the `API_SPECS` array), flattens/normalizes them, and writes `src/data/api/all-apis.json`.
+2. `scripts/generate-api-pages.js` — reads that JSON and emits one `.jsx` page per endpoint under `src/pages/api-doc/`, each rendering `<ApiDocPage>` (`src/pages/_ApiDocPage.jsx`).
+
+The interactive renderer (endpoint detail, "Try It" modal, code samples) lives in `src/component/ApiReference/`. To add or change an API, edit the `API_SPECS` list in `build-api-data.js` or the upstream spec — never edit the generated JSON or page files. Because generation hits the network, an offline `build`/`start` will warn and skip unreachable specs.
+
+## Gotchas
+
+- Build requires Node 18+ (CI uses Node 20). `CI: false` is set in the deploy workflow so warnings don't fail the build there — but `onBrokenLinks: 'throw'` still does.
+- The huge `docs/` directory is flat; use search (filename = slug) rather than browsing.
+- `package.json` declares a `pnpm` `packageManager` field, but the project is installed and built with **npm** (`--legacy-peer-deps`); `pnpm-lock.yaml` is gitignored.

--- a/docs/rbac-roles-and-permissions.md
+++ b/docs/rbac-roles-and-permissions.md
@@ -18,7 +18,6 @@ slug: rbac-roles-and-permissions/
 ---
 
 import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
-import NewTag from '../src/component/newTag';
 
 <script type="application/ld+json"
       dangerouslySetInnerHTML={{ __html: JSON.stringify({
@@ -54,7 +53,7 @@ Custom Roles and Permissions is an enterprise-level feature. Please contact your
 
 ## Prerequisites
 
-- You must be an **Admin** of your <BrandName /> organization.
+- You must be an **Admin** of your <BrandName /> organization. 
 - Ensure your organization has the RBAC feature enabled by the <BrandName /> team.
 - Familiarity with [User Management](/support/docs/user-management/) and [Team Management](/support/docs/team-management/) is recommended.
 
@@ -68,12 +67,16 @@ Navigate to **Organization Settings** > **Custom Roles & Permissions** from the 
 
 | Role | Description | Entity Permissions |
 |------|-------------|-------------------|
-| **Admin** | Full access to all products and entities with complete permissions. | List, Read, Create, Update, Delete, Execute on all entities |
-| **User** | Standard access with full permissions on most products and entities. | List, Read, Create, Update, Delete, Execute on all entities |
-| **Guest** | Read-only access across products with limited entity permissions. | List, Read only on entities |
+| **Admin** | Full access to all products and entities, plus organization-level administration such as settings, billing, integrations, and user and team management. | List, Read, Create, Update, Delete, Execute on all entities, plus organization administration |
+| **User** | Full permissions on all products and entities, but without organization-level administration. | List, Read, Create, Update, Delete, Execute on all entities |
+| **Guest** | Read-only access across products. | List, Read only on entities |
 
 :::tip
 Roles are auto-applied at login.
+:::
+
+:::info
+When a user is assigned more than one role, their effective permissions are the combination of all assigned roles, and the most permissive access applies. Permission changes take effect on the user's next request or page load, no re-login is required.
 :::
 
 ## Creating and Applying Custom Roles
@@ -122,42 +125,40 @@ When creating or editing a role, add **List of Products** as an entity and selec
 
 ## Entity Level Access
 
-Entity-level access allows you to configure granular permissions for specific items and product areas within the platform. Currently, entity-level access is supported for **Test Manager** only.
+Entity-level access allows you to configure granular permissions for specific items and product areas within the platform. Each product exposes its own set of entities, and you can grant specific permissions on each one.
+
+Entity-level access is available for the following products:
+
+| Product | Entities |
+|---------|----------|
+| **Test Manager** | Projects, Test Runs, Test Cases and Test Case Instances |
+| **Automation** | Projects, Builds, Test Case Instances |
+| **HyperExecute** | Projects, Workflows, Organization Settings |
+| **SmartUI** | Projects, Builds |
+| **Analytics & Insights** | Projects (applied to dashboards and reports, read-only) |
 
 :::info
-Support for entity-level access in other products is planned for future releases.
+Entity-level access for **App Automation** is planned for an upcoming release. The exact set of entities, and the actions available on each, can vary from one product to another.
 :::
 
 ### Select Specific Entities
 
-Assign permissions to specific items within the platform:
+When creating or editing a role, you can assign permissions to specific items rather than to all items of a type, for example, granting access only to selected Test Manager projects or to specific HyperExecute projects.
 
-| Entity | Description |
-|--------|-------------|
-| **Projects** | Grant access to Test Manager projects. |
-| **Test Runs** | Grant access to test runs. |
-| **Test Cases and Test Case Instances** | Grant access to Test Manager test cases and test case instances. |
+### Granular Control
 
-### Granular Control <NewTag value="Coming Soon" bgColor="#ffec02" color="#000" />
+For supported products, you can configure fine-grained permissions on each entity using the following permission levels:
 
-Configure fine-grained permissions within specific product areas:
+- **List**: View items in a list.
+- **Read**: View item details.
+- **Create**: Create new items.
+- **Update**: Modify existing items.
+- **Delete**: Remove items.
+- **Execute**: Run or trigger items (for example, abort a build or trigger a HyperExecute job).
 
-| Entity | Description |
-|--------|-------------|
-| **HyperExecute** | Control permissions for jobs, tasks, stages, and configurations within HyperExecute. |
-| **KaneAI and Test Manager** | Control permissions for test plans, builds, milestones, and other Test Manager entities. |
-| **Automation** | Control permissions for builds, sessions, and automation-related resources. |
-| **Analytics** | Control permissions for dashboards, widgets, and reporting features. |
-| **Organization** | Control permissions for organization-level settings, user management, and team management. |
-
-Each granular entity expands into sub-entities with specific permission levels:
-
-- **List**:View items in a list.
-- **Read**:View item details.
-- **Create**:Create new items.
-- **Update**:Modify existing items.
-- **Delete**:Remove items.
-- **Execute**:Run or trigger items (e.g., execute test runs, trigger jobs).
+:::note
+Not every permission level applies to every entity. For example, Analytics & Insights is a read-only reporting surface, so only **List** and **Read** apply there.
+:::
 
 
 <nav aria-label="breadcrumbs">


### PR DESCRIPTION
## Summary

Updates the customer-facing **Roles and Permissions (RBAC)** doc to reflect the latest RBAC capabilities, and adds a `CLAUDE.md` guidance file for the repo.

### `docs/rbac-roles-and-permissions.md`
- **Clarified Admin vs User** — Admin now correctly described as full operations **plus** organization-level administration (settings, billing, integrations, user/team management); User has full operations but no org administration. Previously the two roles looked identical.
- **Added a note** that multiple assigned roles combine (most-permissive access wins) and that permission changes apply on the next request/page load with no re-login.
- **Entity Level Access** — removed the stale "supported for Test Manager only" statement and added a supported-products → entities table (Test Manager, Automation, HyperExecute, SmartUI, Analytics & Insights); App Automation marked as upcoming.
- **Granular Control** — reframed from "Coming Soon" to the available permission levels (List, Read, Create, Update, Delete, Execute), with a note that not every level applies to every entity (e.g. Analytics is read-only).
- Removed the now-unused `NewTag` import.

### `CLAUDE.md`
- Adds repo guidance for future Claude Code sessions (commands, branch/deploy workflow, sidebars, auto-generated API reference, gotchas).

## Validation
- `npm run build` passes cleanly — no broken links, no RBAC-related warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)