### PR TITLE
docs(playwright-android): fix supported version + regex device placeholders

### DIFF
--- a/docs/playwright-android-guide.md
+++ b/docs/playwright-android-guide.md
@@ -152,8 +152,8 @@ const { chromium } = require("playwright");
   const capabilities = {
     "LT:Options": {
       platformName: "android",
-      deviceName: "Pixel.*",
-      platformVersion: "1[0-9]",
+      deviceName: ".*",
+      platformVersion: ".*",
       isRealMobile: true,
       build: "Playwright Android Build",
       name: "Playwright Android Test",
@@ -216,8 +216,8 @@ const { _android } = require("playwright");
   const capabilities = {
     "LT:Options": {
       platformName: "android",
-      deviceName: "Pixel.*",
-      platformVersion: "1[0-9]",
+      deviceName: ".*",
+      platformVersion: ".*",
       isRealMobile: true,
       build: "Playwright Android Build",
       name: "Playwright Android Test",
@@ -301,8 +301,8 @@ def main():
     capabilities = {
         "LT:Options": {
             "platformName": "android",
-            "deviceName": "Pixel.*",
-            "platformVersion": "1[0-9]",
+            "deviceName": ".*",
+            "platformVersion": ".*",
             "isRealMobile": True,
             "build": "Playwright Android Build",
             "name": "Playwright Android Test",
@@ -375,8 +375,8 @@ public class PlaywrightAndroidTest {
     public static void main(String[] args) {
         Map<String, Object> ltOptions = new LinkedHashMap<>();
         ltOptions.put("platformName", "android");
-        ltOptions.put("deviceName", "Pixel.*");
-        ltOptions.put("platformVersion", "1[0-9]");
+        ltOptions.put("deviceName", ".*");
+        ltOptions.put("platformVersion", ".*");
         ltOptions.put("isRealMobile", true);
         ltOptions.put("build", "Playwright Android Build");
         ltOptions.put("name", "Playwright Android Test");
@@ -446,8 +446,8 @@ var capabilities = new Dictionary<string, object>
     ["LT:Options"] = new Dictionary<string, object>
     {
         ["platformName"] = "android",
-        ["deviceName"] = "Pixel.*",
-        ["platformVersion"] = "1[0-9]",
+        ["deviceName"] = ".*",
+        ["platformVersion"] = ".*",
         ["isRealMobile"] = true,
         ["build"] = "Playwright Android Build",
         ["name"] = "Playwright Android Test",

--- a/docs/playwright-android-guide.md
+++ b/docs/playwright-android-guide.md
@@ -84,7 +84,7 @@ export LT_ACCESS_KEY="YOUR_LAMBDATEST_ACCESS_KEY"
 | Language | Supported Playwright Versions |
 |----------|-------------------------------|
 | **JavaScript (Node.js)** | Up to **v1.59.0** |
-| **Java, Python, C#** | Up to **v1.53.2** |
+| **Java, Python, C#** | Up to **v1.53.0** |
 
 <Tabs className="docs__val">
 
@@ -152,8 +152,8 @@ const { chromium } = require("playwright");
   const capabilities = {
     "LT:Options": {
       platformName: "android",
-      deviceName: "Pixel 5",
-      platformVersion: "11",
+      deviceName: "Pixel.*",
+      platformVersion: "1[0-9]",
       isRealMobile: true,
       build: "Playwright Android Build",
       name: "Playwright Android Test",
@@ -216,8 +216,8 @@ const { _android } = require("playwright");
   const capabilities = {
     "LT:Options": {
       platformName: "android",
-      deviceName: "Pixel 5",
-      platformVersion: "11",
+      deviceName: "Pixel.*",
+      platformVersion: "1[0-9]",
       isRealMobile: true,
       build: "Playwright Android Build",
       name: "Playwright Android Test",
@@ -301,8 +301,8 @@ def main():
     capabilities = {
         "LT:Options": {
             "platformName": "android",
-            "deviceName": "Pixel 5",
-            "platformVersion": "11",
+            "deviceName": "Pixel.*",
+            "platformVersion": "1[0-9]",
             "isRealMobile": True,
             "build": "Playwright Android Build",
             "name": "Playwright Android Test",
@@ -375,8 +375,8 @@ public class PlaywrightAndroidTest {
     public static void main(String[] args) {
         Map<String, Object> ltOptions = new LinkedHashMap<>();
         ltOptions.put("platformName", "android");
-        ltOptions.put("deviceName", "Pixel 5");
-        ltOptions.put("platformVersion", "11");
+        ltOptions.put("deviceName", "Pixel.*");
+        ltOptions.put("platformVersion", "1[0-9]");
         ltOptions.put("isRealMobile", true);
         ltOptions.put("build", "Playwright Android Build");
         ltOptions.put("name", "Playwright Android Test");
@@ -446,8 +446,8 @@ var capabilities = new Dictionary<string, object>
     ["LT:Options"] = new Dictionary<string, object>
     {
         ["platformName"] = "android",
-        ["deviceName"] = "Pixel 5",
-        ["platformVersion"] = "11",
+        ["deviceName"] = "Pixel.*",
+        ["platformVersion"] = "1[0-9]",
         ["isRealMobile"] = true,
         ["build"] = "Playwright Android Build",
         ["name"] = "Playwright Android Test",


### PR DESCRIPTION
## What
Updates `docs/playwright-android-guide.md` (page: https://www.testmuai.com/support/docs/playwright-android/).

### 1. Language-Specific Setup version table
- Corrected the **Java, Python, C#** supported Playwright version from `Up to v1.53.2` → `Up to v1.53.0` (consistent with the "Supported Versions" note stating v1.53.0 is supported for these languages).

### 2. Regex device placeholders in example scripts
For all four language tabs (Node.js ×2, Python, Java, C#), replaced hardcoded values with regex placeholders, since device allocation depends on availability in the queue:
- `deviceName`: `"Pixel 5"` → `"Pixel.*"`
- `platformVersion`: `"11"` → `"1[0-9]"`

This follows the documented [REGEX for device name](/support/docs/regular-expression-appium/) behavior, so any available matching device is allotted instead of pinning a single unavailable one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)