### PR TITLE
API Reference: Variant tabs + vertical stacking on static page

### DIFF
--- a/scripts/build-api-data.js
+++ b/scripts/build-api-data.js
@@ -134,13 +134,57 @@ const REQUEST_BODY_EXAMPLE_OVERRIDES = {
       }),
     };
   },
-  // TE-17800: same key rename for the update endpoint.
-  'Test Manager|PUT|/api/v1/folder': (ex) => {
-    if (!ex || typeof ex !== 'object' || !('parent_folder_id' in ex)) return ex;
-    const { parent_folder_id, ...rest } = ex;
-    return { ...rest, parent_id: 'parent_id' };
-  },
+  // PUT /api/v1/folder is now in REQUEST_BODY_VARIANTS_OVERRIDES below — the
+  // upstream example omits the `action` discriminator and conflates rename/move.
 };
+
+// Variant overrides expose multiple body shapes for one endpoint. The modal
+// renders a tab per variant; each variant has its own example + derived fields.
+// Use this when an endpoint accepts distinct payload shapes selected by a
+// discriminator (e.g. PUT /api/v1/folder uses `action: "update"` vs "move").
+const REQUEST_BODY_VARIANTS_OVERRIDES = {
+  // TE-17800: PUT /api/v1/folder serves two operations:
+  //  - Rename: action="update", no parent_id/entity_type/serial_no
+  //  - Move:   action="move",   adds parent_id + entity_type + serial_no
+  // The upstream YAML ships a single example that matches neither real payload.
+  'Test Manager|PUT|/api/v1/folder': () => ([
+    {
+      name: 'Rename',
+      example: {
+        id: 'folder_id',
+        action: 'update',
+        entity_id: 'project_id',
+        name: 'Test Folder - LambdaTest Demo',
+      },
+    },
+    {
+      name: 'Move',
+      example: {
+        id: 'folder_id',
+        action: 'move',
+        entity_id: 'project_id',
+        entity_type: 'project',
+        name: 'Test Folder - LambdaTest Demo',
+        parent_id: 'parent_id',
+        serial_no: 1,
+      },
+    },
+  ]),
+};
+
+// Infer flat field metadata from a primitive-only example object — same logic
+// used by the legacy schema-less-fallback path, factored out for variant reuse.
+function inferFieldsFromExample(example) {
+  if (!example || typeof example !== 'object' || Array.isArray(example)) return [];
+  return Object.entries(example).map(([name, value]) => {
+    let type = 'string';
+    if (typeof value === 'number') type = Number.isInteger(value) ? 'integer' : 'number';
+    else if (typeof value === 'boolean') type = 'boolean';
+    else if (Array.isArray(value)) type = 'array';
+    else if (typeof value === 'object' && value !== null) type = 'object';
+    return { name, type, required: false, description: '' };
+  });
+}
 
 function resolveRef(ref, spec) {
   if (!ref || !ref.startsWith('#/')) return null;
@@ -195,28 +239,37 @@ function extractRequestBody(requestBody, spec, ctx = {}) {
   // editable inputs. Inferred types and required flags are best-effort;
   // long-term fix is for spec authors to add proper `properties`.
   if (properties.length === 0) {
-    if (exampleValue && typeof exampleValue === 'object' && !Array.isArray(exampleValue)) {
-      properties = Object.entries(exampleValue).map(([name, value]) => {
-        let type = 'string';
-        if (typeof value === 'number') type = Number.isInteger(value) ? 'integer' : 'number';
-        else if (typeof value === 'boolean') type = 'boolean';
-        else if (Array.isArray(value)) type = 'array';
-        else if (typeof value === 'object' && value !== null) type = 'object';
-        return { name, type, required: false, description: '' };
-      });
-      if (properties.length > 0) {
-        const loc = ctx.method && ctx.path ? `${ctx.method} ${ctx.path}` : '(unknown endpoint)';
-        const src = ctx.specName ? ` [${ctx.specName}]` : '';
-        console.warn(`⚠️  ${loc}${src}: requestBody has no schema.properties; derived ${properties.length} field(s) from example. Spec should declare properties for accurate types/required/descriptions.`);
-      }
+    properties = inferFieldsFromExample(exampleValue);
+    if (properties.length > 0) {
+      const loc = ctx.method && ctx.path ? `${ctx.method} ${ctx.path}` : '(unknown endpoint)';
+      const src = ctx.specName ? ` [${ctx.specName}]` : '';
+      console.warn(`⚠️  ${loc}${src}: requestBody has no schema.properties; derived ${properties.length} field(s) from example. Spec should declare properties for accurate types/required/descriptions.`);
     }
   }
+
+  // Variant overrides: attach per-tab examples + derived fields when an
+  // endpoint serves multiple payload shapes (e.g. PUT folder rename vs move).
+  const variantsFn = overrideKey ? REQUEST_BODY_VARIANTS_OVERRIDES[overrideKey] : null;
+  const variants = variantsFn
+    ? variantsFn().map((v) => ({
+        name: v.name,
+        example: v.example,
+        properties: inferFieldsFromExample(v.example),
+      }))
+    : null;
+
+  // When variants are present, the first one becomes the canonical top-level
+  // example + properties so non-variant-aware consumers (e.g. the static
+  // CodeExamples panel) show a sensible default instead of stale spec data.
+  const finalExample = variants && variants.length > 0 ? variants[0].example : exampleValue;
+  const finalProperties = variants && variants.length > 0 ? variants[0].properties : properties;
 
   return {
     contentType,
     description: requestBody.description || '',
-    properties,
-    ...(exampleValue !== undefined && { example: exampleValue }),
+    properties: finalProperties,
+    ...(finalExample !== undefined && { example: finalExample }),
+    ...(variants && variants.length > 0 && { variants }),
   };
 }
 

--- a/src/component/ApiReference/CodeExamples.js
+++ b/src/component/ApiReference/CodeExamples.js
@@ -74,6 +74,57 @@ function CodeHighlight({ code, language }) {
   );
 }
 
+// One stacked code panel — title bar with copy button (and optional language
+// selector on the first panel of a multi-variant code section), code body below.
+function CodePanel({
+  title, code, language,
+  showLangSelector, selectedLang, setSelectedLang,
+  langDropdownOpen, setLangDropdownOpen, closeLangDropdown, langBtnRef,
+  onCopy,
+}) {
+  const [copied, setCopied] = useState(false);
+  function handleCopy() {
+    onCopy(setCopied);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+  return (
+    <div style={{ border: '1px solid var(--ifm-color-emphasis-200)', borderRadius: '12px', overflow: 'hidden' }}>
+      <div className="flex items-center gap-2 px-4 py-2.5" style={{ background: 'var(--ifm-color-emphasis-100)', borderBottom: '1px solid var(--ifm-color-emphasis-200)' }}>
+        <span className="flex-1 text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{title}</span>
+        {showLangSelector && (
+          <>
+            <LangSelectorButton
+              selectedLang={selectedLang}
+              open={langDropdownOpen}
+              onClick={() => setLangDropdownOpen((o) => !o)}
+              btnRef={langBtnRef}
+            />
+            <LangDropdownPortal
+              open={langDropdownOpen}
+              anchorRef={langBtnRef}
+              langs={LANGUAGES}
+              selected={selectedLang}
+              onSelect={setSelectedLang}
+              onClose={closeLangDropdown}
+            />
+          </>
+        )}
+        <button
+          onClick={handleCopy}
+          className="p-1.5 rounded-md border-0 bg-transparent appearance-none cursor-pointer text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+          aria-label="Copy code"
+        >
+          {copied ? <CheckIcon /> : <CopyIcon />}
+        </button>
+      </div>
+      <div style={{ background: 'var(--ifm-background-color)' }}>
+        <CodeHighlight code={code} language={language} />
+      </div>
+    </div>
+  );
+}
+
 function formatResponse(value) {
   if (value == null) return '';
   if (typeof value === 'string') {
@@ -86,7 +137,7 @@ function formatResponse(value) {
   return JSON.stringify(value, null, 2);
 }
 
-export default function CodeExamples({ endpoint, selectedLang: selectedLangProp, onLangChange, selectedVariantIdx = 0 }) {
+export default function CodeExamples({ endpoint, selectedLang: selectedLangProp, onLangChange }) {
   const [localLang, setLocalLang] = useState('cURL');
   const selectedLang = selectedLangProp !== undefined ? selectedLangProp : localLang;
   const setSelectedLang = onLangChange || setLocalLang;
@@ -99,22 +150,28 @@ export default function CodeExamples({ endpoint, selectedLang: selectedLangProp,
 
   if (!endpoint) return null;
 
-  // When the endpoint ships requestBody.variants, swap the selected variant's
-  // example + properties into a shimmed endpoint so the snippet matches the
-  // tab the user picked over in the Body section.
+  // When the endpoint ships requestBody.variants (e.g. PUT folder rename/move),
+  // render one code panel per variant stacked vertically. Each panel gets the
+  // variant's example + properties as a shimmed endpoint so the snippet matches
+  // that payload shape. Plain endpoints render a single panel as before.
   const variants = endpoint.requestBody?.variants;
-  const effectiveEndpoint = (variants && variants[selectedVariantIdx])
-    ? {
-        ...endpoint,
-        requestBody: {
-          ...endpoint.requestBody,
-          properties: variants[selectedVariantIdx].properties,
-          example: variants[selectedVariantIdx].example,
-        },
-      }
-    : endpoint;
+  const summary = endpoint.name || endpoint.summary || '';
+  const codePanels = (variants && variants.length > 0)
+    ? variants.map((v) => ({
+        title: `${summary} (${v.name})`,
+        code: generateCodeExample(
+          {
+            ...endpoint,
+            requestBody: { ...endpoint.requestBody, properties: v.properties, example: v.example },
+          },
+          selectedLang,
+        ),
+      }))
+    : [{ title: endpoint.name, code: generateCodeExample(endpoint, selectedLang) }];
   const langDef = LANGUAGES.find((l) => l.label === selectedLang) || LANGUAGES[0];
-  const code = generateCodeExample(effectiveEndpoint, selectedLang);
+  // Keep `code` available for the existing single-pane copy handler (used by
+  // the first panel's copy button when there are no variants).
+  const code = codePanels[0].code;
 
   const responses = endpoint.responses || {};
   const responseTabs = Object.keys(responses).filter(
@@ -143,36 +200,25 @@ export default function CodeExamples({ endpoint, selectedLang: selectedLangProp,
 
   return (
     <div className="space-y-4">
-      {/* Code Examples Panel */}
-      <div style={{ border: '1px solid var(--ifm-color-emphasis-200)', borderRadius: '12px', overflow: 'hidden' }}>
-        <div className="flex items-center gap-2 px-4 py-2.5" style={{ background: 'var(--ifm-color-emphasis-100)', borderBottom: '1px solid var(--ifm-color-emphasis-200)' }}>
-          <span className="flex-1 text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{endpoint.name}</span>
-          <LangSelectorButton
-            selectedLang={selectedLang}
-            open={langDropdownOpen}
-            onClick={() => setLangDropdownOpen((o) => !o)}
-            btnRef={langBtnRef}
-          />
-          <LangDropdownPortal
-            open={langDropdownOpen}
-            anchorRef={langBtnRef}
-            langs={LANGUAGES}
-            selected={selectedLang}
-            onSelect={setSelectedLang}
-            onClose={closeLangDropdown}
-          />
-          <button
-            onClick={copyCode}
-            className="p-1.5 rounded-md border-0 bg-transparent appearance-none cursor-pointer text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
-            aria-label="Copy code"
-          >
-            {codeCopied ? <CheckIcon /> : <CopyIcon />}
-          </button>
-        </div>
-        <div style={{ background: 'var(--ifm-background-color)' }}>
-          <CodeHighlight code={code} language={langDef.prism} />
-        </div>
-      </div>
+      {/* Code Examples Panel(s). When the endpoint has variants we render one
+          panel per variant, stacked vertically. The language selector lives in
+          the first panel's header and applies to all panels. */}
+      {codePanels.map((panel, idx) => (
+        <CodePanel
+          key={panel.title}
+          title={panel.title}
+          code={panel.code}
+          language={langDef.prism}
+          showLangSelector={idx === 0}
+          selectedLang={selectedLang}
+          setSelectedLang={setSelectedLang}
+          langDropdownOpen={langDropdownOpen}
+          setLangDropdownOpen={setLangDropdownOpen}
+          closeLangDropdown={closeLangDropdown}
+          langBtnRef={idx === 0 ? langBtnRef : null}
+          onCopy={(setCopied) => copyText(panel.code, setCopied)}
+        />
+      ))}
 
       {/* Response Panel */}
       {responseTabs.length > 0 && (

--- a/src/component/ApiReference/CodeExamples.js
+++ b/src/component/ApiReference/CodeExamples.js
@@ -86,7 +86,7 @@ function formatResponse(value) {
   return JSON.stringify(value, null, 2);
 }
 
-export default function CodeExamples({ endpoint, selectedLang: selectedLangProp, onLangChange }) {
+export default function CodeExamples({ endpoint, selectedLang: selectedLangProp, onLangChange, selectedVariantIdx = 0 }) {
   const [localLang, setLocalLang] = useState('cURL');
   const selectedLang = selectedLangProp !== undefined ? selectedLangProp : localLang;
   const setSelectedLang = onLangChange || setLocalLang;
@@ -99,8 +99,22 @@ export default function CodeExamples({ endpoint, selectedLang: selectedLangProp,
 
   if (!endpoint) return null;
 
+  // When the endpoint ships requestBody.variants, swap the selected variant's
+  // example + properties into a shimmed endpoint so the snippet matches the
+  // tab the user picked over in the Body section.
+  const variants = endpoint.requestBody?.variants;
+  const effectiveEndpoint = (variants && variants[selectedVariantIdx])
+    ? {
+        ...endpoint,
+        requestBody: {
+          ...endpoint.requestBody,
+          properties: variants[selectedVariantIdx].properties,
+          example: variants[selectedVariantIdx].example,
+        },
+      }
+    : endpoint;
   const langDef = LANGUAGES.find((l) => l.label === selectedLang) || LANGUAGES[0];
-  const code = generateCodeExample(endpoint, selectedLang);
+  const code = generateCodeExample(effectiveEndpoint, selectedLang);
 
   const responses = endpoint.responses || {};
   const responseTabs = Object.keys(responses).filter(

--- a/src/component/ApiReference/EndpointDetail.js
+++ b/src/component/ApiReference/EndpointDetail.js
@@ -680,7 +680,7 @@ function UrlBar({ endpoint, onTryIt }) {
 
 // ─── Main component ──────────────────────────────────────────────────────────
 
-export default function EndpointDetail({ endpoint, apiName, onTryIt, mobileCodeSlot }) {
+export default function EndpointDetail({ endpoint, apiName, onTryIt, mobileCodeSlot, selectedVariantIdx = 0, onVariantChange }) {
   if (!endpoint) {
     return (
       <div className={styles.empty}>
@@ -765,22 +765,49 @@ export default function EndpointDetail({ endpoint, apiName, onTryIt, mobileCodeS
       )}
 
       {/* Request Body */}
-      {endpoint.requestBody && Array.isArray(endpoint.requestBody.properties) && endpoint.requestBody.properties.length > 0 && (
-        <section className={styles.section}>
-          <div className="flex items-center justify-between mb-4 pb-2 border-b border-gray-200 dark:border-white/10">
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Body</h2>
-            {endpoint.requestBody.contentType && (
-              <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">{endpoint.requestBody.contentType}</span>
+      {endpoint.requestBody && (() => {
+        const variants = endpoint.requestBody.variants;
+        const activeVariant = variants && variants[selectedVariantIdx];
+        const bodyProps = activeVariant ? activeVariant.properties : endpoint.requestBody.properties;
+        if (!Array.isArray(bodyProps) || bodyProps.length === 0) return null;
+        return (
+          <section className={styles.section}>
+            <div className="flex items-center justify-between mb-4 pb-2 border-b border-gray-200 dark:border-white/10">
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Body</h2>
+              {endpoint.requestBody.contentType && (
+                <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">{endpoint.requestBody.contentType}</span>
+              )}
+            </div>
+            {variants && variants.length > 0 && (
+              <div className="flex gap-1 mb-4 border-b border-gray-200 dark:border-white/10">
+                {variants.map((v, idx) => {
+                  const active = idx === selectedVariantIdx;
+                  return (
+                    <button
+                      key={v.name}
+                      onClick={() => onVariantChange?.(idx)}
+                      className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                        active
+                          ? 'border-orange-500 text-orange-600 dark:text-orange-400'
+                          : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+                      }`}
+                      style={{ background: 'transparent', cursor: 'pointer', fontFamily: 'inherit' }}
+                    >
+                      {v.name}
+                    </button>
+                  );
+                })}
+              </div>
             )}
-          </div>
-          {endpoint.requestBody.description && (
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4"><InlineText text={endpoint.requestBody.description} /></p>
-          )}
-          {endpoint.requestBody.properties.map((prop, i) => (
-            <ParamRow key={i} param={prop} />
-          ))}
-        </section>
-      )}
+            {endpoint.requestBody.description && (
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4"><InlineText text={endpoint.requestBody.description} /></p>
+            )}
+            {bodyProps.map((prop, i) => (
+              <ParamRow key={`${selectedVariantIdx}-${i}`} param={prop} />
+            ))}
+          </section>
+        );
+      })()}
 
       {/* Response section */}
       <ResponseSection responses={endpoint.responses} responseSchema={endpoint.responseSchema} />

--- a/src/component/ApiReference/EndpointDetail.js
+++ b/src/component/ApiReference/EndpointDetail.js
@@ -680,7 +680,7 @@ function UrlBar({ endpoint, onTryIt }) {
 
 // ─── Main component ──────────────────────────────────────────────────────────
 
-export default function EndpointDetail({ endpoint, apiName, onTryIt, mobileCodeSlot, selectedVariantIdx = 0, onVariantChange }) {
+export default function EndpointDetail({ endpoint, apiName, onTryIt, mobileCodeSlot }) {
   if (!endpoint) {
     return (
       <div className={styles.empty}>
@@ -764,49 +764,37 @@ export default function EndpointDetail({ endpoint, apiName, onTryIt, mobileCodeS
         </section>
       )}
 
-      {/* Request Body */}
+      {/* Request Body — one section per variant when present, otherwise the
+          plain body. Variants stack vertically so users see all payload shapes
+          (e.g. PUT folder rename/move) without a tab interaction. */}
       {endpoint.requestBody && (() => {
         const variants = endpoint.requestBody.variants;
-        const activeVariant = variants && variants[selectedVariantIdx];
-        const bodyProps = activeVariant ? activeVariant.properties : endpoint.requestBody.properties;
-        if (!Array.isArray(bodyProps) || bodyProps.length === 0) return null;
-        return (
-          <section className={styles.section}>
+        const summary = endpoint.name || endpoint.summary || 'Body';
+        const blocks = (variants && variants.length > 0)
+          ? variants.map((v) => ({
+              title: `${summary} (${v.name})`,
+              props: v.properties,
+            }))
+          : (Array.isArray(endpoint.requestBody.properties) && endpoint.requestBody.properties.length > 0
+              ? [{ title: 'Body', props: endpoint.requestBody.properties }]
+              : []);
+        if (blocks.length === 0) return null;
+        return blocks.map((block) => (
+          <section key={block.title} className={styles.section}>
             <div className="flex items-center justify-between mb-4 pb-2 border-b border-gray-200 dark:border-white/10">
-              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Body</h2>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{block.title}</h2>
               {endpoint.requestBody.contentType && (
                 <span className="text-xs text-gray-500 dark:text-gray-400 font-mono">{endpoint.requestBody.contentType}</span>
               )}
             </div>
-            {variants && variants.length > 0 && (
-              <div className="flex gap-1 mb-4 border-b border-gray-200 dark:border-white/10">
-                {variants.map((v, idx) => {
-                  const active = idx === selectedVariantIdx;
-                  return (
-                    <button
-                      key={v.name}
-                      onClick={() => onVariantChange?.(idx)}
-                      className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
-                        active
-                          ? 'border-orange-500 text-orange-600 dark:text-orange-400'
-                          : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
-                      }`}
-                      style={{ background: 'transparent', cursor: 'pointer', fontFamily: 'inherit' }}
-                    >
-                      {v.name}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
             {endpoint.requestBody.description && (
               <p className="text-sm text-gray-600 dark:text-gray-400 mb-4"><InlineText text={endpoint.requestBody.description} /></p>
             )}
-            {bodyProps.map((prop, i) => (
-              <ParamRow key={`${selectedVariantIdx}-${i}`} param={prop} />
+            {block.props.map((prop, i) => (
+              <ParamRow key={i} param={prop} />
             ))}
           </section>
-        );
+        ));
       })()}
 
       {/* Response section */}

--- a/src/component/ApiReference/TryItModal.js
+++ b/src/component/ApiReference/TryItModal.js
@@ -301,7 +301,7 @@ function ParamField({ label, sublabel, type, required, description, value, onCha
   );
 }
 
-export default function TryItModal({ endpoint, onClose, selectedLang: selectedLangProp, onLangChange, initialVariantIdx = 0 }) {
+export default function TryItModal({ endpoint, onClose, selectedLang: selectedLangProp, onLangChange }) {
   // Determine if this is a V2 endpoint (path contains /v2/ or group name contains V2)
   const isV2Endpoint = (endpoint.path && endpoint.path.toLowerCase().includes('/v2/')) ||
     (endpoint.group && endpoint.group.toLowerCase().includes('v2'));
@@ -329,9 +329,7 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
   // (buildCurl, handleSend, generateCodeExample) operate on `effectiveEndpoint`
   // and stay variant-agnostic.
   const variants = endpoint.requestBody?.variants || null;
-  const [selectedVariantIdx, setSelectedVariantIdx] = useState(
-    variants && initialVariantIdx < variants.length ? initialVariantIdx : 0
-  );
+  const [selectedVariantIdx, setSelectedVariantIdx] = useState(0);
   const selectedVariant = variants ? variants[selectedVariantIdx] : null;
   const effectiveEndpoint = useMemo(() => {
     if (!selectedVariant) return endpoint;

--- a/src/component/ApiReference/TryItModal.js
+++ b/src/component/ApiReference/TryItModal.js
@@ -323,22 +323,69 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
 
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  // Variant-aware view of the request body: when the spec ships multiple
+  // payload shapes for one endpoint (e.g. PUT folder rename/move), the modal
+  // picks one tab and presents it as the effective body. Downstream helpers
+  // (buildCurl, handleSend, generateCodeExample) operate on `effectiveEndpoint`
+  // and stay variant-agnostic.
+  const variants = endpoint.requestBody?.variants || null;
+  const [selectedVariantIdx, setSelectedVariantIdx] = useState(0);
+  const selectedVariant = variants ? variants[selectedVariantIdx] : null;
+  const effectiveEndpoint = useMemo(() => {
+    if (!selectedVariant) return endpoint;
+    return {
+      ...endpoint,
+      requestBody: {
+        ...endpoint.requestBody,
+        properties: selectedVariant.properties,
+        example: selectedVariant.example,
+      },
+    };
+  }, [endpoint, selectedVariant]);
   // Compute once at render time — both the params initializer and the body
-  // section need it, and `endpoint` is stable for the modal's lifetime.
-  const flattenedBody = detectFlattenedArrayBody(endpoint);
-  // Prefill body fields with the spec's example so the form is usable on first
-  // open. Flattened-array bodies expose inner primitive fields (each prefilled
-  // with the inner example value).
-  const [params, setParams] = useState(() => {
+  // section need it, and `effectiveEndpoint` is stable for the variant's lifetime.
+  const flattenedBody = detectFlattenedArrayBody(effectiveEndpoint);
+
+  // Build the per-variant prefill — also reused when the user switches tabs.
+  function computeInitialParams() {
     const initial = {};
     if (flattenedBody) {
       for (const f of flattenedBody.innerFields) {
         const val = flattenedBody.innerExample[f.name];
         initial[`__body__${f.name}`] = val == null ? '' : String(val);
       }
+      return initial;
+    }
+    const ex = effectiveEndpoint.requestBody?.example;
+    const props = effectiveEndpoint.requestBody?.properties || [];
+    if (ex && typeof ex === 'object' && !Array.isArray(ex)) {
+      for (const p of props) {
+        if (ex[p.name] === undefined) continue;
+        const v = ex[p.name];
+        initial[`__body__${p.name}`] = v == null ? '' : String(v);
+      }
     }
     return initial;
-  });
+  }
+  // Prefill body fields with the spec example so the form is usable on first
+  // open. Flattened-array bodies expose inner primitive fields; plain bodies
+  // get one prefilled input per property.
+  const [params, setParams] = useState(computeInitialParams);
+
+  // Reset & re-prefill body params whenever the active variant changes.
+  // Other params (path/query/auth) are not affected by variant switches.
+  useEffect(() => {
+    if (!variants) return;
+    setParams((prev) => {
+      const next = {};
+      for (const k of Object.keys(prev)) {
+        if (!k.startsWith('__body__')) next[k] = prev[k];
+      }
+      const fresh = computeInitialParams();
+      return { ...next, ...fresh };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedVariantIdx]);
   const [response, setResponse] = useState(null);
   const [loading, setLoading] = useState(false);
   const [activeResTab, setActiveResTab] = useState(null);
@@ -401,11 +448,11 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
       ? `Basic ${safeBase64(`${username}:${password}`)}`
       : '';
 
-    const bodyProps = endpoint.requestBody?.properties || [];
-    const rawExample = endpoint.requestBody?.example;
-    const contentType = endpoint.requestBody?.contentType || 'application/json';
+    const bodyProps = effectiveEndpoint.requestBody?.properties || [];
+    const rawExample = effectiveEndpoint.requestBody?.example;
+    const contentType = effectiveEndpoint.requestBody?.contentType || 'application/json';
     const isMultipart = contentType === 'multipart/form-data';
-    const flattenedBodyHS = !isMultipart ? detectFlattenedArrayBody(endpoint) : null;
+    const flattenedBodyHS = !isMultipart ? detectFlattenedArrayBody(effectiveEndpoint) : null;
     const userFilledBody = flattenedBodyHS
       ? flattenedBodyHS.innerFields.some((f) => params[`__body__${f.name}`])
       : bodyProps.some((p) => params[`__body__${p.name}`]);
@@ -473,16 +520,16 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
     }
   }
 
-  const curlCode = buildCurl(endpoint, username, password, params, selectedServer);
+  const curlCode = buildCurl(effectiveEndpoint, username, password, params, selectedServer);
   const langDef = LANGUAGES.find((l) => l.label === selectedLang) || LANGUAGES[0];
   const codeToShow = selectedLang === 'cURL'
     ? curlCode
-    : generateCodeExample(endpoint, selectedLang, { username, password, params });
+    : generateCodeExample(effectiveEndpoint, selectedLang, { username, password, params });
   const hasAuth = endpoint.auth && endpoint.auth.length > 0;
   const hasQuery = endpoint.queryParams && endpoint.queryParams.length > 0;
   const hasPath = endpoint.pathParams && endpoint.pathParams.length > 0;
-  const bodyProps = endpoint.requestBody?.properties || [];
-  const hasBody = bodyProps.length > 0;
+  const bodyProps = effectiveEndpoint.requestBody?.properties || [];
+  const hasBody = bodyProps.length > 0 || !!variants;
 
   // Static spec responses — always shown
   const specResponses = endpoint.responses || {};
@@ -637,8 +684,32 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
             {hasBody && (
               <CollapsibleSection
                 title="Body"
-                description={endpoint.requestBody.description || null}
+                description={effectiveEndpoint.requestBody?.description || null}
               >
+                {variants && (
+                  <div style={{
+                    display: 'flex', gap: '6px', padding: '8px 20px 0', borderBottom: '1px solid var(--ifm-color-emphasis-200)',
+                  }}>
+                    {variants.map((v, idx) => {
+                      const active = idx === selectedVariantIdx;
+                      return (
+                        <button
+                          key={v.name}
+                          onClick={() => setSelectedVariantIdx(idx)}
+                          style={{
+                            padding: '8px 14px', fontSize: '13px', fontWeight: active ? 600 : 500,
+                            border: 'none', borderBottom: `2px solid ${active ? '#ED5F00' : 'transparent'}`,
+                            background: 'transparent', cursor: 'pointer',
+                            color: active ? '#ED5F00' : 'var(--ifm-color-emphasis-700)',
+                            fontFamily: 'inherit', marginBottom: '-1px',
+                          }}
+                        >
+                          {v.name}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
                 {flattenedBody ? (
                   flattenedBody.innerFields.map((f) => (
                     <ParamField

--- a/src/component/ApiReference/TryItModal.js
+++ b/src/component/ApiReference/TryItModal.js
@@ -301,7 +301,7 @@ function ParamField({ label, sublabel, type, required, description, value, onCha
   );
 }
 
-export default function TryItModal({ endpoint, onClose, selectedLang: selectedLangProp, onLangChange }) {
+export default function TryItModal({ endpoint, onClose, selectedLang: selectedLangProp, onLangChange, initialVariantIdx = 0 }) {
   // Determine if this is a V2 endpoint (path contains /v2/ or group name contains V2)
   const isV2Endpoint = (endpoint.path && endpoint.path.toLowerCase().includes('/v2/')) ||
     (endpoint.group && endpoint.group.toLowerCase().includes('v2'));
@@ -329,7 +329,9 @@ export default function TryItModal({ endpoint, onClose, selectedLang: selectedLa
   // (buildCurl, handleSend, generateCodeExample) operate on `effectiveEndpoint`
   // and stay variant-agnostic.
   const variants = endpoint.requestBody?.variants || null;
-  const [selectedVariantIdx, setSelectedVariantIdx] = useState(0);
+  const [selectedVariantIdx, setSelectedVariantIdx] = useState(
+    variants && initialVariantIdx < variants.length ? initialVariantIdx : 0
+  );
   const selectedVariant = variants ? variants[selectedVariantIdx] : null;
   const effectiveEndpoint = useMemo(() => {
     if (!selectedVariant) return endpoint;

--- a/src/pages/api-doc/_ApiDocPage.jsx
+++ b/src/pages/api-doc/_ApiDocPage.jsx
@@ -207,6 +207,15 @@ export default function ApiDocPage({ apiSlug, groupSlug, endpointSlug }) {
   const [tryItEndpoint, setTryItEndpoint] = useState(null);
   const [selectedLang, setSelectedLang] = useState('cURL');
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  // Active variant index for endpoints that ship requestBody.variants
+  // (e.g. PUT /api/v1/folder rename/move). Shared between the body section
+  // and the code panel so they stay in sync. Reset whenever the endpoint
+  // navigates.
+  const [selectedVariantIdx, setSelectedVariantIdx] = useState(0);
+
+  // Reset the active variant tab whenever we navigate to a different endpoint.
+  const endpointKey = endpoint ? `${endpoint.method}:${endpoint.path}` : null;
+  useEffect(() => { setSelectedVariantIdx(0); }, [endpointKey]);
 
   // Remove alternate links (preserved from original)
   useEffect(() => {
@@ -400,13 +409,15 @@ export default function ApiDocPage({ apiSlug, groupSlug, endpointSlug }) {
               <EndpointDetail
                 endpoint={endpoint}
                 onTryIt={setTryItEndpoint}
-                mobileCodeSlot={<CodeExamples endpoint={endpoint} selectedLang={selectedLang} onLangChange={setSelectedLang} />}
+                selectedVariantIdx={selectedVariantIdx}
+                onVariantChange={setSelectedVariantIdx}
+                mobileCodeSlot={<CodeExamples endpoint={endpoint} selectedLang={selectedLang} onLangChange={setSelectedLang} selectedVariantIdx={selectedVariantIdx} />}
               />
               <div style={{ height: '80px' }} />
             </main>
 
             <div className={styles.rightPanel}>
-              <CodeExamples endpoint={endpoint} selectedLang={selectedLang} onLangChange={setSelectedLang} />
+              <CodeExamples endpoint={endpoint} selectedLang={selectedLang} onLangChange={setSelectedLang} selectedVariantIdx={selectedVariantIdx} />
             </div>
           </div>
         </div>
@@ -418,6 +429,7 @@ export default function ApiDocPage({ apiSlug, groupSlug, endpointSlug }) {
             onClose={() => setTryItEndpoint(null)}
             selectedLang={selectedLang}
             onLangChange={setSelectedLang}
+            initialVariantIdx={selectedVariantIdx}
           />
         )}
       </Layout>

--- a/src/pages/api-doc/_ApiDocPage.jsx
+++ b/src/pages/api-doc/_ApiDocPage.jsx
@@ -207,15 +207,6 @@ export default function ApiDocPage({ apiSlug, groupSlug, endpointSlug }) {
   const [tryItEndpoint, setTryItEndpoint] = useState(null);
   const [selectedLang, setSelectedLang] = useState('cURL');
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
-  // Active variant index for endpoints that ship requestBody.variants
-  // (e.g. PUT /api/v1/folder rename/move). Shared between the body section
-  // and the code panel so they stay in sync. Reset whenever the endpoint
-  // navigates.
-  const [selectedVariantIdx, setSelectedVariantIdx] = useState(0);
-
-  // Reset the active variant tab whenever we navigate to a different endpoint.
-  const endpointKey = endpoint ? `${endpoint.method}:${endpoint.path}` : null;
-  useEffect(() => { setSelectedVariantIdx(0); }, [endpointKey]);
 
   // Remove alternate links (preserved from original)
   useEffect(() => {
@@ -409,15 +400,13 @@ export default function ApiDocPage({ apiSlug, groupSlug, endpointSlug }) {
               <EndpointDetail
                 endpoint={endpoint}
                 onTryIt={setTryItEndpoint}
-                selectedVariantIdx={selectedVariantIdx}
-                onVariantChange={setSelectedVariantIdx}
-                mobileCodeSlot={<CodeExamples endpoint={endpoint} selectedLang={selectedLang} onLangChange={setSelectedLang} selectedVariantIdx={selectedVariantIdx} />}
+                mobileCodeSlot={<CodeExamples endpoint={endpoint} selectedLang={selectedLang} onLangChange={setSelectedLang} />}
               />
               <div style={{ height: '80px' }} />
             </main>
 
             <div className={styles.rightPanel}>
-              <CodeExamples endpoint={endpoint} selectedLang={selectedLang} onLangChange={setSelectedLang} selectedVariantIdx={selectedVariantIdx} />
+              <CodeExamples endpoint={endpoint} selectedLang={selectedLang} onLangChange={setSelectedLang} />
             </div>
           </div>
         </div>
@@ -429,7 +418,6 @@ export default function ApiDocPage({ apiSlug, groupSlug, endpointSlug }) {
             onClose={() => setTryItEndpoint(null)}
             selectedLang={selectedLang}
             onLangChange={setSelectedLang}
-            initialVariantIdx={selectedVariantIdx}
           />
         )}
       </Layout>


### PR DESCRIPTION
## Summary

Follow-up to PR #3115. Adds variant display improvements to the API reference pages.

### Changes

1. **Variant tabs on static API reference page** - When an endpoint has multiple variants (e.g., Rename vs Move for PUT folder), display them as tabs
2. **Stack variants vertically instead of tabs** - On static pages, stack variant sections vertically for better readability
3. **PUT /api/v1/folder: render Rename / Move as Body tabs** - Specific handling for the folder endpoint variants
4. **Address review comments** - Coerce flattened inner values, fix comments, mark PUT override

### Files changed

- `scripts/build-api-data.js` - Build script enhancements
- `src/component/ApiReference/CodeExamples.js` - Code example rendering
- `src/component/ApiReference/EndpointDetail.js` - Endpoint detail display
- `src/component/ApiReference/TryItModal.js` - Try It modal updates
- `src/component/ApiReference/langUtils.js` - Language utilities

## Test plan

- [ ] `npm start` boots cleanly
- [ ] PUT `/api/v1/folder` shows Rename/Move as separate body options
- [ ] Static API reference page renders variants correctly
- [ ] Variant stacking displays properly on static pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)