### PR TITLE
fix(kane-cli): quote front-matter description to unblock Stage deploy

### DIFF
--- a/docs/kane-cli-introduction.md
+++ b/docs/kane-cli-introduction.md
@@ -2,7 +2,7 @@
 id: kane-cli-introduction
 title: Kane CLI Documentation - Getting Started
 sidebar_label: Introduction
-description: Kane CLI is an AI-powered command-line tool that runs browser automation tests in plain English: from your terminal, IDE, or CI pipeline.
+description: "Kane CLI is an AI-powered command-line tool that runs browser automation tests in plain English: from your terminal, IDE, or CI pipeline."
 keywords:
   - kane cli
   - kaneai


### PR DESCRIPTION
## Problem
The **Stage deployment** workflow has been **failing on every merge since #3122**, so nothing has deployed to `stage.testmuinternal.ai` since #3117. The Docusaurus build crashes with:

```
incomplete explicit mapping pair; a key node is missed...
docs/kane-cli-introduction.md, line 4
```

The `description` front-matter value contains an unquoted internal `": "` (`...plain English: from your terminal...`), which YAML interprets as a nested mapping key.

## Fix
Wrap the `description` value in double quotes so it's parsed as a single string.

## Impact
Unblocks the Stage build/deploy pipeline, allowing all queued `stage` changes to ship (including the recently merged Playwright Android #3121 and iOS #3124 doc updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)