### PR TITLE
docs(smartui): fix Smart Ignore hooks capability for web automation

### DIFF
--- a/docs/smartui-smartignore.md
+++ b/docs/smartui-smartignore.md
@@ -83,7 +83,7 @@ This allows you to selectively apply Smart Ignore to specific screenshots, makin
 
 #### 3. Using Smart Ignore in Hooks Flow (Automation Capabilities)
 
-If you are using SmartUI Hooks (for example Selenium `executeScript("smartui.takeScreenshot=...")` style), enable Smart Ignore using `ignoreType` in capabilities.
+If you are using SmartUI Hooks for web automation (for example Selenium `executeScript("smartui.takeScreenshot=...")` style), enable Smart Ignore using the `smartUI.smartIgnore` capability.
 
 ```javascript
 const capabilities = {
@@ -93,12 +93,18 @@ const capabilities = {
     accessKey: process.env.LT_ACCESS_KEY,
     visual: true,
     'smartUI.project': 'My-Project',
-    ignoreType: ['smartignore']
+    'smartUI.smartIgnore': true
   }
 };
 ```
 
-> Smart Ignore is a strategy mode. Prefer `ignoreType` strategy configuration over a standalone `smartignore: true` flag.
+For Selenium with Java, set the same capability inside your `LT:Options`:
+
+```java
+ltOptions.put("smartUI.smartIgnore", true);
+```
+
+> **Note:** In the web automation Hooks flow, the Smart Ignore comparison mode must be enabled with the `smartUI.smartIgnore: true` capability. The `ignoreType: ['smartignore']` configuration does **not** switch the comparison mode to Smart Ignore for web automation Hooks. Smart Ignore takes effect from the subsequent execution build (the first build establishes the baseline, and the comparison applies on the next build).
 
 For full Hooks examples with Layout, Full Page, and Smart Ignore, see:
 - [Hooks: Layout + Full Page + Smart Ignore](/support/docs/smartui-hooks-layout-fullpage-smartignore/)


### PR DESCRIPTION
## What

Fixes the **Using Smart Ignore in Hooks Flow (Automation Capabilities)** section of [`smartui-smartignore`](https://www.testmuai.com/support/docs/smartui-smartignore/#3-using-smart-ignore-in-hooks-flow-automation-capabilities).

## Why

For SmartUI **web automation** Hooks, the documented `ignoreType: ['smartignore']` capability does **not** switch the comparison mode to Smart Ignore. The working capability is `smartUI.smartIgnore: true`. This was reproduced with a prospect (Salesforce, Selenium + Java) and confirmed by the SmartUI team — the correct capability is `ltOptions.put("smartUI.smartIgnore", true);`, with Smart Ignore taking effect from the subsequent execution build.

## Changes

- Replace `ignoreType: ['smartignore']` with `'smartUI.smartIgnore': true` in the capabilities example.
- Add the Selenium Java form: `ltOptions.put("smartUI.smartIgnore", true);`.
- Correct the note that previously (incorrectly) recommended preferring `ignoreType` over the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)