### PR TITLE
docs: Tunnel | Add release note for gRPC/HTTP/2 CONNECT fix (TE-17124)

### DIFF
--- a/docs/tunel-release-notes.md
+++ b/docs/tunel-release-notes.md
@@ -41,6 +41,10 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
       })
     }}
 ></script>
+## Version 3.2.29 (14th June 2026)
+- **gRPC / HTTP/2 Tunnel Fix**
+  - Fixed gRPC-over-HTTP/2 traffic hanging through the tunnel for strict HTTP/1.1 CONNECT clients (e.g. Flutter / grpc-dart apps on real devices). The tunnel now replies `HTTP/1.1 200` on the passthrough CONNECT path, so these clients establish the tunnel instead of timing out.
+
 ## Version 3.2.28 (24th May 2026)
 - **Security Updates and Stability Fixes**
   - Security Fixes for CVE


### PR DESCRIPTION
## What
Adds a Tunnel Client release note (**Version 3.2.29 — 14th June 2026**) for the gRPC-over-HTTP/2 passthrough CONNECT fix.

## Why
Strict HTTP/1.1 CONNECT clients (e.g. Flutter / grpc-dart apps on real devices) hung through the tunnel because the passthrough CONNECT path replied with `HTTP/1.0 200 OK`. The fix replies `HTTP/1.1 200` so these clients establish the tunnel instead of timing out.

## References
- Code PR: LambdatestIncPrivate/burrow#634
- Jira: [TE-17124](https://lambdatest.atlassian.net/browse/TE-17124)
- Customer ticket: [LTPM-3067](https://lambdatest.atlassian.net/browse/LTPM-3067)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TE-17124]: https://lambdatest.atlassian.net/browse/TE-17124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LTPM-3067]: https://lambdatest.atlassian.net/browse/LTPM-3067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ