### PR TITLE
docs: add SmartUI Automation Dashboard to sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -3389,6 +3389,11 @@ module.exports = {
         items: [
           {
             type: "doc",
+            label: "SmartUI in Automation Dashboard",
+            id: "smartui-automation-dashboard",
+          },
+          {
+            type: "doc",
             label: "Baseline Management",
             id: "smartui-baseline-management",
           },


### PR DESCRIPTION
## Summary

Adds `smartui-automation-dashboard` to the **Core Features** section in `sidebars.js` so the doc appears in the staging site navigation.

Companion to the doc added in #3087 (already merged).

## Changes

- **`sidebars.js`** — 5 lines added, no other files touched

## Test plan

- [ ] SmartUI in Automation Dashboard appears under Core Features in the left nav on staging
- [ ] Clicking it loads `/support/docs/smartui-automation-dashboard/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)