### PR TITLE
docs(playwright-ios): add Beta notice above Supported Versions

### DIFF
--- a/docs/playwright-ios-guide.md
+++ b/docs/playwright-ios-guide.md
@@ -54,6 +54,12 @@ Playwright test automation on real iOS devices is now supported on <BrandName />
 
 This guide will cover the basics of getting started with Playwright testing on iOS devices on the <BrandName /> platform.
 
+:::info Currently in BETA
+
+Playwright testing on real iOS devices is currently in **Beta**. To enable this feature for your organization, please contact your <span className="doc__lt" onClick={() => window.openLTChatWidget()}>account team</span> to have the feature flag turned on.
+
+:::
+
 :::tip Supported Versions
 - Playwright versions **v1.53.0** and above (until **v1.57.0**) are supported for iOS real device testing.
 - All languages use the **stock Playwright packages** — no custom forks or client-side changes required.


### PR DESCRIPTION
Adds a Beta callout to the **Getting Started With Playwright Testing on iOS Real Devices** page (`playwright-ios-device/`), directly above the **Supported Versions** section.

## Change
- New `:::info Currently in BETA` admonition highlighting that Playwright testing on real iOS devices is in **Beta**.
- Instructs users to contact their **account team** (via the `doc__lt` chat-widget link) to have the **feature flag** enabled for their organization.
- Uses the same beta-callout / admonition design used elsewhere in the docs for visual consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)