### PR TITLE
TE-17800: surface spec body example + flatten single-item array bodies in Try It

### DIFF
--- a/scripts/build-api-data.js
+++ b/scripts/build-api-data.js
@@ -117,6 +117,30 @@ function categorizeParams(parameters) {
   return { auth, pathParams, queryParams };
 }
 
+// Local patches for known-wrong examples in upstream specs.
+// Each function takes the raw example and returns the corrected one.
+// Remove the matching entry once the upstream YAML is fixed.
+const REQUEST_BODY_EXAMPLE_OVERRIDES = {
+  // TE-17800: upstream uses `parent_folder_id`, real API expects `parent_id`.
+  // Rename both the key and its self-referential placeholder value.
+  'Test Manager|POST|/api/v1/folder': (ex) => {
+    if (!ex || !Array.isArray(ex.folders)) return ex;
+    return {
+      ...ex,
+      folders: ex.folders.map((f) => {
+        if (!f || typeof f !== 'object' || !('parent_folder_id' in f)) return f;
+        const { parent_folder_id, ...rest } = f;
+        return { ...rest, parent_id: 'parent_id' };
+      }),
+    };
+  },
+  'Test Manager|PUT|/api/v1/folder': (ex) => {
+    if (!ex || typeof ex !== 'object' || !('parent_folder_id' in ex)) return ex;
+    const { parent_folder_id, ...rest } = ex;
+    return { ...rest, parent_id: 'parent_id' };
+  },
+};
+
 function resolveRef(ref, spec) {
   if (!ref || !ref.startsWith('#/')) return null;
   const parts = ref.slice(2).split('/');
@@ -145,6 +169,15 @@ function extractRequestBody(requestBody, spec, ctx = {}) {
     }
     schema = merged;
   }
+  // Resolve the example up front (with local override) so derived property names
+  // from the example fallback below also pick up the correction.
+  const rawExample = bodyContent.example ?? schema.example;
+  const overrideKey = (ctx.specName && ctx.method && ctx.path)
+    ? `${ctx.specName}|${ctx.method}|${ctx.path}`
+    : null;
+  const overrideFn = overrideKey ? REQUEST_BODY_EXAMPLE_OVERRIDES[overrideKey] : null;
+  const exampleValue = overrideFn ? overrideFn(rawExample) : rawExample;
+
   const props = schema.properties || {};
   const required = schema.required || [];
   let properties = Object.entries(props).map(([name, propSchema]) => {
@@ -161,9 +194,8 @@ function extractRequestBody(requestBody, spec, ctx = {}) {
   // editable inputs. Inferred types and required flags are best-effort;
   // long-term fix is for spec authors to add proper `properties`.
   if (properties.length === 0) {
-    const example = bodyContent.example ?? schema.example;
-    if (example && typeof example === 'object' && !Array.isArray(example)) {
-      properties = Object.entries(example).map(([name, value]) => {
+    if (exampleValue && typeof exampleValue === 'object' && !Array.isArray(exampleValue)) {
+      properties = Object.entries(exampleValue).map(([name, value]) => {
         let type = 'string';
         if (typeof value === 'number') type = Number.isInteger(value) ? 'integer' : 'number';
         else if (typeof value === 'boolean') type = 'boolean';
@@ -179,7 +211,12 @@ function extractRequestBody(requestBody, spec, ctx = {}) {
     }
   }
 
-  return { contentType, description: requestBody.description || '', properties };
+  return {
+    contentType,
+    description: requestBody.description || '',
+    properties,
+    ...(exampleValue !== undefined && { example: exampleValue }),
+  };
 }
 
 function schemaToExample(schema, spec, seen = new Set()) {

--- a/scripts/build-api-data.js
+++ b/scripts/build-api-data.js
@@ -134,6 +134,7 @@ const REQUEST_BODY_EXAMPLE_OVERRIDES = {
       }),
     };
   },
+  // TE-17800: same key rename for the update endpoint.
   'Test Manager|PUT|/api/v1/folder': (ex) => {
     if (!ex || typeof ex !== 'object' || !('parent_folder_id' in ex)) return ex;
     const { parent_folder_id, ...rest } = ex;

--- a/src/component/ApiReference/TryItModal.js
+++ b/src/component/ApiReference/TryItModal.js
@@ -4,7 +4,7 @@ import { Highlight, themes } from 'prism-react-renderer';
 import MethodBadge from './MethodBadge';
 import InlineText from './InlineText';
 import styles from './TryItModal.module.css';
-import { LANGUAGES, generateCodeExample, LangDropdownPortal, LangSelectorButton, coerceBodyValue } from './langUtils';
+import { LANGUAGES, generateCodeExample, LangDropdownPortal, LangSelectorButton, coerceBodyValue, detectFlattenedArrayBody } from './langUtils';
 
 const githubWithGreenKeys = {
   ...themes.github,
@@ -94,19 +94,56 @@ function buildCurl(endpoint, username, password, params, baseUrl) {
   const authLine = hasAuth ? ` \\\n  --header 'Authorization: ${authHeader}'` : '';
 
   const bodyProps = endpoint.requestBody?.properties || [];
+  const rawExample = endpoint.requestBody?.example;
   const contentType = endpoint.requestBody?.contentType || 'application/json';
+  const isMultipart = contentType === 'multipart/form-data';
+  const flattenedBody = !isMultipart ? detectFlattenedArrayBody(endpoint) : null;
+  const userFilledBody = flattenedBody
+    ? flattenedBody.innerFields.some((f) => params[`__body__${f.name}`])
+    : bodyProps.some((p) => params[`__body__${p.name}`]);
+  const useRawExample = !isMultipart && !flattenedBody && !userFilledBody
+    && rawExample != null && typeof rawExample === 'object';
   let bodyLine = '';
-  if (bodyProps.length > 0) {
-    const bodyEntries = bodyProps.map((p) => [p.name, coerceBodyValue(params[`__body__${p.name}`] || '', p.type)]);
-    if (contentType === 'multipart/form-data') {
+  if (bodyProps.length > 0 || useRawExample || flattenedBody) {
+    if (isMultipart) {
+      const bodyEntries = bodyProps.map((p) => [p.name, coerceBodyValue(params[`__body__${p.name}`] || '', p.type)]);
       bodyLine = bodyEntries
         .filter(([, v]) => v)
         .map(([k, v]) => ` \\\n  --form '${k}=${v}'`)
         .join('');
+    } else if (flattenedBody) {
+      // Assemble inner object from per-field inputs (with example fallback),
+      // wrap under the spec's array key.
+      const inner = {};
+      for (const f of flattenedBody.innerFields) {
+        const raw = params[`__body__${f.name}`];
+        const fromEx = flattenedBody.innerExample[f.name];
+        const val = (raw !== undefined && raw !== '') ? raw : fromEx;
+        if (val !== undefined && val !== '') inner[f.name] = val;
+      }
+      const bodyJson = { [flattenedBody.wrapperKey]: [inner] };
+      bodyLine = ` \\\n  --header 'Content-Type: application/json' \\\n  --data '${JSON.stringify(bodyJson, null, 2)}'`;
     } else {
-      const bodyObj = Object.fromEntries(bodyEntries.filter(([, v]) => v));
-      if (Object.keys(bodyObj).length) {
-        bodyLine = ` \\\n  --header 'Content-Type: application/json' \\\n  --data '${JSON.stringify(bodyObj)}'`;
+      let bodyJson;
+      if (useRawExample) {
+        bodyJson = rawExample;
+      } else {
+        // Untyped fields fall back to the spec example so editing one field
+        // doesn't blank out the others.
+        const fromExample = (p) => (rawExample && typeof rawExample === 'object') ? rawExample[p.name] : undefined;
+        const bodyEntries = bodyProps.map((p) => {
+          const raw = params[`__body__${p.name}`] || '';
+          if (!raw) {
+            const ex = fromExample(p);
+            return [p.name, ex !== undefined ? ex : ''];
+          }
+          return [p.name, coerceBodyValue(raw, p.type)];
+        });
+        const bodyObj = Object.fromEntries(bodyEntries.filter(([, v]) => v !== '' && v !== undefined));
+        if (Object.keys(bodyObj).length) bodyJson = bodyObj;
+      }
+      if (bodyJson !== undefined) {
+        bodyLine = ` \\\n  --header 'Content-Type: application/json' \\\n  --data '${JSON.stringify(bodyJson, null, 2)}'`;
       }
     }
   }
@@ -284,7 +321,22 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
 
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [params, setParams] = useState({});
+  // Compute once at render time — both the params initializer and the body
+  // section need it, and `endpoint` is stable for the modal's lifetime.
+  const flattenedBody = detectFlattenedArrayBody(endpoint);
+  // Prefill body fields with the spec's example so the form is usable on first
+  // open. Flattened-array bodies expose inner primitive fields (each prefilled
+  // with the inner example value).
+  const [params, setParams] = useState(() => {
+    const initial = {};
+    if (flattenedBody) {
+      for (const f of flattenedBody.innerFields) {
+        const val = flattenedBody.innerExample[f.name];
+        initial[`__body__${f.name}`] = val == null ? '' : String(val);
+      }
+    }
+    return initial;
+  });
   const [response, setResponse] = useState(null);
   const [loading, setLoading] = useState(false);
   const [activeResTab, setActiveResTab] = useState(null);
@@ -348,17 +400,50 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
       : '';
 
     const bodyProps = endpoint.requestBody?.properties || [];
+    const rawExample = endpoint.requestBody?.example;
     const contentType = endpoint.requestBody?.contentType || 'application/json';
+    const isMultipart = contentType === 'multipart/form-data';
+    const flattenedBodyHS = !isMultipart ? detectFlattenedArrayBody(endpoint) : null;
+    const userFilledBody = flattenedBodyHS
+      ? flattenedBodyHS.innerFields.some((f) => params[`__body__${f.name}`])
+      : bodyProps.some((p) => params[`__body__${p.name}`]);
+    const useRawExample = !isMultipart && !flattenedBodyHS && !userFilledBody
+      && rawExample != null && typeof rawExample === 'object';
     let fetchBody;
     let fetchHeaders = { ...(authHeader && { Authorization: authHeader }) };
-    if (bodyProps.length > 0) {
-      if (contentType === 'multipart/form-data') {
+    if (bodyProps.length > 0 || useRawExample || flattenedBodyHS) {
+      if (isMultipart) {
         const fd = new FormData();
         bodyProps.forEach((p) => { if (params[`__body__${p.name}`]) fd.append(p.name, params[`__body__${p.name}`]); });
         fetchBody = fd;
         // Don't set Content-Type for FormData — browser sets it with boundary
+      } else if (flattenedBodyHS) {
+        const inner = {};
+        for (const f of flattenedBodyHS.innerFields) {
+          const raw = params[`__body__${f.name}`];
+          const fromEx = flattenedBodyHS.innerExample[f.name];
+          const val = (raw !== undefined && raw !== '') ? raw : fromEx;
+          if (val !== undefined && val !== '') inner[f.name] = val;
+        }
+        fetchBody = JSON.stringify({ [flattenedBodyHS.wrapperKey]: [inner] });
+        fetchHeaders['Content-Type'] = 'application/json';
+      } else if (useRawExample) {
+        fetchBody = JSON.stringify(rawExample);
+        fetchHeaders['Content-Type'] = 'application/json';
       } else {
-        const bodyObj = Object.fromEntries(bodyProps.map((p) => [p.name, coerceBodyValue(params[`__body__${p.name}`] || '', p.type)]).filter(([, v]) => v));
+        // Untyped fields fall back to the spec example so partial edits don't
+        // strip the other example values.
+        const fromExample = (p) => (rawExample && typeof rawExample === 'object') ? rawExample[p.name] : undefined;
+        const bodyObj = Object.fromEntries(
+          bodyProps.map((p) => {
+            const raw = params[`__body__${p.name}`] || '';
+            if (!raw) {
+              const ex = fromExample(p);
+              return [p.name, ex !== undefined ? ex : ''];
+            }
+            return [p.name, coerceBodyValue(raw, p.type)];
+          }).filter(([, v]) => v !== '' && v !== undefined)
+        );
         if (Object.keys(bodyObj).length) {
           fetchBody = JSON.stringify(bodyObj);
           fetchHeaders['Content-Type'] = 'application/json';
@@ -550,16 +635,30 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
                 title="Body"
                 description={endpoint.requestBody.description || null}
               >
-                {bodyProps.map((p) => (
-                  <ParamField
-                    key={p.name} label={p.name}
-                    type={p.type} required={p.required}
-                    description={p.description}
-                    enumValues={p.enum}
-                    value={params[`__body__${p.name}`] || ''} onChange={(v) => updateParam(`__body__${p.name}`, v)}
-                    placeholder={(p.type || '').toLowerCase().includes('array') ? 'e.g. ["val1", "val2"] or val1, val2' : undefined}
-                  />
-                ))}
+                {flattenedBody ? (
+                  flattenedBody.innerFields.map((f) => (
+                    <ParamField
+                      key={f.name}
+                      label={f.name}
+                      type={f.type}
+                      required={f.required}
+                      description={f.description}
+                      value={params[`__body__${f.name}`] || ''}
+                      onChange={(v) => updateParam(`__body__${f.name}`, v)}
+                    />
+                  ))
+                ) : (
+                  bodyProps.map((p) => (
+                    <ParamField
+                      key={p.name} label={p.name}
+                      type={p.type} required={p.required}
+                      description={p.description}
+                      enumValues={p.enum}
+                      value={params[`__body__${p.name}`] || ''} onChange={(v) => updateParam(`__body__${p.name}`, v)}
+                      placeholder={(p.type || '').toLowerCase().includes('array') ? 'e.g. ["val1", "val2"] or val1, val2' : undefined}
+                    />
+                  ))
+                )}
               </CollapsibleSection>
             )}
           </div>

--- a/src/component/ApiReference/TryItModal.js
+++ b/src/component/ApiReference/TryItModal.js
@@ -118,7 +118,9 @@ function buildCurl(endpoint, username, password, params, baseUrl) {
       for (const f of flattenedBody.innerFields) {
         const raw = params[`__body__${f.name}`];
         const fromEx = flattenedBody.innerExample[f.name];
-        const val = (raw !== undefined && raw !== '') ? raw : fromEx;
+        const val = (raw !== undefined && raw !== '')
+          ? coerceBodyValue(raw, f.type)
+          : fromEx;
         if (val !== undefined && val !== '') inner[f.name] = val;
       }
       const bodyJson = { [flattenedBody.wrapperKey]: [inner] };
@@ -128,7 +130,7 @@ function buildCurl(endpoint, username, password, params, baseUrl) {
       if (useRawExample) {
         bodyJson = rawExample;
       } else {
-        // Untyped fields fall back to the spec example so editing one field
+        // Empty inputs fall back to the spec example so editing one field
         // doesn't blank out the others.
         const fromExample = (p) => (rawExample && typeof rawExample === 'object') ? rawExample[p.name] : undefined;
         const bodyEntries = bodyProps.map((p) => {
@@ -422,7 +424,9 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
         for (const f of flattenedBodyHS.innerFields) {
           const raw = params[`__body__${f.name}`];
           const fromEx = flattenedBodyHS.innerExample[f.name];
-          const val = (raw !== undefined && raw !== '') ? raw : fromEx;
+          const val = (raw !== undefined && raw !== '')
+            ? coerceBodyValue(raw, f.type)
+            : fromEx;
           if (val !== undefined && val !== '') inner[f.name] = val;
         }
         fetchBody = JSON.stringify({ [flattenedBodyHS.wrapperKey]: [inner] });
@@ -431,7 +435,7 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
         fetchBody = JSON.stringify(rawExample);
         fetchHeaders['Content-Type'] = 'application/json';
       } else {
-        // Untyped fields fall back to the spec example so partial edits don't
+        // Empty inputs fall back to the spec example so partial edits don't
         // strip the other example values.
         const fromExample = (p) => (rawExample && typeof rawExample === 'object') ? rawExample[p.name] : undefined;
         const bodyObj = Object.fromEntries(

--- a/src/component/ApiReference/langUtils.js
+++ b/src/component/ApiReference/langUtils.js
@@ -54,8 +54,8 @@ export function detectFlattenedArrayBody(endpoint) {
   if (!Array.isArray(arr) || arr.length !== 1) return null;
   const inner = arr[0];
   if (!inner || typeof inner !== 'object' || Array.isArray(inner)) return null;
-  // Only flatten when every inner value is primitive — keeps the form usable
-  // and avoids nested-textarea complexity.
+  // Bail when any inner value is an array or non-null object — the flat form
+  // can't represent nesting. `null` values are accepted (typed as string).
   const innerFields = Object.entries(inner).map(([name, value]) => {
     let type = 'string';
     if (typeof value === 'number') type = Number.isInteger(value) ? 'integer' : 'number';
@@ -122,7 +122,9 @@ export function generateCodeExample(endpoint, language, { username, password, pa
     for (const f of flattenedBody.innerFields) {
       const raw = params && params[`__body__${f.name}`];
       const fromEx = flattenedBody.innerExample[f.name];
-      const val = (raw !== undefined && raw !== '') ? raw : fromEx;
+      const val = (raw !== undefined && raw !== '')
+        ? coerceBodyValue(raw, f.type)
+        : fromEx;
       if (val !== undefined && val !== '') inner[f.name] = val;
     }
     bodyExample = { [flattenedBody.wrapperKey]: [inner] };

--- a/src/component/ApiReference/langUtils.js
+++ b/src/component/ApiReference/langUtils.js
@@ -38,6 +38,35 @@ export function coerceBodyValue(raw, type) {
   return raw;
 }
 
+// Detect bodies shaped like `{ wrapper: [ { ...primitive fields } ] }` (e.g.
+// Test Manager Create Folder). When matched, the form can render the inner
+// object's primitive fields directly and the body assembly wraps them back
+// into the array shape — giving the same per-field UX as a flat-body endpoint.
+export function detectFlattenedArrayBody(endpoint) {
+  if (!endpoint || !endpoint.requestBody) return null;
+  const props = endpoint.requestBody.properties || [];
+  if (props.length !== 1) return null;
+  const only = props[0];
+  if (only.type !== 'array') return null;
+  const example = endpoint.requestBody.example;
+  if (!example || typeof example !== 'object' || Array.isArray(example)) return null;
+  const arr = example[only.name];
+  if (!Array.isArray(arr) || arr.length !== 1) return null;
+  const inner = arr[0];
+  if (!inner || typeof inner !== 'object' || Array.isArray(inner)) return null;
+  // Only flatten when every inner value is primitive — keeps the form usable
+  // and avoids nested-textarea complexity.
+  const innerFields = Object.entries(inner).map(([name, value]) => {
+    let type = 'string';
+    if (typeof value === 'number') type = Number.isInteger(value) ? 'integer' : 'number';
+    else if (typeof value === 'boolean') type = 'boolean';
+    else if (Array.isArray(value) || (typeof value === 'object' && value !== null)) return null;
+    return { name, type, required: false, description: '' };
+  });
+  if (innerFields.some((f) => f === null)) return null;
+  return { wrapperKey: only.name, innerFields, innerExample: inner };
+}
+
 // prism language mapping — only use languages bundled in prism-react-renderer
 export const LANGUAGES = [
   { label: 'cURL',       prism: 'clike' },
@@ -75,21 +104,50 @@ export function generateCodeExample(endpoint, language, { username, password, pa
   const bodyProps = endpoint.requestBody?.properties || [];
   const contentType = endpoint.requestBody?.contentType || 'application/json';
   const isMultipart = contentType === 'multipart/form-data';
-  const bodyExample = bodyProps.length > 0
-    ? Object.fromEntries(bodyProps.map((p) => {
-        const raw = params && params[`__body__${p.name}`];
-        let val;
-        if (raw) {
-          val = coerceBodyValue(raw, p.type);
-        } else {
-          val = p.type.includes('integer') || p.type.includes('number') ? 0 :
-                p.type.includes('boolean') ? true :
-                p.type.includes('array') ? [] :
-                `<${p.name}>`;
-        }
-        return [p.name, val];
-      }))
-    : null;
+  const rawExample = endpoint.requestBody?.example;
+  const flattenedBody = !isMultipart ? detectFlattenedArrayBody(endpoint) : null;
+  const userFilledBody = flattenedBody
+    ? flattenedBody.innerFields.some((f) => params && params[`__body__${f.name}`])
+    : bodyProps.some((p) => params && params[`__body__${p.name}`]);
+  // Use the spec's example block as the body when the user hasn't typed
+  // anything — keeps nested arrays/objects that property-based synthesis
+  // would flatten to `[]` (e.g. Test Manager Create Folder's `folders[]`).
+  const useRawExample = !isMultipart && !flattenedBody && !userFilledBody
+    && rawExample != null && typeof rawExample === 'object';
+  let bodyExample;
+  if (flattenedBody) {
+    // Assemble the inner object from per-field inputs (with example fallback),
+    // wrap under the spec's array key so the snippet matches the spec shape.
+    const inner = {};
+    for (const f of flattenedBody.innerFields) {
+      const raw = params && params[`__body__${f.name}`];
+      const fromEx = flattenedBody.innerExample[f.name];
+      const val = (raw !== undefined && raw !== '') ? raw : fromEx;
+      if (val !== undefined && val !== '') inner[f.name] = val;
+    }
+    bodyExample = { [flattenedBody.wrapperKey]: [inner] };
+  } else if (useRawExample) {
+    bodyExample = rawExample;
+  } else if (bodyProps.length > 0) {
+    bodyExample = Object.fromEntries(bodyProps.map((p) => {
+      const raw = params && params[`__body__${p.name}`];
+      const fromExample = rawExample && typeof rawExample === 'object' ? rawExample[p.name] : undefined;
+      let val;
+      if (raw) {
+        val = coerceBodyValue(raw, p.type);
+      } else if (fromExample !== undefined) {
+        val = fromExample;
+      } else {
+        val = p.type.includes('integer') || p.type.includes('number') ? 0 :
+              p.type.includes('boolean') ? true :
+              p.type.includes('array') ? [] :
+              `<${p.name}>`;
+      }
+      return [p.name, val];
+    }));
+  } else {
+    bodyExample = null;
+  }
 
   switch (language) {
     case 'cURL': {


### PR DESCRIPTION
## Summary

Three layered fixes to the Try It modal's request-body handling, all driven by the `requestBody.example` blocks that already exist in our upstream OpenAPI specs. Visible win: **POST `/api/v1/folder`** now ships a populated cURL body and a usable per-field form (matches the old Swagger UI), and the `parent_folder_id` → `parent_id` discrepancy from TE-17800 is corrected.

### What changed

1. **Carry the spec example through `extractRequestBody`.**
`scripts/build-api-data.js` now attaches `example` alongside `properties` on `requestBody`, so downstream code can use the author's intended payload. ~18 example-only endpoints (most of Test Manager, Analytics, parts of User Management) previously rendered hollow bodies (e.g. `"folders": []`) and now show the populated example.

2. **Local override for known-wrong upstream examples.**
New `REQUEST_BODY_EXAMPLE_OVERRIDES` map keyed by `<spec>|<method>|<path>`. Currently fixes TE-17800: upstream YAML uses `parent_folder_id` for Test Manager POST/PUT `/api/v1/folder` but the real API expects `parent_id`. The override flips both the key and the self-referential value (now `"parent_id": "parent_id"`). Marked with `// TE-17800` for easy removal once the upstream YAML is patched.

3. **Flatten single-item array bodies into per-field form inputs.**
New `detectFlattenedArrayBody` helper recognises bodies shaped like `{ wrapper: [ { ...primitive fields } ] }` (POST `/api/v1/folder` is the only current trigger). When matched, the Body section renders one input per inner field, prefilled with the example, and `buildCurl`/`handleSend`/`langUtils` wrap the typed inputs back into the array shape on send. Other bodies retain existing rendering. Multipart endpoints explicitly gated off.

Side effect: language tabs (Python/JS/PHP/Go/Java/Ruby) and the live Send request go through the same assembly, so cURL, code snippets, and the real `fetch` all agree on body shape.

### Endpoints affected

| Cohort | Count | What changed |
|---|---|---|
| Example-only specs (hollow body before) | 18 | Now ship populated cURL/body via spec `example:` |
| Had properties + example (synth before) | 24 | Now prefer the spec example over `<placeholder>` synthesis |
| Test Manager POST `/api/v1/folder` | 1 | Flattened to 5 primitive inputs; cURL wraps as `{folders:[{...}]}` |
| TE-17800 field rename | POST + PUT `/api/v1/folder` | `parent_folder_id` → `parent_id` (key + value) |
| Multipart, no-example, primitive-body endpoints | unchanged | No regression |

## Test plan

- [ ] `node scripts/build-api-data.js` exits 0 (warns for the 18 example-only endpoints only)
- [ ] `npm start` boots cleanly
- [ ] POST `/api/v1/folder` Try It: Body section shows 5 prefilled inputs (`name`, `description`, `entity_id`, `entity_type`, `parent_id`)
- [ ] POST `/api/v1/folder` cURL panel: `--data '{ "folders": [{...}] }'` with `parent_id`
- [ ] PUT `/api/v1/folder` Try It: 4 primitive inputs (`id`, `name`, `description`, `parent_id`), cURL `--data` includes `parent_id`
- [ ] PUT folder: typing into one field keeps the other three values from the example (no blanking)
- [ ] Multipart (Automated Screenshots `POST /`): still renders `--form` lines, no textarea, no `--data`
- [ ] Endpoint with array prop but no example (Selenium `POST /sessions/{id}/exceptions`): unchanged behavior, still `"exception": []`
- [ ] User Management `POST /api/user`: cURL now uses spec example values instead of `<password>` placeholders
- [ ] Language tabs (Python/JS/PHP/Go/Java/Ruby) on POST folder all render the wrapped JSON correctly
- [ ] Click Send on POST folder with dummy creds: Network tab shows `POST` with full wrapped JSON body

## Follow-ups (not in this PR)

- Open a ticket against the team owning `swagger-api-support.lambdatest.com/test_management/openapi.yaml` to fix `parent_folder_id` → `parent_id` upstream. Once shipped, delete the two `// TE-17800` entries in `REQUEST_BODY_EXAMPLE_OVERRIDES`.
- 5 User Management `/token` endpoints still ship with `requestBody: null` due to an unrelated guard at `extractRequestBody:136` (missing `schema:`); out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)