### PR TITLE
docs: correct max queuing timeout to 15 minutes

### DIFF
--- a/docs/timeouts-issues-and-resolutions.md
+++ b/docs/timeouts-issues-and-resolutions.md
@@ -96,7 +96,7 @@ Maximum number of test cases that can be queued = n + 150
 
 Queuing timeout could happen because of the below:
 
-**Tests in Queue Taking Too Long to Complete:** Tests are queued for only 10 minutes. If the tests in your queue exceed the 10-minute timeline, they are removed from queue. This aborts the execution of your tests, leading to a timeout error.
+**Tests in Queue Taking Too Long to Complete:** Tests are queued for only 15 minutes. If the tests in your queue exceed the 15-minute timeline, they are removed from queue. This aborts the execution of your tests, leading to a timeout error.
 
 * * *
 


### PR DESCRIPTION
## What
The **Queuing Timeout** section in `docs/timeouts-issues-and-resolutions.md` stated a maximum queue timeout of **10 minutes**. The actual maximum queue timeout is **15 minutes**.

## Change
Updated both mentions in the "Tests in Queue Taking Too Long to Complete" note from 10 minutes → 15 minutes.

Doc page: https://www.testmuai.com/support/docs/timeouts-issues-and-resolutions/#4-queuing-timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)