### PR TITLE
chore: update API data with download app endpoints

### DIFF
--- a/src/data/api/all-apis.json
+++ b/src/data/api/all-apis.json
@@ -1,0 +1,20127 @@
+{
+  "apis": [
+    {
+      "name": "Selenium Automation API",
+      "baseUrl": "https://api.lambdatest.com/automation/api/v1",
+      "servers": [
+        {
+          "url": "https://api.lambdatest.com/automation/api/v1"
+        },
+        {
+          "url": "https://api.lambdatest.com/automation/api/v2",
+          "description": "V2"
+        },
+        {
+          "url": "https://eu-api.lambdatest.com/automation/api/v1"
+        },
+        {
+          "url": "https://eu-api.lambdatest.com/automation/api/v2"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Build",
+          "endpoints": [
+            {
+              "name": "Fetch all builds of an account.",
+              "method": "GET",
+              "path": "/builds",
+              "description": "Fetch all builds of an account. You can limit the number of records and apply filter on status,build date range and sort by users,start date and end date in asc and desc order. You can apply sort on multiple columns.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "offset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "It defines the number of lists on the basis of limit parameter. e.g offset=10"
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch specified number of records. e.g. limit=10"
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of builds with specific statuses. You can pass multiple comma seperated statuses e.g. running,queued,completed,timeout and error."
+                },
+                {
+                  "name": "fromdate",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of builds that executed from the specified Start Date. The Date format must be YYYY-MM-DD. e.g. \"2018-03-15\"."
+                },
+                {
+                  "name": "todate",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of builds that executed till the specified End Date. If both fromdate and todate value provided then it works as range filter. The Date format must be YYYY-MM-DD. e.g. \"2018-03-15\"."
+                },
+                {
+                  "name": "sort",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To sort the list in ascending or descending order using multiple keys. e.g. \"asc.user_id,desc.org_id\""
+                },
+                {
+                  "name": "publicurl",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": "If true, includes the public URL for each build in the response. If false (default), public URLs are omitted. When true, the limit cannot exceed 20."
+                },
+                {
+                  "name": "username",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To filter builds by username(s). You can pass a single username or multiple comma-separated usernames (e.g. \"alice,bob\")."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "Meta": {
+                      "attributes": {
+                        "org_id": 123
+                      },
+                      "result_set": {
+                        "count": 123,
+                        "limit": 123,
+                        "offset": 123,
+                        "total": 123
+                      }
+                    },
+                    "data": [
+                      {
+                        "build_id": 1782,
+                        "name": "shivam-video-test",
+                        "user_id": 1212,
+                        "username": "shivam",
+                        "status_ind": "completed",
+                        "create_timestamp": "2019-02-05T08:24:36.000Z",
+                        "end_timestamp": "2019-02-05T08:27:22.000Z",
+                        "project_id": "ML",
+                        "project_name": "magicleap",
+                        "tags": [
+                          "tag1",
+                          "tag2",
+                          "tag3"
+                        ],
+                        "duration": 719
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Invalid session id value",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "Meta",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Fetch specified build details",
+              "method": "GET",
+              "path": "/builds/{build_id}",
+              "description": "To fetch build details of the buildid specified by the user.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "build_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Build ID that details you want to fetch"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "shareExpiryLimit",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Days after which share link will get expired (3,7,10,30)"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": {
+                      "build_id": 1,
+                      "name": "asdaskjaaa",
+                      "org_id": 1246,
+                      "user_id": 1212,
+                      "username": "john smith",
+                      "status_ind": "completed",
+                      "create_timestamp": "2018-12-23T14:30:14.000Z",
+                      "end_timestamp": "2018-12-25T12:46:38.000Z",
+                      "project_id": 24,
+                      "tags": [
+                        "tag1",
+                        "tag2",
+                        "tag3"
+                      ],
+                      "public_url": "https://automation.lambdatest.com/share?shareId=asdas",
+                      "duration": 156,
+                      "dashboard_url": "https://automation.lambdatest.com/build?&build=1"
+                    },
+                    "message": "Retrieve build list was successful",
+                    "status": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Resource not found",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete Build",
+              "method": "DELETE",
+              "path": "/builds/{build_id}",
+              "description": "To delete specified Build from dashboard.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "build_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Build ID that need to be deleted"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Build deleted successfully",
+                    "status": "success",
+                    "data": {
+                      "result": "1"
+                    }
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Invalid build id value",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Update Build Name or Status",
+              "method": "PATCH",
+              "path": "/builds/{build_id}",
+              "description": "To change build name or status",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "build_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "build id that name need to be changed."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "You can update either name or status or both of a build in single request.",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string<string>",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "status",
+                    "type": "string<string>",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Build updated successfully",
+                    "status": "success",
+                    "data": {
+                      "result": "1"
+                    }
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Stop tests by BuildID",
+              "method": "PUT",
+              "path": "/build/stop",
+              "description": "To stop tests by BuildID.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "build",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "build id for which to stop tests"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": {
+                      "builds": [
+                        "buildId1",
+                        "buildId2",
+                        "buildId3"
+                      ]
+                    },
+                    "message": "Initiated build stop",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad operation",
+                  "example": {
+                    "message": "Invalid Query Params provided",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "403": {
+                  "description": "Forbidden",
+                  "example": {
+                    "message": "Cannot stop more than 10 builds through this API",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "404": {
+                  "description": "Build id not found",
+                  "example": {
+                    "message": "Could not find any build in running state",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Session",
+          "endpoints": [
+            {
+              "name": "Fetch list of all sessions",
+              "method": "GET",
+              "path": "/sessions",
+              "description": "To fetch list of sessions. You can also limit the number of records, and paginate through your data using Parameters.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "build_id",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "To filter sessions of specific build."
+                },
+                {
+                  "name": "username",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To filter sessions of specific user."
+                },
+                {
+                  "name": "test_name",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To filter sessions of specific test name."
+                },
+                {
+                  "name": "offset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "It defines the number of lists on the basis of limit parameter. e.g offset=10"
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch specified number of records. e.g. limit=10"
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of sessions with specific statuses. You can pass multiple comma seperated statuses e.g. running,queued,completed,passed,failed,timeout,error and lambda-error."
+                },
+                {
+                  "name": "fromdate",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of sessions that executed from the specified Start Date. The Date format must be YYYY-MM-DD. e.g. \"2018-03-15\"."
+                },
+                {
+                  "name": "todate",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of sessions that executed till the specified End Date. If both fromdate and todate value provided then it works as range filter. The Date format must be YYYY-MM-DD. e.g. \"2018-03-15\"."
+                },
+                {
+                  "name": "sort",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To sort the list in ascending or descending order using multiple keys. e.g. \"asc.user_id,desc.duration\""
+                },
+                {
+                  "name": "tags",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To filter basis on test tags. e.g. \"testTag1,testTag2,testTag3\""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "Meta": {
+                      "attributes": {
+                        "org_id": 123
+                      },
+                      "result_set": {
+                        "count": 123,
+                        "limit": 123,
+                        "offset": 123,
+                        "total": 123
+                      }
+                    },
+                    "data": [
+                      {
+                        "test_id": "Z17EF-OPUKH-BDAE8-YEPXU",
+                        "build_id": 1,
+                        "build_name": "MACOS 10.12-CHROME-2018-12-23",
+                        "user_id": 250563,
+                        "username": "bahubali",
+                        "status_ind": "passed",
+                        "create_timestamp": "2019-02-05T08:24:36.000Z",
+                        "start_timestamp": "2019-02-05T08:24:58.000Z",
+                        "end_timestamp": "2019-02-05T08:27:22.000Z",
+                        "remark": "completed",
+                        "browser": "chrome",
+                        "platform": "sierra",
+                        "version": "39.0",
+                        "name": "macos 10.12-chrome-39.0",
+                        "session_id": "e7f2d78de1a8822c98e91e49428d0569",
+                        "device": "<string>",
+                        "duration": "8",
+                        "test_type": "selenium",
+                        "tag": [
+                          "tag1",
+                          "tag2",
+                          "tag3"
+                        ],
+                        "customdata": {},
+                        "selenium_logs": "https://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/selenium",
+                        "console_logs": "https://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/console",
+                        "network_logs": "https://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/network",
+                        "command_logs": "http://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/command"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Not Found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "Meta",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "session specific information",
+              "method": "GET",
+              "path": "/sessions/{session_id}",
+              "description": "To fetch specified session details such as name, status,os,browser,version and all generated logs endpoint.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "SESSION ID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "shareExpiryLimit",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Days after which share link will get expired (3,7,10,30)"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": {
+                      "test_id": "Z17EF-OPUKH-BDAE8-YEPXU",
+                      "build_id": 1,
+                      "name": "mytest",
+                      "user_id": 250563,
+                      "username": "bahubali",
+                      "duration": 123,
+                      "platform": "win10",
+                      "browser": "chrome",
+                      "browser_version": "71.0",
+                      "device": "<string>",
+                      "status_ind": "<string>",
+                      "session_id": "bc02fd99593f14e37850745d66197f89",
+                      "build_name": "my-build",
+                      "create_timestamp": "2019-02-05 08:24:36",
+                      "start_timestamp": "2019-02-05 08:24:58",
+                      "end_timestamp": "2019-02-05 08:27:22",
+                      "remark": "completed",
+                      "console_logs_url": "https://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/console",
+                      "network_logs_url": "https://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/network",
+                      "command_logs_url": "http://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/command",
+                      "selenium_logs_url": "http://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/selenium",
+                      "screenshot_url": "https://s3.amazonaws.com/ml-screenshots/00HIR-IQNLL-SDVHV-KDTBM/video/index.m3u8",
+                      "video_url": "https://d15x9hjibri3lt.cloudfront.net/00HIR-IQNLL-SDVHV-KDTBM/screenshots.zip",
+                      "customData": {}
+                    },
+                    "message": "Retrieve session was successful",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Resource associated to session_id is not available.",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "pet status in the store",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete test session",
+              "method": "DELETE",
+              "path": "/sessions/{session_id}",
+              "description": "Delete a session.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "SESSION ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "Session deleted successfully",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "403": {
+                  "description": "Forbidden! Operation not allowed.",
+                  "example": {
+                    "message": "Forbidden! Operation not allowed.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "404": {
+                  "description": "Resource associated to session_id is not available.",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Update test session details.",
+              "method": "PATCH",
+              "path": "/sessions/{session_id}",
+              "description": "To update the test session name, status {\"passed\",\"failed\",\"skipped\", \"ignored\", \"unknown\", \"error\"}, reason, test tags.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "You can update name, status, test tags of a session in single request.",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "status_ind",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "reason",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "custom_data",
+                    "type": "object",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "tags",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "successful operation.",
+                  "example": {
+                    "message": "Session updated successfully",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request.",
+                  "example": {
+                    "message": "Please provide a valid payload",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "403": {
+                  "description": "Forbidden! Operation not allowed.",
+                  "example": {
+                    "message": "Forbidden! Operation not allowed.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "404": {
+                  "description": "Resource associated to session_id is not available.",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Stop session by sessionID",
+              "method": "PUT",
+              "path": "/sessions/{session_id}/stop",
+              "description": "To stop session by sessionID.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Session stopped successfully.",
+                    "status": "success",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad operation",
+                  "example": {
+                    "message": "Oops! Looks like session is already stopped",
+                    "status": "fail",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "To fetch all step by step screenshots",
+              "method": "GET",
+              "path": "/sessions/{session_id}/screenshots",
+              "description": "To fetch all the step by step screenshots in zip format.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Retrieve screenshot url was successful",
+                    "status": "success",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch recorded video of a test session id.",
+              "method": "GET",
+              "path": "/sessions/{session_id}/video",
+              "description": "To fetch video of a recorded test session.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "video_generated_status",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": "Video generated status"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Retrieve video url was successful",
+                    "status": "success",
+                    "url": "<string>",
+                    "view_video_url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "view_video_url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "command logs of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/command",
+              "description": "To fetch the all executed commands of a test session in plain json text. Optionally pass annotationId to fetch annotation-specific command logs.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "annotationId",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Annotation ID (slug) to fetch command logs for a specific annotation. Take this value from the `annotationId` field of a placeholder entry in the full command log response (e.g. `open-homepage_1`). When provided, returns only the command logs for that annotation on the requested page."
+                },
+                {
+                  "name": "pageNumber",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Page number of the annotation command log to fetch. Only used when `annotationId` is set. Defaults to 1. Annotations spanning multiple pages require separate calls per page."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": [
+                      {
+                        "logType": "requestLog",
+                        "testID": "5HLCQ-HPCWH-UOE2O-2CUFA",
+                        "status": 0,
+                        "timestamp": 1551356385,
+                        "Value": {
+                          "requestId": "82e3b7cd-3b04-4bc8-9d2b-567aff450fe4",
+                          "RequestStartTime": 1551356385,
+                          "requestMethod": "POST",
+                          "requestPath": "/wd/hub/session/2F42BCCC-BF43-426A-A72F-F58F58167496/element/node-DF5D363E-84A2-4CA4-9AC4-0F398C606082/click",
+                          "duration": 8,
+                          "requestBody": "{\"sessionId\": \"2F42BCCC-BF43-426A-A72F-F58F58167496\", \"id\": \"node-DF5D363E-84A2-4CA4-9AC4-0F398C606082\"}",
+                          "responseBody": "{\"status\":0,\"sessionId\":\"2F42BCCC-BF43-426A-A72F-F58F58167496\",\"value\":{}}",
+                          "responseStatus": "200 OK",
+                          "screenshotId": "<string>"
+                        }
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "selenium log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/selenium",
+              "description": "To fetch selenum log that contains grid requests and reponses of a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": [
+                      {
+                        "logType": "server",
+                        "testID": "5HLCQ-HPCWH-UOE2O-2CUFA",
+                        "status": 0,
+                        "timestamp": 1551356378609,
+                        "Value": {
+                          "level": "INFO",
+                          "message": "Started new session 2F42BCCC-BF43-426A-A72F-F58F58167496 (org.openqa.selenium.safari.SafariDriverService)",
+                          "timestamp": 1551356378609
+                        }
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Network log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/network",
+              "description": "To fetch Network log that contains all the requested urls of a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get logs based on session id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": [
+                      {
+                        "logType": "server",
+                        "testID": "5HLCQ-HPCWH-UOE2O-2CUFA",
+                        "status": 0,
+                        "timestamp": 1551356378609,
+                        "Value": {
+                          "level": "INFO",
+                          "message": "Started new session 2F42BCCC-BF43-426A-A72F-F58F58167496 (org.openqa.selenium.safari.SafariDriverService)",
+                          "timestamp": 1551356378609
+                        }
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "console log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/console",
+              "description": "To fetch console log that contains console errors thrown by application during a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": [
+                      {
+                        "logType": "server",
+                        "testID": "5HLCQ-HPCWH-UOE2O-2CUFA",
+                        "status": 0,
+                        "timestamp": 1551356378609,
+                        "Value": {
+                          "level": "INFO",
+                          "message": "Started new session 2F42BCCC-BF43-426A-A72F-F58F58167496 (org.openqa.selenium.safari.SafariDriverService)",
+                          "timestamp": 1551356378609
+                        }
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Network har log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/network.har",
+              "description": "To fetch Network har log that contains all the requested har of a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get network har logs based on session id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": [
+                      {
+                        "data": "object",
+                        "message": "Downloaded network.har file successfully",
+                        "status": "success"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Full har log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/full-har",
+              "description": "To fetch Full Network har log that contains all the requested har of a test session along with request and response content.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get network har logs based on session id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": null,
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Upload terminal logs to our lambda storage",
+              "method": "POST",
+              "path": "/sessions/{session_id}/terminal-logs",
+              "description": "You can upload any test/terminal report generated by the testing framework in json,xml,txt and other common format. The file uploaded can then be viewed in the automation dashboard page under LOGS sections. The file size should not exceed 2MB",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "multipart/form-data",
+                "description": "To upload terminal logs file",
+                "properties": [
+                  {
+                    "name": "file",
+                    "type": "string<binary>",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": "File have been uploaded successfully to our lambda storage",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": {
+                    "message": "Oops ! file size too large (> 2MB)",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Upload assertion logs to our lambda storage",
+              "method": "POST",
+              "path": "/sessions/{session_id}/exceptions",
+              "description": "You can upload assertion logs or other logs for a test session. The logs uploaded can then be viewed in the automation dashboard page under EXCEPTION sections. You can only upload a list of strings",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "To upload exception log for a given test session",
+                "properties": [
+                  {
+                    "name": "exception",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": "File have been uploaded successfully to our lambda storage",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": {
+                    "message": "Oops ! file size too large (> 2MB)",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Session Logs (V2)",
+          "endpoints": [
+            {
+              "name": "command logs of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/v2/log/command",
+              "description": "Returns a signed URL to download the full commands.zip for the session. The zip contains the per-page command log JSON files at the root, plus per-annotation command log JSON files (when present) under an `annotations/` subdirectory. To fetch a single annotation's commands inline (without downloading the zip), use the v1 endpoint with `annotationId`.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "URL is succesfully generated",
+                    "status": "success",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "selenium/appium log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/v2/log/selenium",
+              "description": "To fetch selenum/appium log that contains grid requests and reponses of a test session in plain text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "URL is succesfully generated",
+                    "status": "success",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Network log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/v2/log/network",
+              "description": "To fetch Network log that contains all the requested urls of a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get logs based on session id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "URL is succesfully generated",
+                    "status": "success",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "console/browser log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/v2/log/console",
+              "description": "To fetch console/browser log that contains console errors thrown by application during a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "URL is succesfully generated",
+                    "status": "success",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Network har log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/v2/log/network.har",
+              "description": "To fetch Network har log that contains all the requested har of a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get network har logs based on session id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "URL is succesfully generated",
+                    "status": "success",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Full har log of a test session",
+              "method": "GET",
+              "path": "/sessions/{session_id}/v2/log/full-har",
+              "description": "To fetch Full Network har log that contains all the requested har of a test session along with request and response content.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get network har logs based on session id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "URL is succesfully generated",
+                    "status": "success",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Test",
+          "endpoints": [
+            {
+              "name": "Upload assertion logs to our lambda storage",
+              "method": "POST",
+              "path": "/tests/{test_id}/exceptions",
+              "description": "You can upload assertion logs or other logs for a test Id. The logs uploaded can then be viewed in the automation dashboard page under EXCEPTION sections. You can only upload a list of strings",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Test ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "To upload exception log for a given test Id",
+                "properties": [
+                  {
+                    "name": "exception",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": "File have been uploaded successfully to our lambda storage",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": {
+                    "message": "Oops ! file size too large (> 2MB)",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch recorded video of a test id.",
+              "method": "GET",
+              "path": "/test/{test_id}/video",
+              "description": "To fetch video of a recorded test.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Test ID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "video_generated_status",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": "Video generated status"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Retrieve video url was successful",
+                    "status": "success",
+                    "url": "<string>",
+                    "view_video_url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "view_video_url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "tunnel",
+          "endpoints": [
+            {
+              "name": "Fetch running tunnels of your account.",
+              "method": "GET",
+              "path": "/tunnels",
+              "description": "To fetch lists of all tunnels runing in an account.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "Retrieve tunnel was successful",
+                    "status": "success",
+                    "data": [
+                      {
+                        "dns": "<string>",
+                        "email": "<string>",
+                        "username": "<string>",
+                        "shared_tunnel": true,
+                        "folder_path": "<string>",
+                        "local_domains": "<string>",
+                        "org_id": 123,
+                        "start_timestamp": "<string>",
+                        "status_ind": "<string>",
+                        "tunnel_id": 123,
+                        "tunnel_name": "<string>",
+                        "user_id": 123
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Stop a running tunnel",
+              "method": "DELETE",
+              "path": "/tunnels/{tunnel_id}",
+              "description": "To stop a running tunnel in your account. e.g 2345",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "tunnel_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Your tunnel id."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "Delete tunnel was successful.",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "403": {
+                  "description": "Forbidden! Operation not allowed.",
+                  "example": {
+                    "message": "Forbidden! Opertaion not allowed.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "404": {
+                  "description": "Tunnel with specified id does not exists.",
+                  "example": {
+                    "message": "Tunnel with specified id not found.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "platforms",
+          "endpoints": [
+            {
+              "name": "Fetch platforms",
+              "method": "GET",
+              "path": "/platforms",
+              "description": "Fetch platforms along with browsers and versions supported.",
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "Retrieve platforms was successful.",
+                    "status": "success",
+                    "platforms": [
+                      {
+                        "platform": "<string>",
+                        "browsers": [
+                          {
+                            "browser_name": "<string>",
+                            "version": "<string>",
+                            "type": "<string>",
+                            "slug": "<string>"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "platforms",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "prerun",
+          "endpoints": [
+            {
+              "name": "Fetch all pre run files uploaded by the user",
+              "method": "GET",
+              "path": "/files",
+              "description": "This API fetches all the pre run executable which are uploaded to our lambda storage.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "Meta": {
+                      "download_url": "http://api.lambdatest.com/automation/api/v1/files/download",
+                      "org_id": 12345,
+                      "total": 1
+                    },
+                    "data": [
+                      {
+                        "name": "dialog_disable",
+                        "last_modified_at": "2020-08-02T06:46:08Z",
+                        "size": 104,
+                        "capability_url": "lambda:dialog_disable/pre/httpdialog.au3",
+                        "file_path": "dialog_disable/pre/httpdialog.au3"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "Meta",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Upload pre run executable file to our lambda storage",
+              "method": "POST",
+              "path": "/files",
+              "description": "In order to use pre run feature you first need to upload your relevant script files to our lambda storage. For every pre run action you need to upload 2 scripts (Pre run file and Post run file). Pre run file will be executed before starting the test and post run file will be executed after test is completed. If you perform any changes in test machine like changing host file, changing windows registry key, installing certificates, then your post run file should undo those changes",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "multipart/form-data",
+                "description": "To upload a new pre run executable files",
+                "properties": [
+                  {
+                    "name": "pre_run_file",
+                    "type": "string<binary>",
+                    "required": true,
+                    "description": "If your script requires some reference to other file that needs to be present in our machines then you can upload multiple pre_run_file and download those files in your script using download API"
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": true,
+                    "description": "Name of your pre run executable"
+                  },
+                  {
+                    "name": "post_run_file",
+                    "type": "string<binary>",
+                    "required": true,
+                    "description": "script file that will revert the actions performed by pre run file. If there is no post action that needs to performed then you can upload an empty file"
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": [
+                      {
+                        "file": "httpdialog.au3",
+                        "error": ""
+                      }
+                    ],
+                    "message": "Files have been uploaded successfully to our lambda storage",
+                    "status": "success"
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": {
+                    "message": "Oops! The name that you have provided already exists. Please use different name or delete this script first",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete pre run from our lambda storage",
+              "method": "DELETE",
+              "path": "/files/delete",
+              "description": "This API deletes a pre run executable script from our lambda storage. Since pre run executable name should be unique, this API is useful if you want to re-upload your updated pre run script with the name same as the previous one.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "To delete a pre run executable",
+                "properties": [
+                  {
+                    "name": "file_path",
+                    "type": "string",
+                    "required": true,
+                    "description": "file path of pre run file in our lambda storage. To delete a pre run, you can either specify pre_run or post_run file path. You can get file_path from the GET /files API"
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "File have been successfully deleted from our lambda storage",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Invalid file path value",
+                  "example": {
+                    "message": "File doesn't exist in lambda storage",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Check if the file is approved by Lambdatest",
+              "method": "POST",
+              "path": "/files/validate",
+              "description": "Once the pre run executable is successfully uploaded, LambdaTest will check the script and approve it after successful verification. This API will tell if the file is approved or not",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "To check if the file is approved by Lambdatest",
+                "properties": [
+                  {
+                    "name": "file_path",
+                    "type": "string",
+                    "required": true,
+                    "description": "file path of pre run file in our lambda storage. You can get file_path from the GET /files API"
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": {
+                      "post_run_file_path": "dialog_disable/post/httpdialogenable.au3"
+                    },
+                    "message": "File exist in our lambda storage and is approved successfully",
+                    "staus": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Invalid file path value",
+                  "example": {
+                    "message": "The script is not yet approved by our team",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "staus",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Download pre run executable file.",
+              "method": "PUT",
+              "path": "/files/download",
+              "description": "Download pre run executable file.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "To download a pre run executable",
+                "properties": [
+                  {
+                    "name": "file_path",
+                    "type": "string",
+                    "required": true,
+                    "description": "file path of pre run file in our lambda storage. You can get file_path from the GET /files API"
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": null,
+                  "type": null
+                },
+                "400": {
+                  "description": "Invalid file path value specified",
+                  "example": {
+                    "message": "Error in downloading file from lambda storage",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "user-files",
+          "endpoints": [
+            {
+              "name": "Fetch all user files uploaded by the user",
+              "method": "GET",
+              "path": "/user-files",
+              "description": "This API fetches all the user files which are uploaded to our lambda storage.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "Meta": {
+                      "org_id": 12345,
+                      "total": 1
+                    },
+                    "data": [
+                      {
+                        "key": "file_example_JPG_2500kB.jpg",
+                        "last_modified_at": "2020-08-02T06:46:08Z",
+                        "size": 104
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "Meta",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Upload files to our lambda storage",
+              "method": "POST",
+              "path": "/user-files",
+              "description": "You can upload multiple files to our lambda storage. A maximum of 150 files can be uploaded per organization. We have limit of 20 MB files size per API. So if you are total file sizes reach the limit, please upload your files in multiple API calls",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "multipart/form-data",
+                "description": "To upload new user files",
+                "properties": [
+                  {
+                    "name": "files",
+                    "type": "string<binary>",
+                    "required": true,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "file": "file_example_JPG_2500kB.jpg",
+                    "error": "",
+                    "message": "File have been uploaded successfully to our lambda storage"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": {
+                    "message": "Oops! The name that you have provided already exists. Please use different name or delete this script first",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "file",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "error",
+                  "type": "string",
+                  "required": false,
+                  "description": "error message if there is any error in uploading file. If file upload is success, then it will empty",
+                  "hasChildren": false
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete user files from our lambda storage",
+              "method": "DELETE",
+              "path": "/user-files/delete",
+              "description": "This API deletes user file from lambda storage",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "To delete a user fle",
+                "properties": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "required": true,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "File have been successfully deleted from our lambda storage",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Invalid file path value",
+                  "example": {
+                    "message": "File doesn't exist in lambda storage",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Download user file from lambda storage.",
+              "method": "PUT",
+              "path": "/user-files/download",
+              "description": "Download user file from lambda storage.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "To download a user file",
+                "properties": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "required": true,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": null,
+                  "type": null
+                },
+                "400": {
+                  "description": "Invalid file path value specified",
+                  "example": {
+                    "message": "Error in downloading file from lambda storage",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Lighthouse",
+          "endpoints": [
+            {
+              "name": "To fetch the Lighthouse performance report data.",
+              "method": "GET",
+              "path": "/lighthouse/report/{session_id}",
+              "description": "To fetch URL to download the generated Lighthouse performance report JSON data.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "SESSION ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Operation successful",
+                  "example": {
+                    "message": "Retrieve Lighthouse Report data was successful.",
+                    "status": "success",
+                    "data": "<string>"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request. Conditional combination of 'chrome' browser & capability 'performance=true' is not there.",
+                  "example": {
+                    "message": "Please provide valid inputs. Conditional combination of 'chrome' browser & capability 'performance=true' is not satisfied for the test associated with the given sessionId.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Resource associated to session_id is not available.",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "500": {
+                  "description": "Unable to get Lighthouse report data.",
+                  "example": {
+                    "message": "Unable to get Lighthouse report data.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Organisation",
+          "endpoints": [
+            {
+              "name": "Get organisation concurrency",
+              "method": "GET",
+              "path": "/org/concurrency",
+              "description": "This API fetches the organisation level concurrency",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": {
+                      "queued": 100,
+                      "running": 100
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Invalid request to fetch org concurrency",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "extensions",
+          "endpoints": [
+            {
+              "name": "Fetch all extensions uploaded by the user",
+              "method": "GET",
+              "path": "/files/extensions",
+              "description": "This API fetches all the extensions which are uploaded to our lambda storage.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "Meta": {
+                      "org_id": 12345,
+                      "total": 1
+                    },
+                    "data": [
+                      {
+                        "key": "extension_1.zip",
+                        "last_modified_at": "2020-08-02T06:46:08Z",
+                        "size": 104,
+                        "s3_url": "https://automation-prod-user-files.s3.amazonaws.com/extensions/orgId-123456/extension_1.zip"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "Meta",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Upload new extensions in zip format to our lambda storage",
+              "method": "POST",
+              "path": "/files/extensions",
+              "description": "Upload new extensions in zip format to our lambda storage",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "multipart/form-data",
+                "description": "To upload new extensions",
+                "properties": [
+                  {
+                    "name": "extensions",
+                    "type": "string<binary>",
+                    "required": true,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "error": "",
+                    "s3_url": "https://automation-prod-user-files.s3.amazonaws.com/extensions/orgId-123456/extension_1.zip",
+                    "message": "File have been uploaded successfully to our lambda storage"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": {
+                    "message": "Oops! The name that you have provided already exists. Please use different name or delete this script first",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "error",
+                  "type": "string",
+                  "required": false,
+                  "description": "error message if there is any error in uploading file. If file upload is success, then it will empty",
+                  "hasChildren": false
+                },
+                {
+                  "name": "s3_url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete extension from our lambda storage",
+              "method": "DELETE",
+              "path": "/files/extensions/delete",
+              "description": "This API deletes extension from lambda storage",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "To delete a extension",
+                "properties": [
+                  {
+                    "name": "key",
+                    "type": "string",
+                    "required": true,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "File have been successfully deleted from our lambda storage",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Invalid file path value",
+                  "example": {
+                    "message": "File doesn't exist in lambda storage",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Resolution",
+          "endpoints": [
+            {
+              "name": "Get Resolutions of Platforms",
+              "method": "GET",
+              "path": "/resolutions",
+              "description": "This API fetches available supported Platforms Resolution",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "resolutions": {
+                      "BigSur": [
+                        "1024x768",
+                        "1280x960",
+                        "1280x1024"
+                      ],
+                      "Catalina": [
+                        "1024x768",
+                        "1280x960",
+                        "1280x1024"
+                      ],
+                      "Windows11": [
+                        "1024x768",
+                        "1280x800",
+                        "1280x1024"
+                      ],
+                      "Windows10": [
+                        "1024x768",
+                        "1280x800",
+                        "1280x1024"
+                      ]
+                    },
+                    "message": "Resolutions are retrieved successfully",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Invalid request to fetch supported resolutions",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "resolutions",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Geolocation",
+          "endpoints": [
+            {
+              "name": "Get Ips of geolocation",
+              "method": "GET",
+              "path": "/geoLocation/ips",
+              "description": "This API fetches all the possible ips of geolocation. It is recommended to filter using two digit country code.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "countryCode",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To filter ips of specific country."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": {
+                      "in": [
+                        "0.0.0.0",
+                        "0.0.0.0",
+                        "0.0.0.0"
+                      ],
+                      "us": [
+                        "0.0.0.0",
+                        "0.0.0.0"
+                      ]
+                    },
+                    "message": "Geolocation IP fetched successfully",
+                    "status": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Autoheal Command Logs",
+          "endpoints": [
+            {
+              "name": "Fetch autohealed commands data for a test",
+              "method": "GET",
+              "path": "/autoheal/test/{test_id}",
+              "description": "Retrieve all autohealed commands for a specific test session, including original and healed locators with execution duration.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Test ID for which to fetch autohealed commands"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Maximum number of records to return (default 100)"
+                },
+                {
+                  "name": "offset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Number of records to skip for pagination (default 0)"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successfully retrieved autohealed commands data",
+                  "example": {
+                    "status": "success",
+                    "message": null,
+                    "data": {
+                      "total_healed_commands": 11,
+                      "test_id": "DA-WIN-160849-1756966096614912604KKM",
+                      "healed_commands": [
+                        {
+                          "request_id": "LT01K49NG343J2YDNEQ60HQVQY13-6NSZV-US-EAST-1",
+                          "test_id": "DA-WIN-160849-1756966096614912604KKM",
+                          "original_locator": {
+                            "using": "css selector",
+                            "value": "[class=\"list-unstyled\"]>:nth-child(4)>input"
+                          },
+                          "healed_locator": {
+                            "using": "css selector",
+                            "value": "input.custom-checkbox.ng-pristine.ng-untouched.ng-valid.ng-empty"
+                          },
+                          "duration": 349
+                        },
+                        {
+                          "request_id": "LT01K49NG2BMVQ50K6XF53K9VZHN-L2V78-US-EAST-1",
+                          "test_id": "DA-WIN-160849-1756966096614912604KKM",
+                          "original_locator": {
+                            "using": "css selector",
+                            "value": "[class=\"list-unstyled\"]>:nth-child(3)>input"
+                          },
+                          "healed_locator": {
+                            "using": "css selector",
+                            "value": "input.custom-checkbox.ng-pristine.ng-untouched.ng-valid.ng-empty"
+                          },
+                          "duration": 398
+                        }
+                      ]
+                    }
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request - Invalid parameters",
+                  "example": {
+                    "status": "fail",
+                    "message": "Invalid limit parameter",
+                    "data": null
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized - Authentication failed",
+                  "example": {
+                    "status": "fail",
+                    "message": "Unauthorized",
+                    "data": null
+                  },
+                  "type": "object"
+                },
+                "404": {
+                  "description": "Test not found or not accessible",
+                  "example": {
+                    "status": "fail",
+                    "message": "Test not found",
+                    "data": null
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal server error",
+                  "example": {
+                    "status": "error",
+                    "message": "Failed to fetch autohealed data",
+                    "data": null
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Automated Screenshots API",
+      "baseUrl": "https://api.lambdatest.com/screenshots/v1",
+      "servers": [
+        {
+          "url": "https://api.lambdatest.com/screenshots/v1"
+        },
+        {
+          "url": "https://eu-api.lambdatest.com/screenshots/v1"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Get OS-Browsers",
+          "endpoints": [
+            {
+              "name": "Fetch all available os-browser combinations.",
+              "method": "GET",
+              "path": "/os-browsers",
+              "description": "Fetch all os browsers combinations available on lambdatest platform.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "os",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Fetch details for a particular OS"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "windows 10": {
+                      "chrome": [
+                        "76",
+                        "75"
+                      ],
+                      "firefox": [
+                        "67",
+                        "66"
+                      ],
+                      "opera": [
+                        "55",
+                        "54"
+                      ]
+                    },
+                    "macos mojave": {
+                      "chrome": [
+                        "76",
+                        "75"
+                      ],
+                      "firefox": [
+                        "67",
+                        "66"
+                      ],
+                      "opera": [
+                        "55",
+                        "54"
+                      ]
+                    }
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Unauthorized"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "windows 10",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "macos mojave",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Get Devices",
+          "endpoints": [
+            {
+              "name": "Fetch all available device combinations.",
+              "method": "GET",
+              "path": "/devices",
+              "description": "Fetch all os devices combinations available on lambdatest platform.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "os",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Fetch details for a particular OS"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "ios 12.0": {
+                      "devices": [
+                        "iphone xr",
+                        "iphone xs",
+                        "iphone xs max"
+                      ]
+                    },
+                    "android 7.0": {
+                      "devices": [
+                        "galaxy j7 max",
+                        "galaxy s8",
+                        "galaxy s8+",
+                        "galaxy tab s3 9.3",
+                        "huawei honor 6x",
+                        "nexus 5x",
+                        "nexus 6p",
+                        "oppo r9"
+                      ]
+                    }
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Unauthorized"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "ios 12.0",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "android 7.0",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Get Resolutions",
+          "endpoints": [
+            {
+              "name": "Fetch all available resolution on different OS.",
+              "method": "GET",
+              "path": "/resolutions",
+              "description": "Fetch all available resolution on different OS.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "mac_res": [
+                      "1024x768",
+                      "1280x1024"
+                    ],
+                    "win_res": [
+                      "1024x768",
+                      "1280x1024"
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Unauthorized"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "mac_res",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "win_res",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Get Screenshots",
+          "endpoints": [
+            {
+              "name": "Fetch specified screenshot details.",
+              "method": "GET",
+              "path": "/{test_id}",
+              "description": "To fetch specified screenshot details.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Test ID that details you want to fetch"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "test_id": "TES100968331562237283314836",
+                    "defer_time": 5,
+                    "test_status": "completed",
+                    "url": "https://www.lambdatest.com",
+                    "callback_url": "https://www.example.com",
+                    "screenshots": [
+                      {
+                        "os": "windows 10",
+                        "browser": "chrome",
+                        "browser_version": "76",
+                        "status": "completed",
+                        "screenshot_url": "https://s3.amazonaws.com/s3-screenshots/prod/ACT100968331562237283340194/screenshot/win-cr-76.0.png",
+                        "thumbnail_url": "https://s3.amazonaws.com/s3-screenshots/prod/ACT100968331562237283340194/screenshot/win-cr-76.0.png",
+                        "activity_id": "ACT100968331562237283340194",
+                        "resolution": "1024x768"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Unauthorized"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Screenshot API is supported only in our premium plans. Please upgrade."
+                  },
+                  "type": null
+                },
+                "404": {
+                  "description": "Resource not found",
+                  "example": {
+                    "message": "No data found",
+                    "reason": "test_id is invalid"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Get Zipped Screenshots",
+          "endpoints": [
+            {
+              "name": "Fetch Zipped Screenshots",
+              "method": "GET",
+              "path": "/{test_id}/zip",
+              "description": "Fetch Zipped Screenshots",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Test ID that Zipped Screenshots you want to fetch"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "url": "https://s3-screenshots.s3.amazonaws.com/screenshots/TES1009632231568637527345629.zip"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Unauthorized"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Screenshot API is supported only in our premium plans. Please upgrade."
+                  },
+                  "type": null
+                },
+                "404": {
+                  "description": "Resource not found",
+                  "example": {
+                    "message": "No data found",
+                    "reason": "test_id is invalid"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Get Profiles",
+          "endpoints": [
+            {
+              "name": "Fetch login profiles",
+              "method": "GET",
+              "path": "/profiles",
+              "description": "Fetch login profiles",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "profiles": [
+                      {
+                        "name": "lambda-login",
+                        "profile_config": {
+                          "credentials": {
+                            "password": "password",
+                            "username": "name"
+                          },
+                          "locators": {
+                            "password": {
+                              "type": "name",
+                              "value": "password"
+                            },
+                            "submit": {
+                              "type": "css",
+                              "value": "button.btn-lg"
+                            },
+                            "username": {
+                              "type": "name",
+                              "value": "email"
+                            }
+                          },
+                          "login_url": "https://accounts.lambdatest.com/login",
+                          "profile_name": "lambda-login"
+                        }
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Unauthorized"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "profiles",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Get Locations",
+          "endpoints": [
+            {
+              "name": "Fetch Locations",
+              "method": "GET",
+              "path": "/locations",
+              "description": "Fetch list of available Geolocations",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "locations": [
+                      {
+                        "code": "US",
+                        "name": "United States"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Unauthorized"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "locations",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Start Screenshot Test",
+          "endpoints": [
+            {
+              "name": "Start Screenshot Test",
+              "method": "POST",
+              "path": "/",
+              "description": "Start Screenshot Test",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "start screenshot test payload.",
+                "properties": [
+                  {
+                    "name": "url",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "defer_time",
+                    "type": "number",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "email",
+                    "type": "boolean",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "mac_res",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "win_res",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "tunnel",
+                    "type": "boolean",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "tunnel_identifier",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "username",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "password",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "callback_url",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "configs",
+                    "type": "object",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "test_id": "TES100968331562243938913767"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": {
+                    "message": "The os, browser, browser_version combination is either unsupported or doesn't exist. Please try again with a different combination."
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Unauthorized"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Screenshot API is supported only in our premium plans. Please upgrade."
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Stop Screenshot Test",
+          "endpoints": [
+            {
+              "name": "Stop specified screenshot test",
+              "method": "PUT",
+              "path": "/stop/{test_id}",
+              "description": "Stop specified screenshot test",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Test ID that details you want to stop"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Test stopped successfully"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Unauthorized"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "message": "Screenshot API is supported only in our premium plans. Please upgrade."
+                  },
+                  "type": null
+                },
+                "404": {
+                  "description": "Resource not found",
+                  "example": {
+                    "message": "No active Screenshot test found for this test_id"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "App Automation API (Real Devices)",
+      "baseUrl": "https://manual-api.lambdatest.com",
+      "servers": [
+        {
+          "url": "https://manual-api.lambdatest.com",
+          "description": "Server 1"
+        },
+        {
+          "url": "https://eu-manual-api.lambdatest.com",
+          "description": "Server 1 eu"
+        },
+        {
+          "url": "https://mobile-api.lambdatest.com/mobile-automation/api/v1",
+          "description": "Server 2"
+        },
+        {
+          "url": "https://eu-mobile-api.lambdatest.com/mobile-automation/api/v1",
+          "description": "Server 2 eu"
+        },
+        {
+          "url": "https://mobile-api.lambdatest.com",
+          "description": "Server 3"
+        },
+        {
+          "url": "https://eu-mobile-api.lambdatest.com",
+          "description": "Server 3 eu"
+        },
+        {
+          "url": "https://api.lambdatest.com",
+          "description": "Server 4",
+          "variables": {
+            "protocol": {
+              "default": "https",
+              "enum": [
+                "https"
+              ]
+            }
+          }
+        }
+      ],
+      "groups": [
+        {
+          "name": "Application (Espresso/XCUI)",
+          "endpoints": [
+            {
+              "name": "Upload a framework file for testing(Espresso/XCUI) (Server 1)",
+              "method": "POST",
+              "path": "/app/uploadFramework",
+              "description": "Upload a framework file for testing purposes. Supports Espresso for Android and XCUITest for iOS.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "multipart/form-data",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "appFile",
+                    "type": "string<binary>",
+                    "required": true,
+                    "description": "The application file to be uploaded."
+                  },
+                  {
+                    "name": "type",
+                    "type": "enum<string>",
+                    "required": true,
+                    "description": "The type of the application (XCUITest for iOS, Espresso for Android).",
+                    "enum": [
+                      "xcuit-ios",
+                      "espresso-android"
+                    ]
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": "Name of the application."
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successfully uploaded the framework.",
+                  "example": {
+                    "app_id": "lt://APP1016038711693231735315475",
+                    "name": "<string>",
+                    "type": "<string>",
+                    "url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "415": {
+                  "description": "Unsupported media type. Ensure the provided file format is valid.",
+                  "example": null,
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal server error. Please try again later.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "app_id",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Application (Appium)",
+          "endpoints": [
+            {
+              "name": "Upload Application to a Real Device (Server 1)",
+              "method": "POST",
+              "path": "/app/upload/realDevice",
+              "description": "Upload an application (.ipa,.apk,.aab) for testing on a real device.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "multipart/form-data",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "appFile",
+                    "type": "string<binary>",
+                    "required": true,
+                    "description": "Path to the application file on your local system."
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": true,
+                    "description": "Name of the application."
+                  },
+                  {
+                    "name": "custom_id",
+                    "type": "string",
+                    "required": false,
+                    "description": "Custom ID of the application."
+                  },
+                  {
+                    "name": "visibility",
+                    "type": "enum<string>",
+                    "required": false,
+                    "description": "Visibility scope of the uploaded application.",
+                    "enum": [
+                      "individual",
+                      "team"
+                    ]
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Application successfully uploaded for testing.",
+                  "example": {
+                    "app_id": "APP10160502401693989036908244",
+                    "name": "Appname",
+                    "type": "android",
+                    "app_url": "lt://APPID",
+                    "url": "APP_URL",
+                    "custom_id": "Custom"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "415": {
+                  "description": "Unsupported media type. Ensure the provided file format is valid.",
+                  "example": null,
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal server error. Please try again later.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "app_id",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "app_url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "custom_id",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch all uploaded applications (Server 1)",
+              "method": "GET",
+              "path": "/app/data",
+              "description": "Fetch all applications based on the provided type (android/iOS) and access level (user/organization).",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "type",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "Application type (android/iOS)"
+                },
+                {
+                  "name": "level",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "Access level (user/organization)"
+                },
+                {
+                  "name": "offset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Page offset defines the number of records to skip before fetching data. It is used along with the limit to fetch a specific page of data."
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch specified number of records. e.g. limit=10"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successfully retrieved applications.",
+                  "example": {
+                    "metaData": {
+                      "type": "<string>",
+                      "total": 123
+                    },
+                    "data": [
+                      {
+                        "app_id": "<string>",
+                        "name": "<string>",
+                        "type": "<string>",
+                        "updated_at": "2018-03-15T12:00:00Z",
+                        "shared": true,
+                        "source": "<string>"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "404": {
+                  "description": "Resource not found.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "metaData",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Get data by Custom ID (Server 1)",
+              "method": "GET",
+              "path": "/app/custom_id/{customId}",
+              "description": "Retrieve data by custom ID from LambdaTest.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "customId",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "The custom ID to retrieve data for"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "metadataPresent",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": true,
+                  "description": "Specify if metadata is present (true or false)"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful response",
+                  "example": [
+                    {
+                      "app_id": "<string>",
+                      "source": "<string>",
+                      "type": "android",
+                      "url": "<string>",
+                      "patched_url": "<string>",
+                      "name": "<string>",
+                      "custom_id": "<string>",
+                      "md5_hash": "<string>",
+                      "cf_url": "<string>",
+                      "cf_ap_url": "<string>",
+                      "cf_patched_url": "<string>",
+                      "cf_ap_patched_url": "<string>"
+                    }
+                  ],
+                  "type": "array"
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Download App by ID (Server 1)",
+              "method": "GET",
+              "path": "/app/{appId}/download",
+              "description": "Download the binary of an uploaded application (.apk/.aab/.ipa) using its unique `appId`. The file is streamed back as an attachment.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "appId",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "The unique ID of the application to download (e.g., `APP1016038711693231735315475`)."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Application binary streamed successfully as a file attachment.",
+                  "example": null,
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request. The `appId` is invalid, corrupt, the app no longer exists, or the file is not available.",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal server error. Please try again later.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Download App by Custom ID (Server 1)",
+              "method": "GET",
+              "path": "/app/custom_id/{customId}/download",
+              "description": "Download the binary of an uploaded application (.apk/.aab/.ipa) using its `customId`. The file is streamed back as an attachment.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "customId",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "The custom ID of the application to download."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Application binary streamed successfully as a file attachment.",
+                  "example": null,
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request. The `customId` is invalid or no app was found for the provided custom ID.",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal server error. Please try again later.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Delete your uploaded applications (Server 1)",
+              "method": "DELETE",
+              "path": "/app/delete",
+              "description": "Delete the uploaded applications based on the provided appIds.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "appIds",
+                    "type": "string",
+                    "required": false,
+                    "description": "Comma-separated string of App IDs to delete (e.g., \"APP1016038711693231735315475\")"
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successfully deleted the selected application(s).",
+                  "example": {
+                    "message": "Deleted successfully."
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request. Invalid input or missing parameters.",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "default": {
+                  "description": "An unexpected error occurred.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete a single uploaded application (Server 1)",
+              "method": "DELETE",
+              "path": "/app/{appId}",
+              "description": "Deletes an uploaded application using its unique `appId`.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "appId",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "The ID of the application to delete (e.g., `APP1234567890`)."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Application deleted successfully.",
+                  "example": {
+                    "message": "Deleted successfully."
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request. Invalid or missing appId.",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "404": {
+                  "description": "Application not found.",
+                  "example": null,
+                  "type": null
+                },
+                "default": {
+                  "description": "An unexpected error occurred.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Media",
+          "endpoints": [
+            {
+              "name": "Fetch media list for an organization (server 4)",
+              "method": "GET",
+              "path": "/mfs/v1.0/media/list",
+              "description": "Retrieve a list of uploaded media files (images, videos, etc.) associated with an organization.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "custom_id",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "The custom ID to retrieve Media."
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Media type (image/video/doc/cert)"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful response containing media list",
+                  "example": {
+                    "media_url": "Media_URL",
+                    "media_id": "MEDIA12234567890",
+                    "name": "sample.png",
+                    "custom-id": "Sample_Image",
+                    "type": "image"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "415": {
+                  "description": "Unsupported media type. Ensure the provided file format is valid.",
+                  "example": null,
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal server error. Please try again later.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Delete a media asset (server 4)",
+              "method": "DELETE",
+              "path": "/mfs/v1.0/media/{media_id}",
+              "description": "Deletes the media files associated with the given `media_id`.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "media_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "The Media Id to retrieve data for deletion."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successfully deleted the selected media(s).",
+                  "example": {
+                    "Status": "Deleted successfully."
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request. Invalid input or missing parameters.",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "default": {
+                  "description": "An unexpected error occurred.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Upload Media File (Image/Video/Document/Certificate) (Server 4)",
+              "method": "POST",
+              "path": "/mfs/v1.0/media/upload/",
+              "description": "Upload a media file (.jpg, .png, .mp4, .pdf, etc.) for use.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "multipart/form-data",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "media_file",
+                    "type": "string<binary>",
+                    "required": true,
+                    "description": "The media file to be uploaded."
+                  },
+                  {
+                    "name": "type",
+                    "type": "enum<string>",
+                    "required": false,
+                    "description": "Type of media (e.g., image, video, document, Certificate).",
+                    "enum": [
+                      "Image",
+                      "Video",
+                      "Documents",
+                      "Certificate"
+                    ]
+                  },
+                  {
+                    "name": "custom_id",
+                    "type": "string",
+                    "required": false,
+                    "description": "Optional custom identifier for later retrieval."
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successfully uploaded the media file.",
+                  "example": {
+                    "media_url": "lt://MEDIA12345",
+                    "name": "image.png",
+                    "custom_id": "Image_1",
+                    "Status": "Successful"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "415": {
+                  "description": "Unsupported media type. Ensure the provided file format is valid.",
+                  "example": null,
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal server error. Please try again later.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "media_url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "custom_id",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "Status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Devices List",
+          "endpoints": [
+            {
+              "name": "Fetch available devices for running tests (Server 2)",
+              "method": "GET",
+              "path": "/list",
+              "description": "Retrieves the list of devices available for running tests. You can filter the devices based on the region.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "region",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "Region to filter available devices ( 'eu', 'us', 'ap')"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": [
+                    {
+                      "deviceId": "d123",
+                      "deviceName": "Pixel 4",
+                      "platformName": "Android",
+                      "platformVersion": "10.0",
+                      "deviceStatus": "Available"
+                    }
+                  ],
+                  "type": "array"
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": {
+                    "code": 123,
+                    "message": "<string>"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Unauthorized",
+                  "example": {
+                    "code": 123,
+                    "message": "<string>"
+                  },
+                  "type": "object"
+                },
+                "404": {
+                  "description": "Not Found",
+                  "example": {
+                    "code": 123,
+                    "message": "<string>"
+                  },
+                  "type": "object"
+                },
+                "500": {
+                  "description": "Internal Server Error",
+                  "example": {
+                    "code": 123,
+                    "message": "<string>"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Concurrency Details",
+          "endpoints": [
+            {
+              "name": "Get your account's concurrency details (Server 2)",
+              "method": "GET",
+              "path": "/org/concurrency",
+              "description": "Retrieve the concurrency details for your account.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation ()",
+                  "example": {
+                    "data": {
+                      "max_concurrency": 123,
+                      "max_queue": 123,
+                      "queued": 123,
+                      "running": 123
+                    }
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Application Processing (Appium)",
+          "endpoints": [
+            {
+              "name": "Fetch patched APK URL (Server 3)",
+              "method": "POST",
+              "path": "/mobile-automation/api/v1/fetchpatchedapkurl",
+              "description": "This endpoint facilitates the retrieval of a patched APK URL and provides information on whether the patching process is complete or not. It is essential for Appium automation and supports testing workflows.\n",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "appId",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "imageInjectionEnabled",
+                    "type": "boolean",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "screenshotUnblockEnabled",
+                    "type": "boolean",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": {
+                      "cf_ap_patched_url": "",
+                      "cf_patched_url": "",
+                      "imageinjection_ready": false,
+                      "patched_url": "",
+                      "screenshotunblock_ready": false,
+                      "status": "success"
+                    },
+                    "status": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized access. Authentication required.",
+                  "example": null,
+                  "type": null
+                },
+                "404": {
+                  "description": "Resource not found.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Execute Test (Espresso/XCUI)",
+          "endpoints": [
+            {
+              "name": "Execute espresso test on the LambdaTest platform (Server 3)",
+              "method": "POST",
+              "path": "/framework/v1/espresso/build",
+              "description": "This endpoint enables you to execute automated tests using the LambdaTest platform.\n",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "app",
+                    "type": "string",
+                    "required": true,
+                    "description": "The APPID of the uploaded app, usually in the format 'lt://APP_ID'."
+                  },
+                  {
+                    "name": "testSuite",
+                    "type": "string",
+                    "required": true,
+                    "description": "The ID of the uploaded test suite to be executed, usually in the format 'lt://TestSuite_ID'."
+                  },
+                  {
+                    "name": "device",
+                    "type": "array",
+                    "required": true,
+                    "description": "List of device identifiers where the test should be executed. e.g., ['Galaxy S21 5G-12', 'iPhone 12']."
+                  },
+                  {
+                    "name": "queueTimeout",
+                    "type": "integer",
+                    "required": true,
+                    "description": "Maximum time in seconds to wait for devices to be available in the queue. Defaults to 10800 seconds (3 hours)."
+                  },
+                  {
+                    "name": "idleTimeout",
+                    "type": "integer",
+                    "required": true,
+                    "description": "Maximum idle time in seconds before a running test is terminated. Defaults to 150 seconds."
+                  },
+                  {
+                    "name": "deviceLog",
+                    "type": "boolean",
+                    "required": true,
+                    "description": "Enable or disable device log capturing. Defaults to true."
+                  },
+                  {
+                    "name": "network",
+                    "type": "boolean",
+                    "required": true,
+                    "description": "Enable or disable network log capturing. Defaults to false."
+                  },
+                  {
+                    "name": "build",
+                    "type": "string",
+                    "required": true,
+                    "description": "Name of the build for identification purposes."
+                  },
+                  {
+                    "name": "geoLocation",
+                    "type": "string",
+                    "required": false,
+                    "description": "Geo-location setting for the test, specified as a country code. Defaults to 'US'."
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "status": [
+                      "Success"
+                    ],
+                    "buildId": [
+                      "1395514"
+                    ],
+                    "message": [
+                      ""
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "status": "error",
+                    "message": "Unauthorized"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "status",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "buildId",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "message",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Execute XCUI test on the LambdaTest platform (Server 3)",
+              "method": "POST",
+              "path": "/framework/v1/xcui/build",
+              "description": "Execute the automation tests on Lambdatest platform using the provided parameters.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "app",
+                    "type": "string",
+                    "required": true,
+                    "description": "Uploaded app's APPID"
+                  },
+                  {
+                    "name": "testSuite",
+                    "type": "string",
+                    "required": true,
+                    "description": "Uploaded test suite's ID"
+                  },
+                  {
+                    "name": "device",
+                    "type": "array",
+                    "required": true,
+                    "description": "Device(s) to execute the test on"
+                  },
+                  {
+                    "name": "queueTimeout",
+                    "type": "integer",
+                    "required": true,
+                    "description": "Queue timeout value in seconds"
+                  },
+                  {
+                    "name": "idleTimeout",
+                    "type": "integer",
+                    "required": true,
+                    "description": "Idle timeout value in seconds"
+                  },
+                  {
+                    "name": "devicelog",
+                    "type": "boolean",
+                    "required": true,
+                    "description": "Enable or disable device logs"
+                  },
+                  {
+                    "name": "network",
+                    "type": "boolean",
+                    "required": true,
+                    "description": "Enable or disable network logs"
+                  },
+                  {
+                    "name": "build",
+                    "type": "string",
+                    "required": true,
+                    "description": "Build name"
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "status": [
+                      "Success"
+                    ],
+                    "buildId": [
+                      "1395514"
+                    ],
+                    "message": [
+                      ""
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": {
+                    "status": "error",
+                    "message": "Unauthorized"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "status",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "buildId",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "message",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Session",
+          "endpoints": [
+            {
+              "name": "Fetch the app URL for a particular session (Server 2)",
+              "method": "GET",
+              "path": "/metadata/{session_id}/details",
+              "description": "Retrieve the app URL being used for a specific session.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "ID of the session"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "appUrl": "<string>"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "appUrl",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch list of all sessions (Server 2)",
+              "method": "GET",
+              "path": "/sessions",
+              "description": "To fetch list of sessions. You can also limit the number of records, and paginate through your data using Parameters.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "build_id",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "To filter sessions of specific build."
+                },
+                {
+                  "name": "username",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To filter sessions of specific user."
+                },
+                {
+                  "name": "offset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "It defines the number of lists on the basis of limit parameter. e.g offset=10"
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch specified number of records. e.g. limit=10"
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of sessions with specific status. You can pass multiple comma seperated status e.g. queued,completed,passed,failed,timeout,error and lambda error."
+                },
+                {
+                  "name": "fromdate",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of sessions that executed from the specified Start Date. The Date format must be YYYY-MM-DD. e.g. \"2018-03-15\"."
+                },
+                {
+                  "name": "todate",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of sessions that executed till the specified End Date. If both fromdate and todate value provided then it works as range filter. The Date format must be YYYY-MM-DD. e.g. \"2018-03-15\"."
+                },
+                {
+                  "name": "sort",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To sort the list in ascending or descending order using multiple keys. e.g. \"asc.user_id,desc.duration\""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "Meta": {
+                      "attributes": {
+                        "org_id": 123
+                      },
+                      "result_set": {
+                        "count": 1,
+                        "limit": 1,
+                        "offset": 123,
+                        "total": 100
+                      }
+                    },
+                    "data": [
+                      {
+                        "test_id": "Z17EF-OPUKH-BDAE8-YEPXU",
+                        "build_id": 1,
+                        "build_name": "MACOS 10.12-CHROME-2018-12-23",
+                        "user_id": 250563,
+                        "username": "bahubali",
+                        "status_ind": "passed",
+                        "create_timestamp": "2019-02-05 08:24:36",
+                        "start_timestamp": "2019-02-05 08:24:58",
+                        "end_timestamp": "2019-02-05 08:27:22",
+                        "remark": "completed",
+                        "platform": "android",
+                        "version": "12",
+                        "name": "Google Pixel 6_12_1JNEQOQMS1",
+                        "session_id": "e7f2d7jkwdkbjdsvbkc8d0569",
+                        "device": "Google Pixel 6",
+                        "duration": "369",
+                        "tag": [
+                          "tag1",
+                          "tag2",
+                          "tag3"
+                        ],
+                        "customdata": {
+                          "project": "my-project",
+                          "environment": "staging",
+                          "build_number": "123"
+                        },
+                        "appium_logs": "sessions/jnwkdnkvdsf0c4-4jnkdjkbdvscbfc5/log/appium",
+                        "console_logs": "sessions/jnwkdnkvdsf0c4-4jnkdjkbdvscbfc5/log/console",
+                        "network_logs": "sessions/jnwkdnkvdsf0c4-4jnkdjkbdvscbfc5/log/network",
+                        "device_logs": "sessions/jnwkdnkvdsf0c4-4jnkdjkbdvscbfc5/log/devicelog",
+                        "command_logs": "sessions/jnwkdnkvdsf0c4-4jnkdjkbdvscbfc5/log/command",
+                        "video_url": "?mobile=true&testID=AMABJDFAB9G&auth=0880eb1993ghkdjsvkbjfd",
+                        "screenshot_url": "http://dmanfqoqano.cloudfront.net/orgId-0/AIQBFMANNB9G/screenshots.zip"
+                      }
+                    ],
+                    "message": "Retrieve build list was successful",
+                    "status": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Not Found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "Meta",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "session specific information (Server 2)",
+              "method": "GET",
+              "path": "/sessions/{session_id}",
+              "description": "To fetch specified session details such as name, status,os,browser,version and all generated logs endpoint.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "SESSION ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": {
+                      "test_id": "Z17EF-OPUKH-BDAE8-YEPXU",
+                      "build_id": 1,
+                      "name": "mytest",
+                      "user_id": 250563,
+                      "username": "bahubali",
+                      "duration": 123,
+                      "platform": "win10",
+                      "browser": "chrome",
+                      "browser_version": "71.0",
+                      "device": "<string>",
+                      "status_ind": "<string>",
+                      "session_id": "bc02fd99593f14e37850745d66197f89",
+                      "build_name": "my-build",
+                      "create_timestamp": "2019-02-05 08:24:36",
+                      "start_timestamp": "2019-02-05 08:24:58",
+                      "end_timestamp": "2019-02-05 08:27:22",
+                      "remark": "completed",
+                      "console_logs_url": "https://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/console",
+                      "network_logs_url": "https://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/network",
+                      "command_logs_url": "http://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/command",
+                      "appium_logs_url": "http://api.lambdatest.com/automation/api/v1/sessions/bc02fd99593f14e37850745d66197f89/log/appium",
+                      "screenshot_url": "https://s3.amazonaws.com/ml-screenshots/00HIR-IQNLL-SDVHV-KDTBM/video/index.m3u8",
+                      "video_url": "https://d15x9hjibri3lt.cloudfront.net/00HIR-IQNLL-SDVHV-KDTBM/screenshots.zip",
+                      "customData": {}
+                    },
+                    "message": "Retrieve session was successful",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Resource associated to session_id is not available.",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "pet status in the store",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete test session (Server 2)",
+              "method": "DELETE",
+              "path": "/sessions/{session_id}",
+              "description": "Delete a session.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "SESSION ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "Session deleted successfully",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "403": {
+                  "description": "Forbidden! Operation not allowed.",
+                  "example": {
+                    "message": "Forbidden! Operation not allowed.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "404": {
+                  "description": "Resource associated to session_id is not available.",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Update session name and status. (Server 2)",
+              "method": "PATCH",
+              "path": "/sessions/{session_id}",
+              "description": "To update the test session name and status {\"passed\",\"failed\"}.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "You can update both name and status of a session in single request.",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "status_ind",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "custom_data",
+                    "type": "object",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "successful operation.",
+                  "example": {
+                    "message": "Session updated successfully",
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request.",
+                  "example": {
+                    "message": "Please provide a valid payload",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "403": {
+                  "description": "Forbidden! Operation not allowed.",
+                  "example": {
+                    "message": "Forbidden! Operation not allowed.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "404": {
+                  "description": "Resource associated to session_id is not available.",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch recorded video of a test session id. (Server 2)",
+              "method": "GET",
+              "path": "/sessions/{session_id}/video",
+              "description": "To fetch video of a recorded test session.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Retrieve video url was successful",
+                    "status": "success",
+                    "url": "<string>",
+                    "view_video_url": "<string>"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "view_video_url",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "command logs of a test session (Server 2)",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/command",
+              "description": "To fetch the all executed commands of a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "pageoffset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Page offset defines the number of records to skip, based on the limit parameter, to fetch a specific page of data. e.g pageoffset=10"
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch specified number of records. e.g. limit=10"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "Value": {
+                      "logType": "requestLog",
+                      "testID": "5HLCQ-HPCWH-UOE2O-2CUFA",
+                      "status": 0,
+                      "timestamp": 1551356385,
+                      "orgID": 0,
+                      "requestId": "82e3b7cd-3b04-4bc8-9d2b-567aff450fe4",
+                      "RequestStartTime": 1551356385,
+                      "requestMethod": "POST",
+                      "requestPath": "/wd/hub/session/2F42BCCC-BF43-426A-A72F-F58F58167496/element/node-DF5D363E-84A2-4CA4-9AC4-0F398C606082/click",
+                      "duration": 8,
+                      "requestBody": "{\"sessionId\": \"2F42BCCC-BF43-426A-A72F-F58F58167496\", \"id\": \"node-DF5D363E-84A2-4CA4-9AC4-0F398C606082\"}",
+                      "responseBody": "{\"status\":0,\"sessionId\":\"2F42BCCC-BF43-426A-A72F-F58F58167496\",\"value\":{}}",
+                      "responseStatus": "200 OK",
+                      "screenshotId": "56bcabhakjasnac75142bc"
+                    }
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "Value",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "appium log of a test session (Server 2)",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/appium",
+              "description": "To fetch appium log that contains grid requests and reponses of a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": null,
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Network log of a test session (Server 2)",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/network",
+              "description": "To fetch Network log that contains all the requested urls of a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get logs based on session id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "_id": "uigakk12kbad",
+                    "cache": {},
+                    "startedDateTime": "2022-03-14T08:48:33.516688738Z",
+                    "time": 0,
+                    "timings": {
+                      "receive": 0,
+                      "send": 0,
+                      "wait": 0
+                    },
+                    "request": {
+                      "bodySize": 0,
+                      "cookies": [
+                        "<string>"
+                      ],
+                      "headers": [
+                        "<string>"
+                      ],
+                      "headersSize": -1,
+                      "httpVersion": "HTTP/1.1",
+                      "method": "CONNECT",
+                      "queryString": [
+                        "<string>"
+                      ],
+                      "url": "http://testing.com"
+                    },
+                    "response": {
+                      "bodySize": 0,
+                      "content": {
+                        "encodeing": "base64",
+                        "mimeType": "",
+                        "text": "",
+                        "size": 0
+                      },
+                      "cookies": [
+                        "<string>"
+                      ],
+                      "headers": [
+                        "<string>"
+                      ],
+                      "headersSize": -1,
+                      "httpVersion": "HTTP/1.1",
+                      "redirectURL": "",
+                      "status": 200,
+                      "statusText": "OK"
+                    }
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "_id",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "cache",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "startedDateTime",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "time",
+                  "type": "integer",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "timings",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "request",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "response",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "devicelog log of a test session (Server 2)",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/devicelog",
+              "description": "To fetch devicelog log that contains devicelog errors thrown by application during a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": null,
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "devicelog custom logs of a test session in .zip file (Server 2)",
+              "method": "GET",
+              "path": "/sessions/{session_id}/log/devicelogzip",
+              "description": "To fetch devicelog in zipped format that contains all device logs including custom logs generated during a test session.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "session_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Session ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Zipped device logs fetched successfully.",
+                  "example": null,
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Stop a running test session (server 2)",
+              "method": "PUT",
+              "path": "/sessions/{test_id}/stop",
+              "description": "Stops a running test session using its `test_id`",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "The ID of the session (test) to stop."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": []
+              },
+              "responses": {
+                "200": {
+                  "description": "Test Session stopped successfully.",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized request.",
+                  "example": null,
+                  "type": null
+                },
+                "404": {
+                  "description": "Test Id not found.",
+                  "example": null,
+                  "type": null
+                },
+                "409": {
+                  "description": "Stop Already in Progress.",
+                  "example": null,
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal Server Error",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Build",
+          "endpoints": [
+            {
+              "name": "Fetch all builds of an account. (Server 2)",
+              "method": "GET",
+              "path": "/builds",
+              "description": "Fetch all builds of an account. You can limit the number of records and apply filter on status,build date range and sort by users,start date and end date in asc and desc order. You can apply sort on multiple columns.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "offset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "It defines the number of lists on the basis of limit parameter. e.g offset=10"
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch specified number of records. e.g. limit=10"
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of builds with specific status. You can pass multiple comma seperated status e.g. running,queued,completed,timeout and error."
+                },
+                {
+                  "name": "fromdate",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of builds that executed from the specified Start Date. The Date format must be YYYY-MM-DD. e.g. \"2018-03-15\"."
+                },
+                {
+                  "name": "todate",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To fetch the list of builds that executed till the specified End Date. If both fromdate and todate value provided then it works as range filter. The Date format must be YYYY-MM-DD. e.g. \"2018-03-15\"."
+                },
+                {
+                  "name": "sort",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "To sort the list in ascending or descending order using multiple keys. e.g. \"asc.user_id\""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "Meta": {
+                      "attributes": {
+                        "org_id": 123
+                      },
+                      "result_set": {
+                        "count": 1,
+                        "limit": 1,
+                        "offset": 123,
+                        "total": 100
+                      }
+                    },
+                    "data": [
+                      {
+                        "build_id": 1782,
+                        "name": "shivam-video-test",
+                        "user_id": 1212,
+                        "username": "shivam",
+                        "status_ind": "completed",
+                        "create_timestamp": "2019-02-05 08:24:36",
+                        "end_timestamp": "2019-02-05 08:27:22",
+                        "project_id": 0,
+                        "project_name": "automation1",
+                        "tags": [
+                          "tag1",
+                          "tag2",
+                          "tag3"
+                        ]
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Invalid session id value",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "Meta",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Fetch specified build details (Server 2)",
+              "method": "GET",
+              "path": "/builds/{build_id}",
+              "description": "To fetch build details of the buildid specified by the user.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "build_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Build ID that details you want to fetch"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": {
+                      "build_id": 1,
+                      "name": "asdaskjaaa",
+                      "user_id": 1212,
+                      "username": "john smith",
+                      "status_ind": "completed",
+                      "create_timestamp": "2018-12-23 14:30:14",
+                      "end_timestamp": "2018-12-25 12:46:38",
+                      "tags": [
+                        "tag1",
+                        "tag2",
+                        "tag3"
+                      ]
+                    },
+                    "message": "Retrieve build list was successful",
+                    "status": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Resource not found",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete Build (Server 2)",
+              "method": "DELETE",
+              "path": "/builds/{build_id}",
+              "description": "To delete specified Build from dashboard.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "build_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Build ID that need to be deleted"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Build deleted successfully",
+                    "status": "success",
+                    "data": {
+                      "result": "1"
+                    }
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Invalid build id value",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Update Build Name (Server 2)",
+              "method": "PATCH",
+              "path": "/builds/{build_id}",
+              "description": "To change build name.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "build_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "build id that name need to be changed."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "Updated Build Name",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string<string>",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "build_result",
+                    "type": "string<string>",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "message": "Build updated successfully",
+                    "status": "success",
+                    "data": {
+                      "result": "1"
+                    }
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad Request",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Stop a running build (server 2)",
+              "method": "PUT",
+              "path": "/builds/{build_id}/stop",
+              "description": "Stops the execution of a running build using its `build_id`.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "build_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "The ID of the build to stop."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": []
+              },
+              "responses": {
+                "200": {
+                  "description": "Build stopped successfully.",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized. Invalid or missing authentication.",
+                  "example": null,
+                  "type": null
+                },
+                "404": {
+                  "description": "Build ID not found.",
+                  "example": null,
+                  "type": null
+                },
+                "409": {
+                  "description": "Stop request already in progress.",
+                  "example": null,
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal server error.",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Smart UI",
+      "baseUrl": "https://api.lambdatest.com/automation/smart-ui",
+      "servers": [
+        {
+          "url": "https://api.lambdatest.com/automation/smart-ui"
+        },
+        {
+          "url": "https://eu-api.lambdatest.com/automation/smart-ui"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Upload Screenshots",
+          "endpoints": [
+            {
+              "name": "Upload any locally captured images to SmartUI for visual regression testing.Maximum Upload Size:100MB",
+              "method": "POST",
+              "path": "/v2/upload",
+              "description": "Using this API you can upload any local images to our cloud comparsion. You can upload images and add their meta-data information to map the screenshots for comparsion.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "multipart/form-data",
+                "description": "Pass your list of screenshots which needs to be uploaded for comparison. (Minimum 1 file required)",
+                "properties": [
+                  {
+                    "name": "files",
+                    "type": "string<binary>",
+                    "required": true,
+                    "description": ""
+                  },
+                  {
+                    "name": "projectToken",
+                    "type": "string",
+                    "required": true,
+                    "description": ""
+                  },
+                  {
+                    "name": "buildName",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "baseline",
+                    "type": "boolean",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "screenshotNames",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "githubURL",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": {
+                      "filesUploaded": {
+                        "error": "",
+                        "message": "",
+                        "fileName": "Screenshot 2022-12-05 at 5.00.37 PM.png",
+                        "screenshotName": "screenshot1"
+                      },
+                      "buildName": "build-1",
+                      "buildId": "f3e9bf89-4b61-4eb2-ad60-aaa72150d05e",
+                      "projectName": "demo-project",
+                      "totalFilesUploaded": 1,
+                      "projectId": "65bd1675-fe42-40bf-9698-7610cb4211bd"
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Invalid/Missing Project Token . Missing mandatory parameters or wrong input.",
+                  "example": {
+                    "data": "Please Specify Project Token. It is a mandatory parameter",
+                    "message": "error",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Get Build Status",
+          "endpoints": [
+            {
+              "name": "Fetch build status by buildId or buildName",
+              "method": "GET",
+              "path": "/build/status",
+              "description": "This API fetches the build status along with the count of different screenshot statuses. **Note:** When both `buildId` and `buildName` are provided in the request, `buildId` will be given priority over `buildName`.\n",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "projectToken",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "Validate and map the project in which the build exists"
+                },
+                {
+                  "name": "buildId",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Unique ID for the build. You can get it from the URL of build's tests page."
+                },
+                {
+                  "name": "buildName",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Name of the build. (For storybook project, provide build ID)"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": {
+                      "changesFound": 2,
+                      "approved": 3,
+                      "underReview": 0,
+                      "rejected": 0,
+                      "buildId": "2423e94d-7f12-460c-8de7-e35db3698d8a",
+                      "buildName": "c24dd3e",
+                      "projectName": "web-project",
+                      "buildStatus": "Changes Need Approval",
+                      "message": "Fetched Build Status Successfully"
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Mandatory parameters are missing/empty in request. Please add/correct them in query parameters",
+                  "example": {
+                    "data": {
+                      "data": {
+                        "changesFound": 0,
+                        "approved": 0,
+                        "underReview": 0,
+                        "rejected": 0,
+                        "buildId": "",
+                        "buildName": "",
+                        "projectName": "",
+                        "buildStatus": "",
+                        "message": ""
+                      }
+                    },
+                    "message": "Mandatory parameters are missing/empty in request. Please add/correct them in query parameters",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Get Screenshot Status",
+          "endpoints": [
+            {
+              "name": "Fetch build status by buildId / buildName",
+              "method": "GET",
+              "path": "/screenshot/build/status",
+              "description": "This API fetches the status of all screenshots which are uploaded to smartui using either build id or build name. **Note:** When both `buildId` and `buildName` are provided in the request, `buildId` will be given priority over `buildName`.\n",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "projectToken",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "To validate the project in which you want to map your uploaded screenshots"
+                },
+                {
+                  "name": "buildId",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "You can pass the id of speicifc build if you need to map multiple screenshots of different tests to one build. (Optional)"
+                },
+                {
+                  "name": "buildName",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "You can pass the name of specific build if you need to map multiple screenshots of different tests to one build. (Optional)"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": {
+                      "Screenshots": [
+                        {
+                          "screenshotId": "3137e779-e00a-4d88-8cbe-9ff2eb8cceaf",
+                          "mismatchPercentage": 12.65,
+                          "threshold": 1200,
+                          "status": "Under Screening"
+                        }
+                      ],
+                      "buildId": "50af60e1-8709-40b1-981f-19636de5a590",
+                      "buildName": "0e1915b",
+                      "projectName": "FPS-Monterey",
+                      "buildStatus": "1 Under Review"
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Either Screenshot don't exist or bad input",
+                  "example": {
+                    "data": {
+                      "Screenshots": "null",
+                      "buildId": "f3e9bf89-4b61-4eb2-ad60-aaa72150d05e",
+                      "buildName": "build-1",
+                      "projectName": "demo-project"
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Fetch Build Screenshots",
+          "endpoints": [
+            {
+              "name": "Fetch SmartUI build screenshots by project_id and build_id",
+              "method": "GET",
+              "path": "/build/screenshots",
+              "description": "This API fetches all screenshots of a particular build with comparison details. **Note:** When both `build_id` and `build_name` are provided in the request, `buildId` will be given priority over `buildName`.\n",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "project_name",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "The name of the particular project (project id can also be used)"
+                },
+                {
+                  "name": "project_id",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Unique identifier of the project (project name can also be used)"
+                },
+                {
+                  "name": "build_name",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Build name can also be used instead of build Id (Optional)"
+                },
+                {
+                  "name": "build_id",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Fetches all the screenshots of a particular build"
+                },
+                {
+                  "name": "baseline",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": "Fetches the screenshots of the baseline build of the project"
+                },
+                {
+                  "name": "screenshot_name",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Fetches details of a specific screenshot"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "screenshots": [
+                      {
+                        "screenshot_name": "first",
+                        "captured_image": "URL",
+                        "baseline_image": "URL",
+                        "compared_image": "URL",
+                        "browser_name": "chrome",
+                        "browser_version": "118.0",
+                        "viewport": "1920x1080",
+                        "os": "default",
+                        "mismatch_percentage": 0.1,
+                        "status": "Approved",
+                        "approved_by": "dummy",
+                        "captured_image_timestamp": "2023-11-10 13:47:24",
+                        "compared_image_timestamp": "2023-11-10 13:47:29"
+                      }
+                    ],
+                    "build": {
+                      "build_id": "c74f72b5-2dd9-42a4-9478-cd8174a56152",
+                      "name": "build-1",
+                      "baseline": false,
+                      "build_status": "Approved"
+                    },
+                    "project": {
+                      "project_id": "ed2ee7bc-d90d-4719-91a7-19636de5a590",
+                      "name": "web-project",
+                      "username": "dummy"
+                    }
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Either Screenshot don't exist or bad input specified",
+                  "example": {
+                    "error": "smartui project not found for specified input"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "screenshots",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "build",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "project",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Cypress Automation",
+      "baseUrl": "https://api.lambdatest.com/automation/api/v1/cypress",
+      "servers": [
+        {
+          "url": "https://api.lambdatest.com/automation/api/v1/cypress"
+        },
+        {
+          "url": "https://eu-api.lambdatest.com/automation/api/v1/cypress"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Cypress",
+          "endpoints": [
+            {
+              "name": "Zipped report for a cypress test",
+              "method": "GET",
+              "path": "/report/{test_id}",
+              "description": "To fetch zipped report for a cypress test.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get cypress report based on test id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": null,
+                  "type": null
+                },
+                "400": {
+                  "description": "test id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Command logs of a cypress test id",
+              "method": "GET",
+              "path": "/log/{test_id}/command",
+              "description": "To fetch all the executed commands of a cypress test id in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Test ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": {
+                      "spec": "examples/actions.spec.js",
+                      "suites": [
+                        {
+                          "tests": [
+                            {
+                              "code": "https://on.cypress.io/cy.get...",
+                              "context": null,
+                              "duration": 1782,
+                              "err": {},
+                              "fail": true,
+                              "fullTitle": "Actions .blur() - blur off a DOM element.",
+                              "isHook": false,
+                              "parentUUID": "ff9d286c-2d74-4241-8554-b5fe32a4d7e2",
+                              "pass": true,
+                              "pending": true,
+                              "skipped": true,
+                              "speed": "medium",
+                              "state": "passed",
+                              "timedOut": null,
+                              "title": "blur off a DOM element",
+                              "uuid": "0bbd4e33-d38c-44ac-acd0-702142c10594"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "message": "Retrieve logs list was successful",
+                    "status": "success"
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Logs not found",
+                  "example": {
+                    "message": "No logs are currently available. Logs may not have been generated yet or may have expired.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Console log of a cypress test id",
+              "method": "GET",
+              "path": "/log/{test_id}/console",
+              "description": "To fetch cypress console log that contains console errors thrown by application during a test session in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Test ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": "{...}",
+                    "message": "Retrieve logs list was successful",
+                    "status": "success"
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Logs not found",
+                  "example": {
+                    "message": "No logs are currently available. Logs may not have been generated yet or may have expired.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Network log of a Cypress test id",
+              "method": "GET",
+              "path": "/log/{test_id}/network",
+              "description": "To fetch Network log that contains all the requested urls of a Cypress test id in plain json text.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get logs based on test id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "data": [
+                      {
+                        "Value": {
+                          "_id": "e2ac17b1f2ef625a",
+                          "cache": {},
+                          "request": {},
+                          "response": {},
+                          "startedDateTime": "2022-04-04T13:47:40.853493Z",
+                          "time": 0,
+                          "timings": {}
+                        },
+                        "logType": "network",
+                        "order": 5,
+                        "testID": "5TSTJ-LIPQM-VDVJH-CT129"
+                      }
+                    ],
+                    "message": "Retrieve logs list was successful",
+                    "status": "success"
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                },
+                "404": {
+                  "description": "Logs not found",
+                  "example": {
+                    "message": "No logs are currently available. Logs may not have been generated yet or may have expired.",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Enhanced Mochawesome JSON Report",
+              "method": "GET",
+              "path": "/mochawesome/enhanced/{test_id}",
+              "description": "To fetch mochawesome json report for a test with additional key(video url, screenshot url).",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "get mochawesome json report for a test id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "successful operation",
+                  "example": {
+                    "stats": "{...}",
+                    "results": "[{...}, {...}]",
+                    "meta": "{...}"
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "session id not found",
+                  "example": {
+                    "message": "Either resource not found or already deleted",
+                    "status": "fail"
+                  },
+                  "type": "object"
+                },
+                "401": {
+                  "description": "Access denied. Auth error.",
+                  "example": "HTTP Basic: Access denied.",
+                  "type": "string"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "stats",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "results",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "meta",
+                  "type": "string",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "User Management",
+      "baseUrl": "https://auth.lambdatest.com/",
+      "servers": [
+        {
+          "url": "https://auth.lambdatest.com/"
+        },
+        {
+          "url": "https://eu-auth.lambdatest.com/"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Users",
+          "endpoints": [
+            {
+              "name": "Get All users",
+              "method": "GET",
+              "path": "/api/organization/users",
+              "description": "Get All users",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Get All users",
+                  "example": {
+                    "data": [
+                      {
+                        "email": "pawan17@lambdatest.com",
+                        "group": {
+                          "id": 814,
+                          "name": "g2"
+                        },
+                        "id": 407868,
+                        "name": "pawan rai",
+                        "role": "Admin"
+                      },
+                      {
+                        "email": "kliosbuhek@qiott.com",
+                        "group": {
+                          "id": 817,
+                          "name": "g7"
+                        },
+                        "id": 407869,
+                        "name": "Pawan",
+                        "role": "Admin"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Get All users Error",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Edit details by admin",
+              "method": "POST",
+              "path": "/api/organization/user",
+              "description": "Edit details by admin",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "Edit details by admin",
+                "properties": [
+                  {
+                    "name": "group_id",
+                    "type": "number",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "user_id",
+                    "type": "number",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "group_id": 421,
+                  "name": "Pawan",
+                  "user_id": 407869
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Edit name by admin Success",
+                  "example": {
+                    "message": "User profile updated successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Wrong id",
+                  "example": {
+                    "message": "Please, contact administration as you don't have right privileges to permform this action",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Update User Role by admin",
+              "method": "PATCH",
+              "path": "/api/organization/user/{user_id}",
+              "description": "Update User Role by admin",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "user id of member"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "role",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "role": "Admin"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Update User Role",
+                  "example": {
+                    "message": "Organization role updated Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Update User Role with invalid email",
+                  "example": {
+                    "message": "Sorry, Requested Role is not valid",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete members",
+              "method": "DELETE",
+              "path": "/api/organization/user/{user_id}",
+              "description": "Delete members",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "user id of member"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "User deleted Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Delete Member from other Org Error",
+                  "example": {
+                    "message": "Please, contact administration as you don't have right privileges to permform this action",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "User Password by admin",
+              "method": "PATCH",
+              "path": "/api/organization/users/{user_id}/password",
+              "description": "User Password by admin",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "user id of member"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "confirm_password",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "new_password",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "confirm_password": "password1",
+                  "new_password": "password1"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "User Password by admin Success",
+                  "example": {
+                    "message": "Password changed successfully, for user - Pawan",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "User Password by admin",
+                  "example": {
+                    "message": {
+                      "password": "Please do not use last used passwords"
+                    },
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Get all member and invited users",
+              "method": "GET",
+              "path": "/api/organization/users-list",
+              "description": "Get all member and invited users",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Get all member and invited users Success",
+                  "example": {
+                    "data": [
+                      {
+                        "Email": "kliosbuhek@qiott.com",
+                        "Group": "g7",
+                        "InvitedAt": "2022-12-30T17:00:51Z",
+                        "InvitedBy": "pawan rai",
+                        "LastLoginAt": "2022-12-30T17:01:20Z",
+                        "Name": "Pawan",
+                        "Role": "Admin",
+                        "Status": "Active"
+                      },
+                      {
+                        "Email": "pawan17@lambdatest.com",
+                        "Group": "g2",
+                        "InvitedAt": null,
+                        "InvitedBy": null,
+                        "LastLoginAt": "2022-12-30T16:57:59Z",
+                        "Name": "pawan rai",
+                        "Role": "Admin",
+                        "Status": "Internal"
+                      },
+                      {
+                        "Email": "pawan12@qiott.com",
+                        "Group": null,
+                        "InvitedAt": "2022-12-30T17:02:46Z",
+                        "InvitedBy": "pawan rai",
+                        "LastLoginAt": null,
+                        "Name": null,
+                        "Role": "User",
+                        "Status": "Pending"
+                      },
+                      {
+                        "Email": "1secaml@qiott.com",
+                        "Group": null,
+                        "InvitedAt": "2022-12-30T17:02:46Z",
+                        "InvitedBy": "pawan rai",
+                        "LastLoginAt": null,
+                        "Name": null,
+                        "Role": "Admin",
+                        "Status": "Pending"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Get all member and invited users Failure",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Service Account",
+          "endpoints": [
+            {
+              "name": "Get All Service Accounts",
+              "method": "GET",
+              "path": "/api/organization/service-accounts",
+              "description": "Get All Service Accounts",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Get All Service Accounts Success",
+                  "example": {
+                    "data": [
+                      {
+                        "group": {
+                          "id": 814,
+                          "name": "g2"
+                        },
+                        "id": 407938,
+                        "name": "pawan Groupupdated",
+                        "created_at": "2023-02-15T13:06:55.000Z"
+                      },
+                      {
+                        "group": {
+                          "id": 814,
+                          "name": "g2"
+                        },
+                        "id": 407939,
+                        "name": "pawan rai",
+                        "created_at": "2023-02-15T13:06:55.000Z"
+                      },
+                      {
+                        "group": {
+                          "id": 814,
+                          "name": "g2"
+                        },
+                        "id": 407943,
+                        "name": "pawan rai",
+                        "created_at": "2023-02-15T13:06:55.000Z"
+                      },
+                      {
+                        "group": {
+                          "id": 814,
+                          "name": "g2"
+                        },
+                        "id": 412429,
+                        "name": "pawan rai",
+                        "created_at": "2023-02-15T13:06:55.000Z"
+                      },
+                      {
+                        "group": {
+                          "id": 809,
+                          "name": "g6"
+                        },
+                        "id": 412430,
+                        "name": "pawan rai",
+                        "created_at": "2023-02-15T13:06:55.000Z"
+                      },
+                      {
+                        "group": {
+                          "id": 815,
+                          "name": "g5"
+                        },
+                        "id": 412431,
+                        "name": "pawan rai",
+                        "created_at": "2023-02-15T13:06:55.000Z"
+                      },
+                      {
+                        "group": null,
+                        "id": 412432,
+                        "name": "pawan rai",
+                        "created_at": "2023-02-15T13:06:55.000Z"
+                      },
+                      {
+                        "group": {
+                          "id": 814,
+                          "name": "g2"
+                        },
+                        "id": 412433,
+                        "name": "pawan rai",
+                        "created_at": "2023-02-15T13:06:55.000Z"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Get All Service Accounts Failure",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Create Service Account",
+              "method": "POST",
+              "path": "/api/organization/service-accounts",
+              "description": "Create Service Account",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "group_id",
+                    "type": "number",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "group_id": 814,
+                  "name": "pawan rai"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Create Service Accounts Success",
+                  "example": {
+                    "group": {
+                      "id": 814,
+                      "name": "g2"
+                    },
+                    "message": "Service Account Created SuccessFully",
+                    "name": "pawan rai",
+                    "type": "success",
+                    "id": 515639
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Create Service Accounts Failure",
+                  "example": {
+                    "message": "Something went wrong! Group not found",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "group",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "id",
+                  "type": "number",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Update Service Account",
+              "method": "PUT",
+              "path": "/api/organization/service-accounts/{id}",
+              "description": "Update Service Account",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "ID of Service Account"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "name": "pawan rai"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Update Service Accounts Success",
+                  "example": {
+                    "message": "Service Account updated successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Update Service Accounts Failure",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete service account",
+              "method": "DELETE",
+              "path": "/api/organization/service-accounts/{id}",
+              "description": "Delete service account",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "ID of Service Account"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Delete service accounts",
+                  "example": {
+                    "message": "Service Account Deleted SuccessFully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Delete service accounts with invalid user id",
+                  "example": {
+                    "message": "Sorry! User not found or invalid",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Invites Users",
+          "endpoints": [
+            {
+              "name": "Invite user with Group",
+              "method": "POST",
+              "path": "/api/organization/invites/users",
+              "description": "Invite user with Group",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [],
+                "example": [
+                  {
+                    "email": "xyz2@lambdatest.com",
+                    "group_id": 803,
+                    "role": "User"
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Invite user with Group",
+                  "example": {
+                    "message": "Invite Sent Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Get invited users",
+              "method": "GET",
+              "path": "/api/organization/invites",
+              "description": "Get invited users",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Get invited users",
+                  "example": {
+                    "data": [
+                      {
+                        "accepted_at": "2022-12-30T17:01:19Z",
+                        "group": null,
+                        "id": 9131,
+                        "recipient_email": "kliosbuhek@qiott.com",
+                        "role": "User",
+                        "sender": {
+                          "email": "pawan17@lambdatest.com",
+                          "id": 407868,
+                          "name": "pawan rai"
+                        },
+                        "sent_at": "2022-12-30T17:00:51Z",
+                        "status": "Accepted"
+                      },
+                      {
+                        "group": null,
+                        "id": 9132,
+                        "recipient_email": "pawan12@qiott.com",
+                        "role": "User",
+                        "sender": {
+                          "email": "pawan17@lambdatest.com",
+                          "id": 407868,
+                          "name": "pawan rai"
+                        },
+                        "sent_at": "2022-12-30T17:02:46Z",
+                        "status": "Withdrawn"
+                      },
+                      {
+                        "group": null,
+                        "id": 9133,
+                        "recipient_email": "1secaml@qiott.com",
+                        "role": "Admin",
+                        "sender": {
+                          "email": "pawan17@lambdatest.com",
+                          "id": 407868,
+                          "name": "pawan rai"
+                        },
+                        "sent_at": "2022-12-30T17:02:46Z",
+                        "status": "Pending"
+                      },
+                      {
+                        "group": null,
+                        "id": 9134,
+                        "recipient_email": "xyz2@lambdatest.com",
+                        "role": "User",
+                        "sender": {
+                          "email": "pawan17@lambdatest.com",
+                          "id": 407868,
+                          "name": "pawan rai"
+                        },
+                        "sent_at": "2022-12-30T17:47:55Z",
+                        "status": "Withdrawn"
+                      },
+                      {
+                        "group": null,
+                        "id": 9144,
+                        "recipient_email": "pawan12@qiott.com",
+                        "role": "User",
+                        "sender": {
+                          "email": "pawan17@lambdatest.com",
+                          "id": 407868,
+                          "name": "pawan rai"
+                        },
+                        "sent_at": "2023-01-02T08:04:03Z",
+                        "status": "Pending"
+                      },
+                      {
+                        "group": null,
+                        "id": 9145,
+                        "recipient_email": "1secaml@qiott.com",
+                        "role": "Admin",
+                        "sender": {
+                          "email": "pawan17@lambdatest.com",
+                          "id": 407868,
+                          "name": "pawan rai"
+                        },
+                        "sent_at": "2023-01-02T08:04:03Z",
+                        "status": "Withdrawn"
+                      },
+                      {
+                        "group": null,
+                        "id": 9146,
+                        "recipient_email": "xyz2@lambdatest.com",
+                        "role": "User",
+                        "sender": {
+                          "email": "pawan17@lambdatest.com",
+                          "id": 407868,
+                          "name": "pawan rai"
+                        },
+                        "sent_at": "2023-01-02T08:07:24Z",
+                        "status": "Withdrawn"
+                      },
+                      {
+                        "group": {
+                          "id": 814,
+                          "name": "g2"
+                        },
+                        "id": 9147,
+                        "recipient_email": "xyz2@lambdatest.com",
+                        "role": "User",
+                        "sender": {
+                          "email": "pawan17@lambdatest.com",
+                          "id": 407868,
+                          "name": "pawan rai"
+                        },
+                        "sent_at": "2023-01-02T08:08:45Z",
+                        "status": "Pending"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Get invited users without auth",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Resend Invite",
+              "method": "PUT",
+              "path": "/api/organization/invite/{invite_id}",
+              "description": "Resend Invite",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "invite_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Invitation ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Resend Invite Success",
+                  "example": {
+                    "message": "Resent Invitiation Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Resend Invite Failure",
+                  "example": {
+                    "message": "Sorry, Invalid invite",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete invite user",
+              "method": "DELETE",
+              "path": "/api/organization/invite/{invite_id}",
+              "description": "Delete invite user",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "invite_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Invitation ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Delete invite user Success",
+                  "example": {
+                    "message": "Invite user deleted Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Delete invite user for withdrawn user",
+                  "example": {
+                    "message": "Please, contact administration as you don't have right privileges to permform this action",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Token",
+          "endpoints": [
+            {
+              "name": "Generate Service Account token",
+              "method": "POST",
+              "path": "/api/organization/service-accounts/{id}/token",
+              "description": "Generate Service Account token",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Service Account ID"
+                }
+              ],
+              "requestBody": null,
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Access Token generated successfully",
+                    "token": {
+                      "id": 421827,
+                      "token": "bmrt4HX52bTcOHniFl3HAA9G4ehQHnLqUkGmLPRVxfef4iIBVZ",
+                      "user_id": 407938,
+                      "username": "4152033k0HaL6tuC"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Failure",
+                  "example": {
+                    "message": "Unauthenticated.",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch Service Account Token",
+              "method": "GET",
+              "path": "/api/organization/service-accounts/{id}/token",
+              "description": "Fetch Service Account Token",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Service Account ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Access Token retrieved successfully",
+                    "token": {
+                      "id": 426314,
+                      "token": "EwnnWltfbiauIWQcGp5R6WlgIZgiP0FIuNszYIM8qP4NSuwveC",
+                      "user_id": 407939,
+                      "username": "415203LOjvQIAizR"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Fetch Service Account Token other org user_id",
+                  "example": {
+                    "message": "Please, contact administration as you don't have right privileges to permform this action",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Fetch Service Account Token wrong user id",
+                  "example": {
+                    "message": "Sorry! User not found or invalid",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Regen token by admin",
+              "method": "POST",
+              "path": "/api/organization/users/{user_id}/token",
+              "description": "Regen token by admin",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "User ID"
+                }
+              ],
+              "requestBody": null,
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Access Token generated successfully",
+                    "token": {
+                      "id": 426313,
+                      "token": "iodiOqGDsjE27MfFROUa0OZzCpJnGDmHmKiHwrogtbuEDOLqIt",
+                      "user_id": 407939,
+                      "username": "415203LOjvQIAizR"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Regen token by admin other org user id",
+                  "example": {
+                    "message": "Please, contact administration as you don't have right privileges to permform this action",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch user token by admin",
+              "method": "GET",
+              "path": "/api/organization/users/{user_id}/token",
+              "description": "Fetch user token by admin",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "User ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Access Token retrieved successfully",
+                    "token": {
+                      "id": 426312,
+                      "token": "6KVBcEhO9iMdGXnZbxh8Ki19tNEX8GPpYjGPP5ivKHfKMUkF9s",
+                      "user_id": 407868,
+                      "username": "pawan17"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Users",
+                  "example": {
+                    "message": "Sorry! User not found or invalid",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "User Profile",
+          "endpoints": [
+            {
+              "name": "User Password",
+              "method": "PATCH",
+              "path": "/api/user/password",
+              "description": "User Password",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "new_password",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "password",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "new_password": "password3",
+                  "password": "password"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "User Password Success",
+                  "example": {
+                    "message": "Password changed successfully, Please login again!",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "User Password Failure",
+                  "example": {
+                    "message": "Please do not use last used passwords",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch token by users",
+              "method": "GET",
+              "path": "/api/user/token",
+              "description": "Fetch token by users",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Access Token retrieved successfully",
+                    "token": {
+                      "id": 426312,
+                      "token": "6KVBcEhO9iMdGXnZbxh8Ki19tNEX8GPpYjGPP5ivKHfKMUkF9s",
+                      "user_id": 407868,
+                      "username": "pawan17"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Fetch token by users Failure",
+                  "example": {
+                    "message": "Unauthenticated.",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Generate token by user",
+              "method": "POST",
+              "path": "/api/users/token",
+              "description": "Generate token by user",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": null,
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Access Token generated successfully",
+                    "token": {
+                      "id": 421758,
+                      "token": "moZ9TJNna0e5CJ744Ab0e7SBIhXRywG5DiaZzmd9atYQk6WNBv",
+                      "user_id": 407868,
+                      "username": "pawan17"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Failure",
+                  "example": {
+                    "message": "Unauthenticated.",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Edit name by User",
+              "method": "POST",
+              "path": "/api/user",
+              "description": "Edit name by User",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "name": "pawan rai"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Edit name User success",
+                  "example": {
+                    "message": "User profile updated successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Edit name User Fail",
+                  "example": {
+                    "message": "Sorry, Body payload should not be empty",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Edit name User Failure",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Getting User Preference",
+              "method": "GET",
+              "path": "/api/user/preference",
+              "description": "Getting User Preference",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": [
+                    {
+                      "description": "Describe email type here so that it becomes easy for user to understand",
+                      "label": "automation",
+                      "name": "Automation Daily",
+                      "value": 0
+                    },
+                    {
+                      "description": "Describe email type here so that it becomes easy for user to understand",
+                      "label": "marketing",
+                      "name": "offers and deals",
+                      "value": 0
+                    },
+                    {
+                      "description": "Describe email type here so that it becomes easy for user to understand",
+                      "label": "newsletter",
+                      "name": "Newsletters",
+                      "value": 0
+                    },
+                    {
+                      "description": "Get notified when we release something new",
+                      "label": "product",
+                      "name": "Product Updates",
+                      "value": 1
+                    },
+                    {
+                      "description": "Describe email type here so that it becomes easy for user to understand",
+                      "label": "weekly",
+                      "name": "Weekly Reports",
+                      "value": 1
+                    }
+                  ],
+                  "type": null
+                },
+                "401": {
+                  "description": "Failure",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Updating user preference",
+              "method": "PATCH",
+              "path": "/api/user/preference/{product}",
+              "description": "Updating user preference",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "product",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Product name"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Preference is Updated successfully.",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Failure",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Support Access",
+          "endpoints": [
+            {
+              "name": "Get Support Access history",
+              "method": "GET",
+              "path": "/api/organization/support-access",
+              "description": "Get Support Access history",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "access_granted": 1,
+                    "history": [
+                      {
+                        "access_granted_at": "2023-01-19T19:42:54Z",
+                        "access_granted_by": "",
+                        "access_revoked_at": "2023-01-19T19:43:20Z",
+                        "access_revoked_by": "pawan rai",
+                        "status": "Revoked",
+                        "updated_at": "2023-01-19T19:42:54Z"
+                      },
+                      {
+                        "access_granted_at": "2023-01-19T19:43:28Z",
+                        "access_granted_by": "",
+                        "access_revoked_at": "0001-01-01T00:00:00Z",
+                        "access_revoked_by": "pawan rai",
+                        "status": "Active",
+                        "updated_at": "2023-01-19T19:43:28Z"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Failure",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "access_granted",
+                  "type": "number",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "history",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Grant Support Access",
+              "method": "PUT",
+              "path": "/api/organization/support-access/grant",
+              "description": "Grant Support Access",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Support Access Granted Successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Failure",
+                  "example": {
+                    "message": "Support Access already active for organization",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Revoke Support Access",
+              "method": "PUT",
+              "path": "/api/organization/support-access/revoke",
+              "description": "Revoke Support Access",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Support Access Revoked Successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Failure",
+                  "example": {
+                    "message": "Support Access already Revoked for this  organization",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Groups",
+          "endpoints": [
+            {
+              "name": "Create Group",
+              "method": "POST",
+              "path": "/api/v1/organization/group",
+              "description": "Create Group",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "users",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "allocated_concurrency",
+                    "type": "object",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Group created successfully!",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid product ID error",
+                  "example": {
+                    "message": "Sorry! Given Product concurrency are invalid ,",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Make Default Group",
+              "method": "PATCH",
+              "path": "/api/v1/organization/group",
+              "description": "Make Default Group",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "group_id",
+                    "type": "number",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "group_id": 1010
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Default Group Updated Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Group ID error",
+                  "example": {
+                    "message": "Error while updating org group for users",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Get all Groups",
+              "method": "GET",
+              "path": "/api/v1/organization/groups",
+              "description": "Get all Groups",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "data": {
+                      "available_concurrency": [
+                        {
+                          "key": "prod_KUHcM296xEk2Cy",
+                          "product_name": "Manual Testing - Live",
+                          "value": 3
+                        }
+                      ],
+                      "groups": [
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "Manual Testing - Live",
+                              "value": 3
+                            }
+                          ],
+                          "id": 1011,
+                          "is_default_group": 1,
+                          "name": "G1",
+                          "service_accounts": 3,
+                          "total_users": 4
+                        }
+                      ]
+                    }
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Get All Groups Failure",
+                  "example": {
+                    "message": "Sorry! Authentication token is missing or invalid",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Update multiple Group",
+              "method": "PUT",
+              "path": "/api/v1/organization/groups",
+              "description": "Update multiple Group",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "groups",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "groups": [
+                    {
+                      "allocated_concurrency": {
+                        "prod_KUHcM296xEk2Cy": 4
+                      },
+                      "id": 1011
+                    }
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Group updated successfully!",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Product ID'",
+                  "example": {
+                    "message": "Sorry! Given Product concurrency are invalid ,,",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Get Groups By ID",
+              "method": "GET",
+              "path": "/api/v1/organization/group/{group_id}",
+              "description": "Get Groups By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "group_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Group ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "allocated_concurrency": [
+                      {
+                        "key": "prod_KUHcM296xEk2Cy",
+                        "product_name": "Manual Testing - Live",
+                        "value": 3
+                      }
+                    ],
+                    "id": 1011,
+                    "is_default_group": 1,
+                    "name": "G1",
+                    "service_accounts": 3,
+                    "total_users": 4,
+                    "users": [
+                      {
+                        "id": 418070,
+                        "username": "pawan rai"
+                      },
+                      {
+                        "id": 418073,
+                        "username": "pawan Admin"
+                      },
+                      {
+                        "id": 439456,
+                        "username": "pawan rai"
+                      },
+                      {
+                        "id": 462258,
+                        "username": "pawan rai"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Group ID error",
+                  "example": {
+                    "message": "Requested group Id 1012 doesn't belongs to the given organization",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "allocated_concurrency",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "id",
+                  "type": "number",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "is_default_group",
+                  "type": "number",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "service_accounts",
+                  "type": "number",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "total_users",
+                  "type": "number",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "users",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Update Group By ID",
+              "method": "PUT",
+              "path": "/api/v1/organization/group/{group_id}",
+              "description": "Update Group By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "group_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Group ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "users",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "allocated_concurrency",
+                    "type": "object",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Group updated successfully!",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Product ID",
+                  "example": {
+                    "message": "Sorry! Given Product concurrency are invalid ,,",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete Group",
+              "method": "DELETE",
+              "path": "/api/v1/organization/group/{group_id}",
+              "description": "Delete Group",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "group_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Group ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "message": "Group deleted successfully!",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Group Error",
+                  "example": {
+                    "message": "Requested group Id 1012 doesn't belongs to the given organization",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Sub Organization - CRUD",
+          "endpoints": [
+            {
+              "name": "Get Sub Organizations",
+              "method": "GET",
+              "path": "/api/organization/sub-org",
+              "description": "Get Sub Organizations",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "expand",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": "Expand sub-organization details"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Get Sub Orgs",
+                  "example": {
+                    "data": {
+                      "root_org": {
+                        "available_concurrency": [
+                          {
+                            "key": "prod_KUHcM296xEk2Cy",
+                            "product_name": "Manual Testing - Live",
+                            "value": 0
+                          },
+                          {
+                            "key": "prod_KVAmU3gGH3RkiD",
+                            "product_name": "Manual Testing - Real Devices",
+                            "value": 3
+                          },
+                          {
+                            "key": "prod_KUHg1I1YdCPH3Z",
+                            "product_name": "Web Automation on Desktop",
+                            "value": 3
+                          },
+                          {
+                            "key": "prod_KVAoeaYoNyEjfn_linux",
+                            "product_name": "HyperExecute Cloud (Linux Only)",
+                            "value": 9
+                          },
+                          {
+                            "key": "prod_KVAntn3WDiTl2j",
+                            "product_name": "Native App Automation (Trial)",
+                            "value": 7
+                          }
+                        ],
+                        "created_at": "2022-12-02T14:17:28Z",
+                        "name": "100",
+                        "org_id": 166750
+                      },
+                      "sub_orgs": [
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_KVAoeaYoNyEjfn_linux",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KVAntn3WDiTl2j",
+                              "product_name": "",
+                              "value": 3
+                            },
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "Manual Testing - Live",
+                              "value": 1
+                            }
+                          ],
+                          "created_at": "2023-01-25T18:49:29Z",
+                          "name": "SubOrg 1",
+                          "org_id": 166849,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_NFR_nonrec",
+                              "product_name": "",
+                              "value": 2
+                            }
+                          ],
+                          "created_at": "2023-01-25T18:56:33Z",
+                          "name": "SubOrg 1",
+                          "org_id": 166850,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_NFR_nonrec",
+                              "product_name": "",
+                              "value": 2
+                            }
+                          ],
+                          "created_at": "2023-01-25T19:17:39Z",
+                          "name": "SubOrg 2",
+                          "org_id": 166851,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_NFR_nonrec",
+                              "product_name": "",
+                              "value": 2
+                            },
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KVAmU3gGH3RkiD",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KUHg1I1YdCPH3Z",
+                              "product_name": "",
+                              "value": 1
+                            }
+                          ],
+                          "created_at": "2023-01-27T16:00:32Z",
+                          "name": "SubOrg 2",
+                          "org_id": 166852,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_KVAmU3gGH3RkiD",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KUHg1I1YdCPH3Z",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_NFR_nonrec",
+                              "product_name": "",
+                              "value": 2
+                            },
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "",
+                              "value": 1
+                            }
+                          ],
+                          "created_at": "2023-01-27T16:03:34Z",
+                          "name": "SubOrg 2",
+                          "org_id": 166853,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KVAmU3gGH3RkiD",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KUHg1I1YdCPH3Z",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_NFR_nonrec",
+                              "product_name": "",
+                              "value": 2
+                            }
+                          ],
+                          "created_at": "2023-01-27T16:06:14Z",
+                          "name": "SubOrg 2",
+                          "org_id": 166854,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KVAmU3gGH3RkiD",
+                              "product_name": "",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KUHg1I1YdCPH3Z",
+                              "product_name": "",
+                              "value": 1
+                            }
+                          ],
+                          "created_at": "2023-01-27T16:09:54Z",
+                          "name": "SubOrg 2",
+                          "org_id": 166855,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "Manual Testing - Live",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KVAmU3gGH3RkiD",
+                              "product_name": "Manual Testing - Real Devices",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KUHg1I1YdCPH3Z",
+                              "product_name": "Web Automation on Desktop",
+                              "value": 1
+                            }
+                          ],
+                          "created_at": "2023-01-27T16:11:12Z",
+                          "name": "SubOrg 2",
+                          "org_id": 166856,
+                          "service_account_count": 1,
+                          "service_accounts": [
+                            {
+                              "id": 78101,
+                              "name": "rishab service",
+                              "role": "Guest",
+                              "status": "Active"
+                            }
+                          ],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "Manual Testing - Live",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KVAmU3gGH3RkiD",
+                              "product_name": "Manual Testing - Real Devices",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KUHg1I1YdCPH3Z",
+                              "product_name": "Web Automation on Desktop",
+                              "value": 1
+                            }
+                          ],
+                          "created_at": "2023-01-30T11:00:05Z",
+                          "name": "SubOrg 2",
+                          "org_id": 166857,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "Manual Testing - Live",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KVAmU3gGH3RkiD",
+                              "product_name": "Manual Testing - Real Devices",
+                              "value": 1
+                            },
+                            {
+                              "key": "prod_KUHg1I1YdCPH3Z",
+                              "product_name": "Web Automation on Desktop",
+                              "value": 1
+                            }
+                          ],
+                          "created_at": "2023-01-30T11:00:10Z",
+                          "name": "SubOrg 2",
+                          "org_id": 166858,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        },
+                        {
+                          "allocated_concurrency": [
+                            {
+                              "key": "prod_KUHcM296xEk2Cy",
+                              "product_name": "Manual Testing - Live",
+                              "value": 2
+                            }
+                          ],
+                          "created_at": "2023-01-30T11:00:36Z",
+                          "name": "SubOrg 1",
+                          "org_id": 166859,
+                          "service_account_count": 0,
+                          "service_accounts": [],
+                          "user_count": 0,
+                          "users": []
+                        }
+                      ]
+                    }
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Create Sub Organization",
+              "method": "POST",
+              "path": "/api/organization/sub-org",
+              "description": "Create Sub Organization",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "allocated_concurrency",
+                    "type": "object",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "allocated_concurrency": {
+                    "prod_KUHcM296xEk2Cy": 1,
+                    "prod_KUHg1I1YdCPH3Z": 1,
+                    "prod_KVAmU3gGH3RkiD": 1,
+                    "prod_KVAntn3WDiTl2j": 0,
+                    "prod_KVAoeaYoNyEjfn_linux": 0,
+                    "prod_NFR_nonrec": 0
+                  },
+                  "name": "SubOrg 2"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Create Sub Org",
+                  "example": {
+                    "message": "Created Sub-Organisation Successfully",
+                    "type": "success",
+                    "sub_org_id": 45005
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Invalid Concurrency",
+                  "example": {
+                    "message": "Invalid Concurrency Valur for Key - prod_KUHcM296xEk2Cy",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Bulk Update Sub Org",
+              "method": "PUT",
+              "path": "/api/organization/sub-org",
+              "description": "Bulk Update Sub Org",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "sub_orgs",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "sub_orgs": [
+                    {
+                      "allocated_concurrency": {
+                        "prod_NFR": 3
+                      },
+                      "id": 1000000011,
+                      "name": "Suborg 1 update m1"
+                    },
+                    {
+                      "allocated_concurrency": {
+                        "prod_NFR": 4
+                      },
+                      "id": 1000000010,
+                      "name": "Suborg 2 update m2"
+                    }
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Bulk Update Sub Org",
+                  "example": {
+                    "message": "Updated Sub-Organisation Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Logged In User Does Not Belong To Sub Org",
+                  "example": {
+                    "message": "Logged in user does not belong to a Sub-Organisation",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Concurrency",
+                  "example": {
+                    "message": "Provided Concurrency Invalid for Not For Resale (NFR)",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Update Sub Organization By ID",
+              "method": "PUT",
+              "path": "/api/organization/sub-org/{sub_org_id}",
+              "description": "Update Sub Organization By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "allocated_concurrency",
+                    "type": "object",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "allocated_concurrency": {
+                    "prod_KUHcM296xEk2Cy": 2,
+                    "prod_KUHg1I1YdCPH3Z": 0,
+                    "prod_KVAmU3gGH3RkiD": 0,
+                    "prod_KVAntn3WDiTl2j": 0,
+                    "prod_KVAoeaYoNyEjfn_linux": 0,
+                    "prod_NFR_nonrec": 0
+                  },
+                  "name": "SubOrg 1"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Update Sub Org",
+                  "example": {
+                    "message": "Updated Sub-Organisation Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Invalid Concurrency",
+                  "example": {
+                    "message": "Invalid Concurrency Value for Key - prod_KUHcM296xEk2Cy",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete Sub Organization By ID",
+              "method": "DELETE",
+              "path": "/api/organization/sub-org/{sub_org_id}",
+              "description": "Delete Sub Organization By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Delete Sub Org By ID",
+                  "example": {
+                    "message": "Deleted Sub-Organisation Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Not Found",
+                  "example": {
+                    "message": "Record not found in our db",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Get Sub Organization By ID",
+              "method": "GET",
+              "path": "/api/organization/sub-org/{sub_org_id}",
+              "description": "Get Sub Organization By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Get Sub Org By ID",
+                  "example": {
+                    "data": {
+                      "allocated_concurrency": [
+                        {
+                          "key": "prod_KUHcM296xEk2Cy",
+                          "product_name": "Manual Testing - Live",
+                          "value": 2
+                        }
+                      ],
+                      "created_at": "2023-01-30T11:00:36Z",
+                      "name": "SubOrg 1",
+                      "org_id": 166859,
+                      "service_account_count": 0,
+                      "service_accounts": [],
+                      "user_count": 0,
+                      "users": []
+                    }
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Wrong Org Details",
+                  "example": {
+                    "message": "Something went wrong! getting organization details db error-%s of given user",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Sub Organization - Invite Users",
+          "endpoints": [
+            {
+              "name": "Invite Users to Sub Organization",
+              "method": "POST",
+              "path": "/api/organization/sub-org/{sub_org_id}/invites/users",
+              "description": "Invite Users to Sub Organization",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [],
+                "example": [
+                  {
+                    "email": "pawan12@qiott.com",
+                    "role": "Admin"
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Invite Users to Sub Org",
+                  "example": {
+                    "message": "Invite Sent Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Role",
+                  "example": {
+                    "message": [
+                      {
+                        "email": "pawan12@qiott.com",
+                        "error": "Invalid role"
+                      }
+                    ],
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Get Pending Invites for Sub Organization",
+              "method": "GET",
+              "path": "/api/organization/sub-org/{sub_org_id}/invites",
+              "description": "Get Pending Invites for Sub Organization",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Get Pending Invites for SubOrg",
+                  "example": {
+                    "data": [
+                      {
+                        "group": null,
+                        "id": 4634,
+                        "recipient_email": "rishabhagrawal@lambdatest.com",
+                        "role": "User",
+                        "sender": {
+                          "email": "abhishekj@lambdatest.com",
+                          "id": 99604,
+                          "name": "backend testing"
+                        },
+                        "sent_at": "2023-01-20T12:44:34Z",
+                        "status": "Pending"
+                      }
+                    ]
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Resend Invite",
+              "method": "PUT",
+              "path": "/api/organization/sub-org/{sub_org_id}/invite/{invite_id}",
+              "description": "Resend Invite",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "invite_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Invitation ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Resend Invite",
+                  "example": {
+                    "message": "Resent Invitiation Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Withdraw Invite",
+              "method": "DELETE",
+              "path": "/api/organization/sub-org/{sub_org_id}/invite/{invite_id}",
+              "description": "Withdraw Invite",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "invite_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Invitation ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Withdraw Invite",
+                  "example": {
+                    "message": "Invite user deleted Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Withdraw Expired Invite",
+                  "example": {
+                    "message": "Please, contact administration as you don't have right privileges to permform this action",
+                    "title": "Unauthorized Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Sub Organization - Token",
+          "endpoints": [
+            {
+              "name": "Get User Token",
+              "method": "GET",
+              "path": "/api/organization/sub-org/{sub_org_id}/users/{user_id}/token",
+              "description": "Get User Token",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Org User ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Get User Token",
+                  "example": {
+                    "message": "Access Token retrieved successfully",
+                    "token": {
+                      "id": 34317,
+                      "token": "gfTFHh60awsoDrWeTY21HmEUQUsi1vef1k8acKWT36mjT1qVkn",
+                      "user_id": 11954,
+                      "username": "rishabha"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Regenerate User Token",
+              "method": "POST",
+              "path": "/api/organization/sub-org/{sub_org_id}/users/{user_id}/token",
+              "description": "Regenerate User Token",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Org User ID"
+                }
+              ],
+              "requestBody": null,
+              "responses": {
+                "200": {
+                  "description": "Regenerate User Token",
+                  "example": {
+                    "message": "Access Token generated successfully",
+                    "token": {
+                      "id": 34329,
+                      "token": "Gk6AP0DuLwPOL6f6comvg4Oxxau7MZW3mQ5wpW9EKjOcOXeCrx",
+                      "user_id": 78101,
+                      "username": "rishabhagrawal"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Sub Organization - User",
+          "endpoints": [
+            {
+              "name": "Update User",
+              "method": "POST",
+              "path": "/api/organization/sub-org/{sub_org_id}/users/{user_id}",
+              "description": "Update User",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Org User ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "role",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "role": "Admin"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Update User SubOrg",
+                  "example": {
+                    "message": "User profile updated successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Role",
+                  "example": {
+                    "errors": {
+                      "team_user_role": [
+                        "Please enter a valid user role"
+                      ]
+                    },
+                    "message": "The given data was invalid.",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete Sub Organization User",
+              "method": "DELETE",
+              "path": "/api/organization/sub-org/{sub_org_id}/users/{user_id}",
+              "description": "Delete Sub Organization User",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Org User ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Delete User SubOrg",
+                  "example": {
+                    "message": "User deleted Successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Update User Password By Admin",
+              "method": "PATCH",
+              "path": "/api/organization/sub-org/{sub_org_id}/users/{user_id}/password",
+              "description": "Update User Password By Admin",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "user_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Org User ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "confirm_password",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "new_password",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "confirm_password": "ppoodeikj2",
+                  "new_password": "ppoodeikj2"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Update User Password By Admin",
+                  "example": {
+                    "message": "Password changed successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Move user to Sub Organization",
+              "method": "POST",
+              "path": "/api/organization/sub-org/{sub_org_id}/move-account",
+              "description": "Move user to Sub Organization",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "Move user to Sub Organization",
+                "properties": [
+                  {
+                    "name": "email",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "email": "testuser@lambdatest.com"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Move user to Sub Organization Success",
+                  "example": {
+                    "type": "success",
+                    "message": "User : testuser@lambdatest.com moved to Sub-Organization ID - 12345            "
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Wrong email",
+                  "example": {
+                    "type": "error",
+                    "title": "Bad Request Error",
+                    "message": "Sorry! User not found or invalid"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Register user to Sub Organization",
+              "method": "POST",
+              "path": "/api/organization/sub-org/{sub_org_id}/users",
+              "description": "Register user to Sub Organization",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "Register user to Sub Organization",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "email",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "password",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "org_role",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "name": "testUser",
+                  "email": "testuser@lambdatest.com",
+                  "password": "helloTest@123",
+                  "org_role": "User"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Register user to Sub Organization Success",
+                  "example": {
+                    "type": "success",
+                    "message": "User for email: testuser@lambdatest.com created"
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Wrong org_role",
+                  "example": {
+                    "type": "error",
+                    "title": "Bad Request Error",
+                    "message": "Sorry, Requested Role is not valid"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Sub Organization - Service Account",
+          "endpoints": [
+            {
+              "name": "Get Service Account Token",
+              "method": "GET",
+              "path": "/api/organization/sub-org/{sub_org_id}/service-accounts/{id}/token",
+              "description": "Get Service Account Token",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Org Service Account ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Get Service Account Token",
+                  "example": {
+                    "message": "Access Token retrieved successfully",
+                    "token": {
+                      "id": 34329,
+                      "token": "Gk6AP0DuLwPOL6f6comvg4Oxxau7MZW3mQ5wpW9EKjOcOXeCrx",
+                      "user_id": 78101,
+                      "username": "rishabhagrawal"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Regenerate Service Account Token",
+              "method": "POST",
+              "path": "/api/organization/sub-org/{sub_org_id}/service-accounts/{id}/token",
+              "description": "Regenerate Service Account Token",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Org Service Account ID"
+                }
+              ],
+              "requestBody": null,
+              "responses": {
+                "200": {
+                  "description": "Regenerate Service Account Token",
+                  "example": {
+                    "message": "Access Token generated successfully",
+                    "token": {
+                      "id": 34330,
+                      "token": "Hu8NsHTDT9gT4e1GQFchGrjZqrnHVqf3XahHnjn2wzNTgMQ0XZ",
+                      "user_id": 78101,
+                      "username": "rishabhagrawal"
+                    },
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "token",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Create Service Account",
+              "method": "POST",
+              "path": "/api/organization/sub-org/{sub_org_id}/service-accounts",
+              "description": "Create Service Account",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "name": "Test Service Account"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Create Service Account",
+                  "example": {
+                    "message": "Service Account Created SuccessFully",
+                    "name": "Test Service Account",
+                    "type": "success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid Org",
+                  "example": {
+                    "message": "Something went wrong! getting organization details db error-%s of given user",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Update Service Account",
+              "method": "PUT",
+              "path": "/api/organization/sub-org/{sub_org_id}/service-accounts/{id}",
+              "description": "Update Service Account",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Org Service Account ID"
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "name": "rishab service 2"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Update Service Account",
+                  "example": {
+                    "message": "Service Account updated successfully",
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete Service Account",
+              "method": "DELETE",
+              "path": "/api/organization/sub-org/{sub_org_id}/service-accounts/{id}",
+              "description": "Delete Service Account",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "sub_org_id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Organization ID"
+                },
+                {
+                  "name": "id",
+                  "type": "integer",
+                  "in": "path",
+                  "required": true,
+                  "description": "Sub Org Service Account ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Delete Service Account",
+                  "example": {
+                    "message": "Service Account Deleted SuccessFully",
+                    "type": "success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Test Manager",
+      "baseUrl": "https://test-manager-api.lambdatest.com/",
+      "servers": [
+        {
+          "url": "https://test-manager-api.lambdatest.com/"
+        },
+        {
+          "url": "https://eu-test-manager-api.lambdatest.com/"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Projects",
+          "endpoints": [
+            {
+              "name": "Create Project",
+              "method": "POST",
+              "path": "/api/v1/projects",
+              "description": "Create a New Project",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": "Name of the project"
+                  },
+                  {
+                    "name": "description",
+                    "type": "string",
+                    "required": false,
+                    "description": "Description of the project"
+                  },
+                  {
+                    "name": "tags",
+                    "type": "array",
+                    "required": false,
+                    "description": "Tags associated with the project"
+                  }
+                ],
+                "example": {
+                  "name": "TestProject-Demo",
+                  "description": "Project for testing project creation",
+                  "tags": [
+                    "tag1",
+                    "tag2",
+                    "tag3"
+                  ],
+                  "source": "KTM"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Project created successfully",
+                    "type": "Success",
+                    "id": "01J5Q6WPACPV0HJNVKMG0S141Z"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Update Project By ID",
+              "method": "PUT",
+              "path": "/api/v1/projects",
+              "description": "Update Project Details By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "project_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "description",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "tags",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "project_id": "project_id",
+                  "name": "Test Project -LambdaTest Demo",
+                  "description": "Updated Test Project Demo Description",
+                  "tags": [
+                    "tag1",
+                    "tag2"
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Project updated successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "type": "error",
+                    "title": "Request Not Processed",
+                    "message": "Invalid project ID"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get All Projects",
+              "method": "GET",
+              "path": "/api/v1/projects",
+              "description": "Get All Projects",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "per_page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "sort",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "data": [
+                      {
+                        "project_id": "01J3PWJPQPGHBNPHBXX4DSME1H",
+                        "name": "Test Project",
+                        "description": "This for testing purpose",
+                        "test_case_count": 0,
+                        "created_by": 2048070,
+                        "updated_by": 2048070,
+                        "created_at": "2024-07-26T06:45:15Z",
+                        "updated_at": "2024-07-26T06:45:15Z",
+                        "tags": [
+                          {
+                            "tag_id": 5979,
+                            "name": "Tag-1"
+                          },
+                          {
+                            "tag_id": 5980,
+                            "name": "Tag-2"
+                          }
+                        ]
+                      }
+                    ],
+                    "columnMetadata": {
+                      "created_at": {
+                        "display_name": "Created At",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": true
+                      },
+                      "created_by": {
+                        "display_name": "Created By",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "deleted_at": {
+                        "display_name": "Deleted At",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": true
+                      },
+                      "description": {
+                        "display_name": "Description",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": true
+                      },
+                      "name": {
+                        "display_name": "Name",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": true
+                      },
+                      "organization_id": {
+                        "display_name": "Organization ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "updated_at": {
+                        "display_name": "Updated At",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "updated_by": {
+                        "display_name": "Updated By",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      }
+                    },
+                    "filterMetadata": {
+                      "created_at": {
+                        "display_name": "Created At",
+                        "scopes": [
+                          "created_at_condition_before",
+                          "created_at_condition_after",
+                          "created_at_condition_on",
+                          "created_at_condition_between"
+                        ],
+                        "type": "time.Time"
+                      },
+                      "created_by": {
+                        "display_name": "Created By",
+                        "type": "int"
+                      },
+                      "name": {
+                        "display_name": "Name",
+                        "type": "string"
+                      },
+                      "organization_id": {
+                        "display_name": "Organization ID",
+                        "type": "int"
+                      },
+                      "updated_by": {
+                        "display_name": "Updated By",
+                        "type": "int"
+                      }
+                    },
+                    "pagination": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 10,
+                      "total": 1
+                    }
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get Project By ID",
+              "method": "GET",
+              "path": "/api/v1/projects/{project_id}",
+              "description": "Get Project Details By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "project_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "data": {
+                      "project_id": "01J3PWJPQPGHBNPHBXX4DSME1H",
+                      "name": "Test Project",
+                      "description": "This for testing purpose",
+                      "test_case_count": 0,
+                      "created_by": 2048070,
+                      "updated_by": 2048070,
+                      "created_at": "2024-07-26T06:45:15Z",
+                      "updated_at": "2024-07-26T06:45:15Z",
+                      "tags": [
+                        {
+                          "tag_id": 5979,
+                          "name": "Tag-1"
+                        },
+                        {
+                          "tag_id": 5980,
+                          "name": "Tag-2"
+                        }
+                      ]
+                    }
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "type": "error",
+                    "title": "Request Not Processed",
+                    "message": "Invalid project ID"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Folder",
+          "endpoints": [
+            {
+              "name": "Create Folder",
+              "method": "POST",
+              "path": "/api/v1/folder",
+              "description": "Create New Folder",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "folders",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "folders": [
+                    {
+                      "name": "Test Folder - Demo",
+                      "description": "Test Folder for creating Folder Demo",
+                      "entity_id": "project_id",
+                      "entity_type": "project",
+                      "parent_id": "parent_id"
+                    }
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Folders created successfully",
+                    "type": "Success",
+                    "id": "01J5Q7Z65YF1TE22255HBRVSW7"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Update Folder By ID",
+              "method": "PUT",
+              "path": "/api/v1/folder",
+              "description": "Update Folder By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "action",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "entity_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "id": "folder_id",
+                  "action": "update",
+                  "entity_id": "project_id",
+                  "name": "Test Folder - LambdaTest Demo"
+                },
+                "variants": [
+                  {
+                    "name": "Rename",
+                    "example": {
+                      "id": "folder_id",
+                      "action": "update",
+                      "entity_id": "project_id",
+                      "name": "Test Folder - LambdaTest Demo"
+                    },
+                    "properties": [
+                      {
+                        "name": "id",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      },
+                      {
+                        "name": "action",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      },
+                      {
+                        "name": "entity_id",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      },
+                      {
+                        "name": "name",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      }
+                    ]
+                  },
+                  {
+                    "name": "Move",
+                    "example": {
+                      "id": "folder_id",
+                      "action": "move",
+                      "entity_id": "project_id",
+                      "entity_type": "project",
+                      "name": "Test Folder - LambdaTest Demo",
+                      "parent_id": "parent_id",
+                      "serial_no": 1
+                    },
+                    "properties": [
+                      {
+                        "name": "id",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      },
+                      {
+                        "name": "action",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      },
+                      {
+                        "name": "entity_id",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      },
+                      {
+                        "name": "entity_type",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      },
+                      {
+                        "name": "name",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      },
+                      {
+                        "name": "parent_id",
+                        "type": "string",
+                        "required": false,
+                        "description": ""
+                      },
+                      {
+                        "name": "serial_no",
+                        "type": "integer",
+                        "required": false,
+                        "description": ""
+                      }
+                    ]
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Folder updated successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "type": "error",
+                    "title": "Request Not Processed",
+                    "message": "Invalid folder ID"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get All folder details By Project ID",
+              "method": "GET",
+              "path": "/api/v1/folder/entity/{entity_id}",
+              "description": "Get All folder details By Project ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "entity_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "entity_id is the project_id"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "data": [
+                      {
+                        "name": "Test Folder",
+                        "description": "Folder for testing purpose",
+                        "id": "01J3Q0DBFF2M74H527NZZAPR9B",
+                        "parent_id": null,
+                        "entity_id": "01J3PWJPQPGHBNPHBXX4DSME1H",
+                        "entity_type": "project",
+                        "created_by": 2048070,
+                        "updated_by": 2048070,
+                        "created_at": "2024-07-26T07:52:14Z",
+                        "updated_at": "2024-07-26T07:52:14Z"
+                      }
+                    ]
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get Test Cases By Folder ID",
+              "method": "GET",
+              "path": "/api/v1/projects/{project_id}/folder/{folder_id}/test-cases",
+              "description": "Get Test Case Details by Folder ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "project_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                },
+                {
+                  "name": "folder_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "per_page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "sort",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "data": [
+                      {
+                        "project_id": "01J43X04Q3WG0A0BVXNPT20QM9",
+                        "folder_id": "01J43X53GXR2T0BX63MS69HXCJ",
+                        "test_case_id": "01J43XFH00CXZ3HZ7AMBB32H7Q",
+                        "title": "Test Case - 1",
+                        "description": "Demo Test Case - 1",
+                        "priority": "Medium",
+                        "type": "Regression",
+                        "preconditions": "preconditions",
+                        "estimated_time": 20,
+                        "created_by": 1000137129,
+                        "updated_by": 1000137129,
+                        "created_at": "2024-07-31T08:11:07Z",
+                        "updated_at": "2024-08-01T13:17:34Z",
+                        "status": "Draft",
+                        "tags": [
+                          {
+                            "tag_id": 5865,
+                            "name": "tag2"
+                          },
+                          {
+                            "tag_id": 5866,
+                            "name": "tag3"
+                          },
+                          {
+                            "tag_id": 5867,
+                            "name": "tag090909090909"
+                          }
+                        ],
+                        "internal_id": "TC-2",
+                        "automation_status": "Not Automated",
+                        "is_auteur_generated": false
+                      },
+                      {
+                        "project_id": "01J43X04Q3WG0A0BVXNPT20QM9",
+                        "folder_id": "01J43X53GXR2T0BX63MS69HXCJ",
+                        "test_case_id": "01J43XFGZC1ZQ53HC54B3RDAPW",
+                        "title": "Test case-2",
+                        "description": "Demo Test case -2",
+                        "priority": "Medium",
+                        "type": "Regression",
+                        "preconditions": "preconditions",
+                        "estimated_time": 20,
+                        "created_by": 1000137129,
+                        "updated_by": 1000137129,
+                        "created_at": "2024-07-31T08:11:07Z",
+                        "updated_at": "2024-08-01T13:16:27Z",
+                        "status": "Draft",
+                        "tags": [
+                          {
+                            "tag_id": 5865,
+                            "name": "tag2"
+                          },
+                          {
+                            "tag_id": 5866,
+                            "name": "tag3"
+                          },
+                          {
+                            "tag_id": 5867,
+                            "name": "tag090909090909"
+                          }
+                        ],
+                        "internal_id": "TC-1",
+                        "automation_status": "Not Automated",
+                        "is_auteur_generated": false
+                      }
+                    ],
+                    "columnMetadata": {
+                      "auteur_test_id": {
+                        "display_name": "Auteur Test ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "automation_status": {
+                        "display_name": "Automation Status",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "created_at": {
+                        "display_name": "Created At",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": true
+                      },
+                      "created_by": {
+                        "display_name": "Created By",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "deleted_at": {
+                        "display_name": "Deleted By",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "description": {
+                        "display_name": "Description",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "estimated_time": {
+                        "display_name": "Estimated Time",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "external_id": {
+                        "display_name": "external_id",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "folder_id": {
+                        "display_name": "Folder ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "internal_id": {
+                        "display_name": "internal_id",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "is_auteur_generated": {
+                        "display_name": "Auteur Generated",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "organization_id": {
+                        "display_name": "Organization ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "preconditions": {
+                        "display_name": "Preconditions",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "priority": {
+                        "display_name": "Priority",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "project_id": {
+                        "display_name": "Project ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "status": {
+                        "display_name": "Status",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "title": {
+                        "display_name": "Title",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "type": {
+                        "display_name": "Type",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "updated_at": {
+                        "display_name": "Updated At",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "updated_by": {
+                        "display_name": "Updated By",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      }
+                    },
+                    "filterMetadata": {
+                      "automation_status": {
+                        "display_name": "Automation Status",
+                        "options": [
+                          "Automated",
+                          "Not Automated",
+                          "To Be Automated"
+                        ],
+                        "type": "select"
+                      },
+                      "created_at": {
+                        "display_name": "Created At",
+                        "scopes": [
+                          "created_at_condition_before",
+                          "created_at_condition_after",
+                          "created_at_condition_on",
+                          "created_at_condition_between"
+                        ],
+                        "type": "time.Time"
+                      },
+                      "created_by": {
+                        "display_name": "Created By",
+                        "type": "int"
+                      },
+                      "organization_id": {
+                        "display_name": "Organization ID",
+                        "type": "int"
+                      },
+                      "priority": {
+                        "display_name": "Priority",
+                        "options": [
+                          "Lowest",
+                          "Low",
+                          "Medium",
+                          "High",
+                          "Highest"
+                        ],
+                        "type": "select"
+                      },
+                      "status": {
+                        "display_name": "Status",
+                        "options": [
+                          "Draft",
+                          "Open",
+                          "Closed"
+                        ],
+                        "type": "select"
+                      },
+                      "title": {
+                        "display_name": "Title",
+                        "type": "string"
+                      },
+                      "type": {
+                        "display_name": "Type",
+                        "options": [
+                          "Accessibility",
+                          "Acceptance",
+                          "Compatibility",
+                          "Destructive",
+                          "Performance",
+                          "Integration",
+                          "Functional",
+                          "Regression",
+                          "Smoke & Sanity",
+                          "Security",
+                          "User Interface",
+                          "Usability",
+                          "Other"
+                        ],
+                        "type": "select"
+                      }
+                    },
+                    "pagination": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 20,
+                      "total": 2
+                    }
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "type": "error",
+                    "title": "Request Not Processed",
+                    "message": "Invalid Folder ID"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Environment",
+          "endpoints": [
+            {
+              "name": "Get All Environments",
+              "method": "GET",
+              "path": "/api/v1/environments",
+              "description": "Get All Environments",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "per_page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "sort",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "data": {
+                      "organization_id": 166750,
+                      "environments": [
+                        {
+                          "environment_id": 4,
+                          "platform": "Mobile",
+                          "name": "Mobile iOS",
+                          "os": "iOS",
+                          "os_version": "16",
+                          "browser": "Firefox",
+                          "browser_version": "121",
+                          "brand": "Apple",
+                          "device": "iPhone 15"
+                        },
+                        {
+                          "environment_id": 1,
+                          "platform": "Desktop",
+                          "name": "Mobile iOS",
+                          "os": "MacOS",
+                          "os_version": "Sonoma",
+                          "browser": "Safari",
+                          "browser_version": "17",
+                          "resolution": "1920x1080"
+                        },
+                        {
+                          "environment_id": 3,
+                          "platform": "Mobile",
+                          "name": "Mobile iOS",
+                          "os": "Android",
+                          "os_version": "14",
+                          "browser": "Chrome",
+                          "browser_version": "104",
+                          "brand": "Samsung",
+                          "device": "Galaxy S22"
+                        },
+                        {
+                          "environment_id": 2,
+                          "platform": "Desktop",
+                          "name": "Mobile iOS",
+                          "os": "Windows",
+                          "os_version": "11",
+                          "browser": "Chrome",
+                          "browser_version": "104",
+                          "resolution": "1920x1080"
+                        },
+                        {
+                          "environment_id": 5,
+                          "platform": "Desktop",
+                          "name": "Mobile iOS",
+                          "os": "Windows 11",
+                          "browser": "Chrome",
+                          "resolution": "1024*766"
+                        },
+                        {
+                          "environment_id": 6,
+                          "platform": "Mobile",
+                          "name": "Mobile iOS",
+                          "os": "Android",
+                          "browser": "Chrome",
+                          "brand": "Samsung",
+                          "device": "Flip 3",
+                          "resolution": "1024*766"
+                        },
+                        {
+                          "environment_id": 7,
+                          "platform": "Mobile",
+                          "name": "Mobile iOS",
+                          "os": "ios",
+                          "browser": "Opera",
+                          "brand": "Apple",
+                          "device": "iPhone 13 Pro",
+                          "resolution": "1024*766"
+                        }
+                      ]
+                    }
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Create Environments",
+              "method": "POST",
+              "path": "/api/v1/environments",
+              "description": "Create configuration with environment name and variables. Note that supported variable values (Browser, OS, Device) are not publicly available currently, reach out to support if needed.",
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "configurations",
+                    "type": "array",
+                    "required": true,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "configurations": [
+                    {
+                      "name": "Web Desktop Chrome",
+                      "platform": "web",
+                      "is_custom": false,
+                      "environments": [
+                        {
+                          "os": "Windows",
+                          "os_version": "11",
+                          "browser": "Chrome",
+                          "browser_version": "120",
+                          "resolution": "1920x1080",
+                          "platform_type": "desktop"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Mobile iOS Safari",
+                      "platform": "real-device-mobile",
+                      "is_custom": false,
+                      "environments": [
+                        {
+                          "os": "ios",
+                          "os_version": "17.0",
+                          "browser": "Safari",
+                          "device": "iPhone 15 Pro",
+                          "brand": "Apple",
+                          "platform_type": "mobile"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Custom Android App",
+                      "platform": "real-device-mobile",
+                      "is_custom": true,
+                      "custom_app": true,
+                      "app_auto_update": false,
+                      "app_package": "com.example.app",
+                      "environments": [
+                        {
+                          "os": "android",
+                          "os_version": "13",
+                          "device": "Samsung Galaxy S23",
+                          "brand": "Samsung",
+                          "platform_type": "mobile"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Environments created successfully",
+                  "example": {
+                    "message": "Environments created successfully",
+                    "type": "success",
+                    "environment_id": [
+                      123,
+                      124,
+                      125
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request - Invalid JSON, missing required fields, or query parameters present",
+                  "example": {
+                    "title": "Bad Request Error",
+                    "message": {
+                      "detail": "Body Payload format is not correct"
+                    }
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized - Invalid or missing authentication token",
+                  "example": {
+                    "title": "Unauthorized Error",
+                    "message": "Unauthenticated"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Forbidden - User does not have access to TMS or action is not allowed",
+                  "example": {
+                    "title": "Unauthorized Error",
+                    "message": "Access to the product has been removed. Please contact your admin."
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity - Validation errors or business logic violations",
+                  "example": {
+                    "title": "Request Not Processed",
+                    "message": "Configuration with this name already exists"
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal Server Error - Server-side error occurred",
+                  "example": {
+                    "title": "Internal Server Error",
+                    "message": "Sorry! Something went wrong"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "environment_id",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Update Environment",
+              "method": "PUT",
+              "path": "/api/v1/environments",
+              "description": "Update existing configuration for a specific configuration ID. Note the configuration ID is dynamic and must be fetched from the 'get environments' API before each update.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": "integer",
+                    "required": true,
+                    "description": "Configuration ID (required for update)"
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "required": true,
+                    "description": "Configuration name (required)"
+                  },
+                  {
+                    "name": "platform",
+                    "type": "string",
+                    "required": false,
+                    "description": "Platform type (optional)"
+                  },
+                  {
+                    "name": "environments",
+                    "type": "array",
+                    "required": true,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "id": 44643,
+                  "name": "DesktopConfig",
+                  "platform": "desktop",
+                  "environments": [
+                    {
+                      "os": "macOS",
+                      "os_name": "macOS",
+                      "os_id": "macOS",
+                      "os_version": "macOS Tahoe",
+                      "os_version_id": "OSV100021498719908712",
+                      "browser": "Chrome",
+                      "browser_id": "BRS100021498722190810",
+                      "browser_version": "143",
+                      "browser_version_id": "BRV19216818160455129266",
+                      "resolution": "3840x2160",
+                      "resolution_id": "RES100021498719938809",
+                      "url": "",
+                      "platform_type": "web"
+                    }
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Environment updated successfully",
+                  "example": {
+                    "type": "success",
+                    "message": "Environment updated successfully"
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request - Invalid JSON, missing required fields, or query parameters present",
+                  "example": {
+                    "title": "Bad Request Error",
+                    "message": "Please, give correct input value for the '<field>' field"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Forbidden - User does not have access to TMS or action is not allowed",
+                  "example": {
+                    "title": "Unauthorized Error",
+                    "message": "You are not allowed to perform this action."
+                  },
+                  "type": null
+                },
+                "404": {
+                  "description": "Not Found - Resource not found",
+                  "example": {
+                    "title": "Resource not found",
+                    "message": "Record not found"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity - Business logic errors",
+                  "example": {
+                    "title": "Request Not Processed",
+                    "message": "Invalid Environment ID"
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Internal Server Error",
+                  "example": {
+                    "title": "Internal Server Error",
+                    "message": "Sorry! Something went wrong"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Test Cases",
+          "endpoints": [
+            {
+              "name": "Create Test Cases By Project ID",
+              "method": "POST",
+              "path": "/api/v1/test-cases",
+              "description": "Create New Test Cases",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "project_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "folder_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "test_cases",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "project_id": "project_id",
+                  "folder_id": "folder_id",
+                  "test_cases": [
+                    {
+                      "title": "Demo Test case - 1",
+                      "description": "Description Demo Test case - 1",
+                      "preconditions": "preconditions",
+                      "tags": [
+                        "tag1",
+                        "tag3",
+                        "tagtest1"
+                      ]
+                    },
+                    {
+                      "title": "Demo Test case - 2",
+                      "description": "Description Demo Test case - 2",
+                      "preconditions": "preconditions",
+                      "tags": [
+                        "tag1",
+                        "tag3",
+                        "tagtest1"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test cases created successfully",
+                    "type": "Success",
+                    "id": [
+                      "01J5QB9YQTGBCQJXRFA94C29MB",
+                      "01J5QB9YR9T8XECZX8PXZVFTNE"
+                    ]
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "type": "error",
+                    "title": "Request Not Processed",
+                    "message": "Invalid project ID"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get Test Cases By Project ID",
+              "method": "GET",
+              "path": "/api/v1/projects/{project_id}/test-cases",
+              "description": "get All Test Cases By Project ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "project_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "per_page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "sort",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "data": [
+                      {
+                        "project_id": "01J3PWJPQPGHBNPHBXX4DSME1H",
+                        "folder_id": "01J3Q0DBFF2M74H527NZZAPR9B",
+                        "test_case_id": "01J3Q2ZTG995PXPMQFQE2WYVDV",
+                        "title": "search w3school.com in google search tab",
+                        "description": "",
+                        "priority": "Medium",
+                        "type": "NA",
+                        "estimated_time": 10,
+                        "created_by": 2048070,
+                        "updated_by": 2048070,
+                        "created_at": "2024-07-26T08:37:16Z",
+                        "updated_at": "2024-07-26T08:37:16Z",
+                        "status": "Draft",
+                        "test_steps": null,
+                        "internal_id": "TC-2",
+                        "external_id": null,
+                        "automation_status": "Not Automated",
+                        "bdd_scenarios": null,
+                        "is_auteur_generated": false
+                      },
+                      {
+                        "project_id": "01J3PWJPQPGHBNPHBXX4DSME1H",
+                        "folder_id": "01J3Q0DBFF2M74H527NZZAPR9B",
+                        "test_case_id": "01J3Q2ZTG8DF3B4CK66ZGZ17WY",
+                        "title": "go to google.com",
+                        "description": "",
+                        "priority": "Medium",
+                        "type": "NA",
+                        "estimated_time": 10,
+                        "created_by": 2048070,
+                        "updated_by": 2048070,
+                        "created_at": "2024-07-26T08:37:16Z",
+                        "updated_at": "2024-07-26T08:37:16Z",
+                        "status": "Draft",
+                        "test_steps": null,
+                        "internal_id": "TC-1",
+                        "external_id": null,
+                        "automation_status": "Not Automated",
+                        "bdd_scenarios": null,
+                        "is_auteur_generated": false
+                      }
+                    ],
+                    "columnMetadata": {
+                      "auteur_test_id": {
+                        "display_name": "Auteur Test ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "automation_status": {
+                        "display_name": "Automation Status",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "created_at": {
+                        "display_name": "Created At",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": true
+                      },
+                      "created_by": {
+                        "display_name": "Created By",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "deleted_at": {
+                        "display_name": "Deleted By",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "description": {
+                        "display_name": "Description",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "estimated_time": {
+                        "display_name": "Estimated Time",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "external_id": {
+                        "display_name": "external_id",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "folder_id": {
+                        "display_name": "Folder ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "internal_id": {
+                        "display_name": "internal_id",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "is_auteur_generated": {
+                        "display_name": "Auteur Generated",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "organization_id": {
+                        "display_name": "Organization ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "preconditions": {
+                        "display_name": "Preconditions",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "priority": {
+                        "display_name": "Priority",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "project_id": {
+                        "display_name": "Project ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "status": {
+                        "display_name": "Status",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "title": {
+                        "display_name": "Title",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "type": {
+                        "display_name": "Type",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "updated_at": {
+                        "display_name": "Updated At",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "updated_by": {
+                        "display_name": "Updated By",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      }
+                    },
+                    "filterMetadata": {
+                      "automation_status": {
+                        "display_name": "Automation Status",
+                        "options": [
+                          "Automated",
+                          "Not Automated",
+                          "To Be Automated"
+                        ],
+                        "type": "select"
+                      },
+                      "created_at": {
+                        "display_name": "Created At",
+                        "scopes": [
+                          "created_at_condition_before",
+                          "created_at_condition_after",
+                          "created_at_condition_on",
+                          "created_at_condition_between"
+                        ],
+                        "type": "time.Time"
+                      },
+                      "created_by": {
+                        "display_name": "Created By",
+                        "type": "int"
+                      },
+                      "organization_id": {
+                        "display_name": "Organization ID",
+                        "type": "int"
+                      },
+                      "priority": {
+                        "display_name": "Priority",
+                        "options": [
+                          "Lowest",
+                          "Low",
+                          "Medium",
+                          "High",
+                          "Highest"
+                        ],
+                        "type": "select"
+                      },
+                      "status": {
+                        "display_name": "Status",
+                        "options": [
+                          "Draft",
+                          "Open",
+                          "Closed"
+                        ],
+                        "type": "select"
+                      },
+                      "title": {
+                        "display_name": "Title",
+                        "type": "string"
+                      },
+                      "type": {
+                        "display_name": "Type",
+                        "options": [
+                          "Accessibility",
+                          "Acceptance",
+                          "Compatibility",
+                          "Destructive",
+                          "Performance",
+                          "Integration",
+                          "Functional",
+                          "Regression",
+                          "Smoke & Sanity",
+                          "Security",
+                          "User Interface",
+                          "Usability",
+                          "Other"
+                        ],
+                        "type": "select"
+                      }
+                    },
+                    "pagination": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 40,
+                      "total": 2
+                    }
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "type": "error",
+                    "title": "Request Not Processed",
+                    "message": "Invalid project ID"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Delete Test Case By ID",
+              "method": "DELETE",
+              "path": "/api/v1/test-cases/{test_case_id}",
+              "description": "Delete a test case by its ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_case_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test cases deleted successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "type": "error",
+                    "title": "Request Not Processed",
+                    "message": "Invalid test case provided"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get Test Case By ID",
+              "method": "GET",
+              "path": "/api/v2/test-cases/{test_case_id}",
+              "description": "Get Test Case details by ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_case_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "data": {
+                      "project_id": "sample_project_id",
+                      "folder_id": "sample_folder_id",
+                      "test_case_id": "sample_test_case_id",
+                      "title": "Sample Test Case Title",
+                      "description": "<p>Sample test case description</p>",
+                      "priority": "Normal",
+                      "type": "",
+                      "estimated_time": 10,
+                      "preconditions": "Sample preconditions for the test case",
+                      "path": [
+                        {
+                          "id": "sample_root_folder_id",
+                          "name": "Root Folder"
+                        },
+                        {
+                          "id": "sample_parent_folder_id",
+                          "name": "Parent Folder"
+                        },
+                        {
+                          "id": "sample_folder_id",
+                          "name": "Current Folder"
+                        }
+                      ],
+                      "created_by": 1234567,
+                      "updated_by": 1234567,
+                      "created_at": "2024-07-26T08:37:16Z",
+                      "updated_at": "2024-07-26T09:15:00Z",
+                      "status": "",
+                      "tags": [
+                        {
+                          "tag_id": 100001,
+                          "name": "regression"
+                        },
+                        {
+                          "tag_id": 100002,
+                          "name": "smoke"
+                        }
+                      ],
+                      "test_steps": [
+                        {
+                          "id": "sample_step_id_1",
+                          "serial_no": 1,
+                          "description": "Open the application",
+                          "action": null,
+                          "outcome": "Application opens successfully",
+                          "attachments": null,
+                          "entity_type": "step",
+                          "entity_id": ""
+                        },
+                        {
+                          "id": "sample_step_id_2",
+                          "serial_no": 2,
+                          "description": "Navigate to the target page",
+                          "action": null,
+                          "outcome": "Target page is displayed",
+                          "attachments": null,
+                          "entity_type": "step",
+                          "entity_id": ""
+                        }
+                      ],
+                      "internal_id": "TC-1",
+                      "external_id": "12345",
+                      "jira_details": [
+                        {
+                          "jira_id": "PROJ-123",
+                          "jira_link": "https://example.atlassian.net/browse/PROJ-123",
+                          "platform_name": "jira"
+                        }
+                      ],
+                      "dynamic_field_details": [
+                        {
+                          "field_id": "sample_field_id_1",
+                          "field_name": "User",
+                          "type": "user",
+                          "placeholder": "1",
+                          "is_required": false,
+                          "value": "",
+                          "test_case_id": "sample_test_case_id",
+                          "options": null
+                        },
+                        {
+                          "field_id": "sample_field_id_2",
+                          "field_name": "Automation Candidate",
+                          "type": "single_select",
+                          "placeholder": "",
+                          "is_required": false,
+                          "value": "Yes",
+                          "test_case_id": "sample_test_case_id",
+                          "options": [
+                            "Yes",
+                            "No",
+                            "Not applicable",
+                            "Automated"
+                          ]
+                        }
+                      ],
+                      "automation_status": "Not Automated",
+                      "bdd_scenarios": [],
+                      "is_auteur_generated": false,
+                      "code_generation_status": "",
+                      "test_type": "",
+                      "dataset_id": null,
+                      "params_used": false,
+                      "app_id": "",
+                      "is_mobile": false,
+                      "os": "",
+                      "live_mode": false,
+                      "commit_id": 100001,
+                      "commit_message": "Sample commit message",
+                      "total_steps": 2,
+                      "version": 1,
+                      "snapshot_id": "sample_snapshot_id",
+                      "execution_allowed": false,
+                      "execution_code_request_id": 0,
+                      "latest_commit_id": 100001,
+                      "revert_allowed": false,
+                      "session_status": "",
+                      "session_started_by": 0,
+                      "bulk_automation_status": "inactive",
+                      "automation_in_progress": false,
+                      "kaneai_version": 0,
+                      "revert_disabled": false,
+                      "auteur_commit_id": "",
+                      "is_test_validated": true
+                    },
+                    "metadata": null,
+                    "columnMetadata": {
+                      "auteur_test_id": {
+                        "display_name": "Auteur Test ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "automation_status": {
+                        "display_name": "Automation Status",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "created_at": {
+                        "display_name": "Created At",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": true
+                      },
+                      "created_by": {
+                        "display_name": "Created By",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "dataset_id": {
+                        "display_name": "Dataset ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "deleted_at": {
+                        "display_name": "Deleted By",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "description": {
+                        "display_name": "Description",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "estimated_time": {
+                        "display_name": "Estimated Time",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "external_id": {
+                        "display_name": "external_id",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "folder_id": {
+                        "display_name": "Folder ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "internal_id": {
+                        "display_name": "internal_id",
+                        "default": true,
+                        "can_be_hidden": true,
+                        "sortable": true
+                      },
+                      "is_auteur_generated": {
+                        "display_name": "KaneAI Generated",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "latest_test_commit_id": {
+                        "display_name": "Latest Test Commit ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "organization_id": {
+                        "display_name": "Organization ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "preconditions": {
+                        "display_name": "Preconditions",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "priority": {
+                        "display_name": "Priority",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": true
+                      },
+                      "project_id": {
+                        "display_name": "Project ID",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "status": {
+                        "display_name": "Status",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "title": {
+                        "display_name": "Title",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": true
+                      },
+                      "type": {
+                        "display_name": "Type",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      },
+                      "updated_at": {
+                        "display_name": "Updated At",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      },
+                      "updated_by": {
+                        "display_name": "Updated By",
+                        "default": false,
+                        "can_be_hidden": true,
+                        "sortable": false
+                      }
+                    },
+                    "filterMetadata": {
+                      "automation_status": {
+                        "display_name": "Automation Status",
+                        "options": [
+                          "Automated",
+                          "Not Automated",
+                          "To Be Automated"
+                        ],
+                        "type": "select",
+                        "custom_filters": false
+                      },
+                      "created_at": {
+                        "display_name": "Created At",
+                        "scopes": [
+                          "created_at_condition_before",
+                          "created_at_condition_after",
+                          "created_at_condition_on",
+                          "created_at_condition_between"
+                        ],
+                        "type": "time.Time",
+                        "custom_filters": false
+                      },
+                      "created_by": {
+                        "display_name": "Created By",
+                        "type": "int",
+                        "custom_filters": false
+                      },
+                      "id": {
+                        "display_name": "",
+                        "type": "string",
+                        "custom_filters": false
+                      },
+                      "internal_id": {
+                        "display_name": "internal_id",
+                        "type": "int",
+                        "custom_filters": false
+                      },
+                      "is_auteur_generated": {
+                        "display_name": "KaneAI Generated",
+                        "type": "bool",
+                        "custom_filters": false
+                      },
+                      "jira_issues": {
+                        "display_name": "Issues",
+                        "options": [
+                          "PROJ-123"
+                        ],
+                        "type": "select",
+                        "custom_filters": false
+                      },
+                      "organization_id": {
+                        "display_name": "Organization ID",
+                        "type": "int",
+                        "custom_filters": false
+                      },
+                      "priority": {
+                        "display_name": "Priority",
+                        "options": [
+                          "Lowest",
+                          "Low",
+                          "Medium",
+                          "High",
+                          "Highest",
+                          "Normal"
+                        ],
+                        "type": "select",
+                        "custom_filters": false
+                      },
+                      "status": {
+                        "display_name": "Status",
+                        "options": [
+                          "Unverified",
+                          "Faulty",
+                          "Ready",
+                          "Live",
+                          "Archived"
+                        ],
+                        "type": "select",
+                        "custom_filters": false
+                      },
+                      "title": {
+                        "display_name": "Title",
+                        "type": "string",
+                        "custom_filters": false
+                      },
+                      "type": {
+                        "display_name": "Type",
+                        "options": [
+                          "Accessibility",
+                          "Acceptance",
+                          "Compatibility",
+                          "Destructive",
+                          "Performance",
+                          "Integration",
+                          "Functional",
+                          "Regression",
+                          "Smoke & Sanity",
+                          "Security",
+                          "User Interface",
+                          "Usability",
+                          "Other"
+                        ],
+                        "type": "select",
+                        "custom_filters": false
+                      }
+                    },
+                    "rbac_metadata": {
+                      "can_create_entity": true,
+                      "can_execute_entity": false,
+                      "can_edit_entity": true,
+                      "can_delete_entity": true,
+                      "can_list_entity": true,
+                      "can_read_entity": true,
+                      "can_update_entity": true
+                    }
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "type": "error",
+                    "title": "Request Not Processed",
+                    "message": "Invalid test case provided"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Update Test Case",
+              "method": "PUT",
+              "path": "/api/v2/test-cases",
+              "description": "Update a test case including its steps, metadata, and dynamic fields. This endpoint replaces the separate Test Steps APIs (POST /api/v1/test-steps and PUT /api/v1/test-steps/{test_step_id}). The snapshot_id from the GET response must be included in the request body.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": "string",
+                    "required": true,
+                    "description": "The test case ID to update."
+                  },
+                  {
+                    "name": "project_id",
+                    "type": "string",
+                    "required": true,
+                    "description": "The project ID the test case belongs to."
+                  },
+                  {
+                    "name": "title",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "description",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "type",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "preconditions",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "status",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "priority",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "automation_status",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "external_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "attachments",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "dynamic_fields",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "tags",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "commit_message",
+                    "type": "string",
+                    "required": true,
+                    "description": ""
+                  },
+                  {
+                    "name": "snapshot_id",
+                    "type": "string",
+                    "required": true,
+                    "description": "Required. Must be taken from the GET /api/v2/test-cases/{test_case_id} response."
+                  },
+                  {
+                    "name": "step_events",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "override",
+                    "type": "boolean",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "id": "sample_test_case_id",
+                  "project_id": "sample_project_id",
+                  "title": "Sample Test Case Title",
+                  "description": "<p>Updated test case description</p>",
+                  "type": "",
+                  "preconditions": "Sample preconditions",
+                  "status": "",
+                  "priority": "Medium",
+                  "automation_status": "Not Automated",
+                  "external_id": "TC-1",
+                  "attachments": [],
+                  "dynamic_fields": [
+                    {
+                      "field_id": "sample_field_id_1",
+                      "value": "1234567"
+                    },
+                    {
+                      "field_id": "sample_field_id_2",
+                      "value": "Yes"
+                    }
+                  ],
+                  "tags": [
+                    "regression",
+                    "smoke"
+                  ],
+                  "commit_message": "Updated test case",
+                  "snapshot_id": "sample_snapshot_id",
+                  "step_events": [
+                    {
+                      "test_step_info_id": "sample_step_id_1",
+                      "step_type": "step",
+                      "operation": "MODIFY",
+                      "description": "<p>Updated step 1 description</p>",
+                      "outcome": "<p>Updated step 1 expected outcome</p>",
+                      "attachments": []
+                    },
+                    {
+                      "test_step_info_id": "sample_step_id_2",
+                      "step_type": "step",
+                      "operation": "MODIFY",
+                      "description": "<p>Updated step 2 description</p>",
+                      "outcome": "<p>Updated step 2 expected outcome</p>",
+                      "attachments": []
+                    },
+                    {
+                      "test_step_info_id": "custom-new-step-id",
+                      "step_type": "step",
+                      "operation": "ADD",
+                      "description": "<p>New step description</p>",
+                      "outcome": "<p>New step expected outcome</p>",
+                      "attachments": [],
+                      "parent_step_info_id": "sample_step_id_2"
+                    },
+                    {
+                      "bdd_info_id": "custom-d8689042-a678-4d0f-890a-5acf64e5236a",
+                      "step_type": "bdd_scenario",
+                      "operation": "ADD",
+                      "test_step_info_id": "custom-d8689042-a678-4d0f-890a-5acf64e5236a",
+                      "bdd_data": "Given user is on login page\\nWhen user enters valid credentials\\nThen user is logged in"
+                    }
+                  ],
+                  "override": false
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test case updated successfully",
+                    "type": "Success",
+                    "data": {
+                      "snapshot_id": "sample_snapshot_id"
+                    }
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "type": "error",
+                    "title": "Request Not Processed",
+                    "message": "Invalid test case provided"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Milestone",
+          "endpoints": [
+            {
+              "name": "Create a new milestone",
+              "method": "POST",
+              "path": "/api/v1/milestone",
+              "description": "Endpoint to create a new milestone for a project.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "project_id",
+                    "type": "string",
+                    "required": true,
+                    "description": "Unique identifier for the project."
+                  },
+                  {
+                    "name": "title",
+                    "type": "string",
+                    "required": true,
+                    "description": "Title of the milestone."
+                  },
+                  {
+                    "name": "description",
+                    "type": "string",
+                    "required": false,
+                    "description": "Detailed description of the milestone."
+                  },
+                  {
+                    "name": "test_run_id",
+                    "type": "array",
+                    "required": false,
+                    "description": "List of associated test run IDs."
+                  },
+                  {
+                    "name": "tags",
+                    "type": "array",
+                    "required": false,
+                    "description": "Tags associated with the milestone."
+                  },
+                  {
+                    "name": "start_at",
+                    "type": "string<date-time>",
+                    "required": true,
+                    "description": "Start date and time of the milestone in the format YYYY-MM-DD HH:mm:ss."
+                  },
+                  {
+                    "name": "end_at",
+                    "type": "string<date-time>",
+                    "required": true,
+                    "description": "End date and time of the milestone in the format YYYY-MM-DD HH:mm:ss."
+                  },
+                  {
+                    "name": "owned_by",
+                    "type": "integer",
+                    "required": true,
+                    "description": "User ID of the milestone owner."
+                  },
+                  {
+                    "name": "milestone_id",
+                    "type": "string",
+                    "required": false,
+                    "description": "Unique identifier for the milestone."
+                  }
+                ],
+                "example": {
+                  "project_id": "01JEQSN8WQW76RM59X3KSBZYVH",
+                  "title": "mile mi",
+                  "description": "desc desc.",
+                  "test_run_id": [
+                    "01JF4TH6P7A9TCP2YPZWQX7E3Z"
+                  ],
+                  "tags": [
+                    "t01",
+                    "t02"
+                  ],
+                  "start_at": "2024-01-02T15:04:05.000Z",
+                  "end_at": "2026-01-02T15:04:05.000Z",
+                  "owned_by": 862914
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful creation of the milestone.",
+                  "example": {
+                    "message": "Milestone created successfully",
+                    "type": "Success",
+                    "id": "01JHN7P7PXFF4F85SPXDKTGXWG"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "id",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Get All Milestones By Project ID",
+              "method": "GET",
+              "path": "/api/v1/project/{project_id}/milestones",
+              "description": "Retrieve all milestones associated with a given project ID.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "project_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful retrieval of milestones.",
+                  "example": {
+                    "data": {
+                      "project_id": "01JG9PVWC7MJ9YKR92TMDTVYJC",
+                      "name": "Sample Test Runs",
+                      "description": "",
+                      "test_case_count": 17,
+                      "test_run_count": 0,
+                      "created_by": 1000188123,
+                      "updated_by": 1000188123,
+                      "created_at": "2024-12-29T17:19:20.000Z",
+                      "updated_at": "2024-12-29T17:19:20.000Z",
+                      "tags": [
+                        {
+                          "tag_id": 9043,
+                          "name": "sample"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Delete Milestone",
+              "method": "DELETE",
+              "path": "/api/v1/milestone/{milestone_id}",
+              "description": "Delete a milestone by its ID.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "milestone_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Milestone successfully deleted.",
+                  "example": {
+                    "message": "Milestone deleted successfully",
+                    "type": "Success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get Milestone By ID",
+              "method": "GET",
+              "path": "/api/v1/milestone/{milestone_id}",
+              "description": "Get details of a milestone by its ID.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "milestone_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Milestone successfully retrieved.",
+                  "example": {
+                    "data": {
+                      "milestone_id": "01JHN7P7PXFF4F85SPXDKTGXWG",
+                      "project_id": "01JEQSN8WQW76RM59X3KSBZYVH",
+                      "title": "mile mi",
+                      "description": "desc desc.",
+                      "test_run_id": [
+                        "01JF4TH6P7A9TCP2YPZWQX7E3Z"
+                      ],
+                      "tags": [
+                        "t01",
+                        "t02"
+                      ],
+                      "start_at": "2024-01-02T15:04:05.000Z",
+                      "end_at": "2026-01-02T15:04:05.000Z",
+                      "owned_by": 862914,
+                      "created_at": "2024-12-29T17:19:20.000Z",
+                      "updated_at": "2024-12-29T17:19:20.000Z",
+                      "created_by": 1000188123,
+                      "updated_by": 1000188123
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Update Milestone",
+              "method": "PUT",
+              "path": "/api/v1/milestone/{milestone_id}",
+              "description": "Update details of an existing milestone.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "milestone_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "title",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "description",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "test_run_id",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "tags",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "start_at",
+                    "type": "object",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "end_at",
+                    "type": "object",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "attachments",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "project_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "title": "Sanity milestone",
+                  "description": "",
+                  "test_run_id": [
+                    "01JGAXH73Q0D2WRSZPXTWZVRTP",
+                    "01JGAZ48DPJS4KGB7R0KF7C0SS"
+                  ],
+                  "tags": [],
+                  "start_at": "2024-12-31T00:00:00.000Z",
+                  "end_at": "2025-01-08T00:00:00.000Z",
+                  "attachments": [],
+                  "project_id": "01JG9PVWC7MJ9YKR92TMDTVYJC"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Milestone successfully updated.",
+                  "example": {
+                    "message": "Milestone updated successfully",
+                    "type": "Success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Execution History",
+          "endpoints": [
+            {
+              "name": "Test Execution History By Test Case ID",
+              "method": "GET",
+              "path": "/api/v1/test-execution-history/{test_case_id}",
+              "description": "Test Execution History By Test Case ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_case_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful response",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Test Execution History By Jira ID",
+              "method": "GET",
+              "path": "/api/v1/test-execution-history/jira/{Jira_issue_id}",
+              "description": "Test Execution History By Jira ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "Jira_issue_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful response",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Test Steps",
+          "endpoints": [
+            {
+              "name": "Create Test Steps For TestCase",
+              "method": "POST",
+              "path": "/api/v1/test-steps",
+              "description": "Deprecated: Use PUT /api/v2/test-cases with step_events instead.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "test_case_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "test_steps",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "test_case_id": "test_case_id",
+                  "test_steps": [
+                    {
+                      "serial_no": 1,
+                      "description": "enter emails and password",
+                      "outcome": "Login error"
+                    },
+                    {
+                      "serial_no": 2,
+                      "description": "enter emails and password",
+                      "outcome": "Login error"
+                    }
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test steps created successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Update Test Step By ID",
+              "method": "PUT",
+              "path": "/api/v1/test-steps/{test_step_id}",
+              "description": "Deprecated: Use PUT /api/v2/test-cases with step_events instead.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_step_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "serial_no",
+                    "type": "integer",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "description",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "outcome",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "serial_no": 1,
+                  "description": "updated description",
+                  "outcome": "login outcome "
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test step updated successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Jira Flow",
+          "endpoints": [
+            {
+              "name": "Get All Jira Issues By TestCaseID",
+              "method": "GET",
+              "path": "/api/v1/jira/{test_case_id}",
+              "description": "Get All Jira Issues By TestCaseID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_case_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "data": [
+                      {
+                        "id": "test_case_id",
+                        "organization_id": 33275539,
+                        "created_at": "2024-02-28T07:13:52Z",
+                        "updated_at": "2024-02-28T07:13:52Z",
+                        "entity_id": "entity_id",
+                        "entity_type": "test_case",
+                        "project_id": "project_id",
+                        "jira_id": "jira_id",
+                        "jira_link": "jira_link",
+                        "created_by": 862914,
+                        "updated_by": 862914,
+                        "deleted_at": null
+                      }
+                    ]
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get Test Cases by Jira ID",
+              "method": "GET",
+              "path": "/api/v1/jira/test-case/{Jira_issue_id}",
+              "description": "Get Test Cases by Jira ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "Jira_issue_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "per_page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "id": "Jira_issue_id",
+                    "organization_id": 33275539,
+                    "created_at": "2024-01-15T13:19:56Z",
+                    "updated_at": "2024-01-29T21:32:14Z",
+                    "project_id": "project_id",
+                    "internal_id": 1,
+                    "external_id": null,
+                    "title": "login with right creds",
+                    "description": "NA",
+                    "priority": "medium",
+                    "type": "Regression",
+                    "preconditions": "preconditions",
+                    "status": "draft",
+                    "estimated_time": 20,
+                    "created_by": 862914,
+                    "updated_by": 862914,
+                    "deleted_at": null,
+                    "test_steps": null
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Link Jira Issue",
+              "method": "POST",
+              "path": "/api/v1/jira",
+              "description": "Link Jira Issue",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "project_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "entity_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "entity_type",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "jira_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "project_id": "project_id",
+                  "entity_id": "test_case_id",
+                  "entity_type": "test_case",
+                  "jira_id": "org_id:jira_issue_id"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Jira Issue linked successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Remove Jira Issue",
+              "method": "POST",
+              "path": "/api/v1/jira/remove",
+              "description": "Remove Jira Issue",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "project_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "entity_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "entity_type",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "jira_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "project_id": "project_id",
+                  "entity_id": "test_case_id",
+                  "entity_type": "test_case",
+                  "jira_id": "jira_issue_id"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Jira Issue unlinked successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "Test Runs",
+          "endpoints": [
+            {
+              "name": "Create Test Run",
+              "method": "POST",
+              "path": "/api/v1/test-run",
+              "description": "Create Test Run",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "title",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "objective",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "test_run_instances",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "tags",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "project_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "is_auteur_generated",
+                    "type": "boolean",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "title": "New Test Run",
+                  "objective": "Sample Discreption",
+                  "test_run_instances": [],
+                  "tags": [
+                    "tag1",
+                    "tag2",
+                    "tag3"
+                  ],
+                  "project_id": "sample project id",
+                  "is_auteur_generated": false
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test Run created successfully",
+                    "type": "Success",
+                    "id": "test_run_id"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get All Test Runs By Project ID",
+              "method": "GET",
+              "path": "/api/v1/projects/{project_id}/test-runs",
+              "description": "Get All Test Runs By Project ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "project_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "per_page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successfully retrieved test runs",
+                  "example": {
+                    "data": [
+                      {
+                        "id": "test_run_id",
+                        "title": "Title",
+                        "project_id": "project_id",
+                        "objective": "",
+                        "is_auteur_generated": false,
+                        "tags": null,
+                        "status": "In Progress",
+                        "type": "Manual",
+                        "build_state": "active",
+                        "created_at": "2025-01-14T10:38:54Z",
+                        "updated_at": "2025-01-15T11:17:48Z",
+                        "created_by": "user_id",
+                        "updated_by": "user_id",
+                        "run_result": {
+                          "total_test": 84,
+                          "passed": 14,
+                          "failed": 0,
+                          "skipped": 0,
+                          "not_started": 70
+                        },
+                        "is_build_disabled": false,
+                        "total_test_cases": 2,
+                        "total_environments": 42,
+                        "total_run_instances": 84,
+                        "complete_percent": 16.666666666666664
+                      }
+                    ],
+                    "columnMetadata": {
+                      "build_state": {
+                        "display_name": "Build State",
+                        "default": true,
+                        "can_be_hidden": false,
+                        "sortable": false
+                      }
+                    },
+                    "filterMetadata": {
+                      "build_state": {
+                        "display_name": "Build State",
+                        "options": [
+                          "active",
+                          "archived"
+                        ],
+                        "type": "select"
+                      }
+                    },
+                    "pagination": {
+                      "current_page": 1,
+                      "last_page": 2,
+                      "per_page": 10,
+                      "total": 11
+                    }
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized",
+                  "example": null,
+                  "type": null
+                },
+                "403": {
+                  "description": "Forbidden",
+                  "example": null,
+                  "type": null
+                },
+                "404": {
+                  "description": "Project not found",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "columnMetadata",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "filterMetadata",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "pagination",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Get Test Run By ID",
+              "method": "GET",
+              "path": "/api/v1/test-run/{test_run_id}",
+              "description": "Get Test Run By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_run_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "id": "testrun_id",
+                    "title": "New Test Run",
+                    "objective": "Sample Discription",
+                    "test_run_instances": [],
+                    "tags": [
+                      "tag1",
+                      "tag2",
+                      "tag3"
+                    ],
+                    "project_id": "project_id",
+                    "is_auteur_generated": false
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "message": "Invalid test run ID",
+                    "type": "Error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Delete Test Run",
+              "method": "DELETE",
+              "path": "/api/v1/test-run/{test_run_id}",
+              "description": "Delete Test Run",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_run_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test Run deleted successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Update Test Run By ID",
+              "method": "PUT",
+              "path": "/api/v1/test-run/{test_run_id}",
+              "description": "Update Test Run By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_run_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "title",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "objective",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "tags",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "is_auteur_generated",
+                    "type": "boolean",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "type",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "test_run_instances",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "project_id",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "id": "sample_id",
+                  "title": "New name Test Run",
+                  "objective": "Updated Discription",
+                  "tags": [],
+                  "is_auteur_generated": true,
+                  "type": "Manual",
+                  "test_run_instances": [
+                    {
+                      "test_case_id": "test_case_id",
+                      "assignee": 2144228,
+                      "priority": "Medium",
+                      "name": "Execute API with User Details",
+                      "serial_no": 1,
+                      "environment_id": 1793,
+                      "dataset_id": "dataset_id",
+                      "dataset_version_id": "dataset_version_id",
+                      "dataset_row_id": "dataset_row_id"
+                    }
+                  ],
+                  "project_id": "project_id"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test Run updated successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Duplicate Test Run",
+              "method": "POST",
+              "path": "/api/v1/test-run/duplicate/{test_run_id}",
+              "description": "Duplicate Test Run",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_run_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [],
+                "example": {}
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test Run duplicated successfully",
+                    "type": "Success",
+                    "id": "new_id"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get Test Run Instances by Test Run ID",
+              "method": "GET",
+              "path": "/api/v1/test-run/instances/{test_run_id}",
+              "description": "Retrieves test run instances with details and supports filtering",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_run_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "per_page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "filter[status]",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "filter[assignee]",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successfully retrieved test run instances",
+                  "example": {
+                    "test_run_details": {
+                      "id": "<string>",
+                      "title": "<string>",
+                      "project_id": "<string>",
+                      "objective": "<string>",
+                      "is_auteur_generated": true,
+                      "tags": [
+                        "<string>"
+                      ],
+                      "status": "<string>",
+                      "type": "<string>",
+                      "build_state": "<string>",
+                      "created_at": "2018-03-15T12:00:00Z",
+                      "updated_at": "2018-03-15T12:00:00Z",
+                      "created_by": 123,
+                      "updated_by": 123,
+                      "run_result": {
+                        "total_test": 123,
+                        "passed": 123,
+                        "failed": 123,
+                        "skipped": 123,
+                        "not_started": 123
+                      },
+                      "is_build_disabled": true,
+                      "total_test_cases": 123,
+                      "total_environments": 123,
+                      "total_run_instances": 123,
+                      "complete_percent": 123
+                    },
+                    "test_run_instances": {
+                      "data": [
+                        {
+                          "id": 123,
+                          "test_case_id": "<string>",
+                          "title": "<string>",
+                          "description": "<string>",
+                          "priority": "Lowest",
+                          "type": "<string>",
+                          "internal_id": "<string>",
+                          "order_no": 123,
+                          "status": "Passed",
+                          "assignee": 123,
+                          "automation_status": "Automated",
+                          "remarks": "<string>",
+                          "environment": {
+                            "id": 123,
+                            "name": "<string>",
+                            "brand": "<string>",
+                            "os_name": "<string>",
+                            "os": "<string>",
+                            "os_version": "<string>",
+                            "device": "<string>",
+                            "platform": "<string>",
+                            "browser": "<string>",
+                            "browser_version": "<string>",
+                            "resolution": "<string>",
+                            "is_complete": true,
+                            "order_no": 123,
+                            "assignee": 123
+                          },
+                          "is_build_disabled": true,
+                          "dataset_details": {},
+                          "auteur_test_id": "<string>",
+                          "is_auteur_generated": true,
+                          "linked_test_url": "<string>",
+                          "source": "<string>"
+                        }
+                      ],
+                      "columnMetadata": {},
+                      "filterMetadata": {},
+                      "pagination": {
+                        "current_page": 123,
+                        "last_page": 123,
+                        "per_page": 123,
+                        "total": 123
+                      }
+                    }
+                  },
+                  "type": "object"
+                },
+                "400": {
+                  "description": "Bad request - Invalid parameters",
+                  "example": null,
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized",
+                  "example": null,
+                  "type": null
+                },
+                "404": {
+                  "description": "Test run not found",
+                  "example": null,
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "test_run_details",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "test_run_instances",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Update Test Run Instance",
+              "method": "PUT",
+              "path": "/api/v1/test-run/instance/{test_instance_id}",
+              "description": "Update Test Run Instance",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_instance_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "status",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "assignee",
+                    "type": "integer",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "status": "Passed",
+                  "assignee": 1000167238
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test Run Instance updated successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "message": "Invalid test instance ID",
+                    "type": "Error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Bulk Update Test Run Instances",
+              "method": "PUT",
+              "path": "/api/v1/test-run/{test_run_id}/bulk-update",
+              "description": "Bulk Update Test Run Instances",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_run_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "test_run_instances",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "test_run_instances": [
+                    {
+                      "id": 55793,
+                      "status": "Passed",
+                      "assignee": 1000167238
+                    }
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test Run Instances updated successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "message": "Invalid test run ID",
+                    "type": "Error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Update Test Run Step",
+              "method": "PUT",
+              "path": "/api/v1/test-run/test-run-step/{test_run_step_id}",
+              "description": "Update Test Run Step",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_run_step_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "status",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "remarks",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "attachment_urls",
+                    "type": "array",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "status": "Passed",
+                  "remarks": "Sample remarks",
+                  "attachment_urls": [
+                    "url1",
+                    "url2"
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test Run Step updated successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "message": "Invalid test instance ID",
+                    "type": "Error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Get Test Run Instance By ID",
+              "method": "GET",
+              "path": "/api/v1/test-run/test-run-instance/{test_instance_id}",
+              "description": "Get Test Run Instance By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_instance_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "type": "NA",
+                    "time_taken": null,
+                    "test_steps_count": 0,
+                    "test_run_title": "Sample Test Run",
+                    "test_run_id": "test_run_id",
+                    "test_case_id": "test_case_id",
+                    "executed_by": "user_id",
+                    "id": "sample_id",
+                    "internal_id": "id",
+                    "order_no": 2,
+                    "priority": "Medium",
+                    "project_id": "project_id",
+                    "remarks": "",
+                    "result": "Passed",
+                    "run_testcase_disable": false,
+                    "source": "external",
+                    "started_at": null,
+                    "tags": [],
+                    "test_build_steps": []
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "message": "Invalid test instance ID",
+                    "type": "Error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            },
+            {
+              "name": "Archive Test Run By ID",
+              "method": "PUT",
+              "path": "/api/v1/test-run/archive/{test_run_id}",
+              "description": "Archive Test Run By ID",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "test_run_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "build_state",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ],
+                "example": {
+                  "build_state": "archived"
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "message": "Test Run updated successfully",
+                    "type": "Success"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Unprocessable Entity",
+                  "example": {
+                    "message": "Invalid test run ID",
+                    "type": "Error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "HyperExecute",
+      "baseUrl": "https://api.hyperexecute.cloud",
+      "servers": [
+        {
+          "url": "https://api.hyperexecute.cloud"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Secrets",
+          "endpoints": [
+            {
+              "name": "Create Secrets and store sensitive information in the vault.",
+              "method": "PUT",
+              "path": "/v1.0/secrets/create",
+              "description": "This API allows you to securely [**create and save secrets**](https://www.lambdatest.com/support/docs/hyperexecute-how-to-save-and-manage-secrets/#create-a-new-secret) like API keys or sensitive data, ensuring they remain protected throughout your testing. Industry-standard algorithms encrypt each secret.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "secretKey",
+                    "type": "string",
+                    "required": true,
+                    "description": ""
+                  },
+                  {
+                    "name": "secretValue",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "username",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "orgID",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "Secret created successfully",
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Retrieve all secrets stored in your account.",
+              "method": "GET",
+              "path": "/v1.0/secrets/list/{username}",
+              "description": "This API lets you fetch all the secrets associated with your [**username**](https://www.lambdatest.com/support/docs/hyperexecute-how-to-get-my-username-and-access-key/). You get a comprehensive list of your stored confidential information, making it easier to manage and verify your secrets.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "username",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter your LambdaTest username"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": [
+                      "TestSecret"
+                    ],
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Delete specific secrets permanently from the vault.",
+              "method": "POST",
+              "path": "/v1.0/secrets/delete",
+              "description": "This API permanently [**removes specified secrets**](https://www.lambdatest.com/support/docs/hyperexecute-how-to-save-and-manage-secrets/#delete-the-secrets) from the secure vault when they're no longer needed, helping maintain security and compliance with data retention policies.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "secretKey",
+                    "type": "string",
+                    "required": true,
+                    "description": ""
+                  },
+                  {
+                    "name": "username",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  },
+                  {
+                    "name": "orgID",
+                    "type": "string",
+                    "required": false,
+                    "description": ""
+                  }
+                ]
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "Secret deleted successfully",
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Browsers",
+          "endpoints": [
+            {
+              "name": "Get a list of all browsers supported in HyperExecute.",
+              "method": "GET",
+              "path": "/v2.0/browsers",
+              "description": "This API returns a current list of all supported browser names and versions for a specific operating system in HyperExecute. This information assists you in planning your cross-browser testing strategy and ensuring compatibility across multiple browser environments.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "platform",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "windows 11, windows 10, macos monterey, macos ventura, ubuntu 20"
+                },
+                {
+                  "name": "stable",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": "If true, will return only stable version of browsers."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "message": "",
+                    "platforms": {
+                      "desktop": [
+                        {
+                          "platform": "Windows 10",
+                          "browsers": [
+                            {
+                              "name": "Firefox",
+                              "version": "99.0"
+                            }
+                          ],
+                          "resolutions": [
+                            "1024x768",
+                            "1280x800",
+                            "1280x1024",
+                            "1366x768"
+                          ]
+                        }
+                      ]
+                    },
+                    "status": 200
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "message",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "platforms",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "integer",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Jobs",
+          "endpoints": [
+            {
+              "name": "Check the status of a Job and its associated Tasks.",
+              "method": "GET",
+              "path": "/v2.0/job/{jobID}",
+              "description": "This API retrieve the [**status**](https://www.lambdatest.com/support/docs/hyperexecute-status/) of a specific [**Job**](https://www.lambdatest.com/support/docs/hyperexecute-guided-walkthrough/#jobs-page) by providing the `jobID`. It returns detailed information about each task's progress, including their completion status, execution times, and any errors encountered, giving you a full overview of the job lifecycle",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "jobID",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter your Job ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": {
+                      "id": "08cd3816-6f0b-498a-9fae-99439f756cdb",
+                      "orgId": "121431",
+                      "user": "amanchopra",
+                      "status": "completed",
+                      "jobNumber": "5644",
+                      "jobLabel": null,
+                      "remark": null,
+                      "createdAt": "2023-01-23T07:48:04Z",
+                      "updateAt": "023-01-23T07:53:18Z",
+                      "globalTimeout": 150,
+                      "testSuiteTimeout": 150,
+                      "retryOnFailure": false,
+                      "tunnelName": "",
+                      "runson": "",
+                      "startTime": "2023-01-23T07:50:31Z",
+                      "endTime": "2023-01-23T07:53:18Z",
+                      "type": "autosplit",
+                      "tasks": [
+                        {
+                          "id": "amanc",
+                          "os": "win",
+                          "Job": "08cd3816-6f0b-498a-9fae-99439f756cdb",
+                          "context": "{\"_jobId\": \"08cd3816-6f0b-498a-9fae-99439f756cdb\", \"_taskId\": \"147b7c8a-325f-46d9-8b52-5b9975d01591\"}",
+                          "version": "10",
+                          "status": "completed",
+                          "remark": "completed",
+                          "tunnel_name": "",
+                          "createdAt": "2023-01-23T07:48:15Z",
+                          "updateAt": "2023-01-23T07:53:18Z",
+                          "startTime": "2023-01-23T07:50:33Z",
+                          "endTime": "2023-01-23T07:53:18Z",
+                          "groupNumber": 1,
+                          "iteration": 0,
+                          "debug": false,
+                          "parentTaskId": "",
+                          "failedAt": null,
+                          "initiatedAt": null,
+                          "smartUIEnabled": false,
+                          "type": "infra",
+                          "testIDs": null,
+                          "sessionIDs": null
+                        }
+                      ],
+                      "frameworks": [
+                        "selenium"
+                      ],
+                      "taskCount": {
+                        "aborted": 0,
+                        "cancelled": 0,
+                        "completed": 2,
+                        "failed": 0,
+                        "initiated": 0,
+                        "lambdaError": 0,
+                        "queued": 0,
+                        "running": 0,
+                        "skipped": 0,
+                        "timeout": 0,
+                        "total": 2
+                      },
+                      "totalTests": 3,
+                      "jobSummary": {
+                        "preStatusCount": {
+                          "created": 0,
+                          "inPorgress": 0,
+                          "failed": 0,
+                          "aborted": 0,
+                          "completed": 6,
+                          "skipped": 0,
+                          "lambdaError": 0,
+                          "timeout": 0,
+                          "cancelled": 0,
+                          "logAvailable": 0
+                        },
+                        "postStatusCount": {
+                          "created": 0,
+                          "inPorgress": 0,
+                          "failed": 0,
+                          "aborted": 0,
+                          "completed": 4,
+                          "skipped": 0,
+                          "lambdaError": 0,
+                          "timeout": 0,
+                          "cancelled": 0,
+                          "logAvailable": 0
+                        },
+                        "scenarioStageSummary": {
+                          "totalExcludingRetries": 2,
+                          "totalExecutionTimeIncludingRetriesInSec": 125,
+                          "retries": 0,
+                          "totalRetriesTimeInSec": 0,
+                          "status_counts_excluding_retries": {
+                            "created": 0,
+                            "inPorgress": 0,
+                            "failed": 0,
+                            "aborted": 0,
+                            "completed": 4,
+                            "skipped": 0,
+                            "lambdaError": 0,
+                            "timeout": 0,
+                            "cancelled": 0,
+                            "logAvailable": 0
+                          }
+                        }
+                      },
+                      "screenRecordingForScenarios": false,
+                      "testType": ""
+                    },
+                    "executionTime": "1m41s",
+                    "metadata": {
+                      "total": 2,
+                      "cursor": 0,
+                      "hasmore": false
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "executionTime",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "metadata",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch Scenario details associated with your Job ID",
+              "method": "GET",
+              "path": "/v2.0/job/{jobID}/scenarios",
+              "description": "This API retrieves scenario-level execution details for a given Job ID. A scenario in HyperExecute represents a logical stage or group of test cases executed within a [**Job**](https://www.lambdatest.com/support/docs/hyperexecute-guided-walkthrough/#jobs-page). Each job consists of multiple tasks, and each task may contain one or more scenarios.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "jobID",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter your Job ID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Limits the number of scenarios shown in the response (default is 10, max is 20)."
+                },
+                {
+                  "name": "cursor",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Helps in moving across pagination. Accepts an \"id\" value and returns scenarios with an \"id\" greater than or equal to it.\n"
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Filter scenarios based on their execution status."
+                },
+                {
+                  "name": "search_text",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Filter response based on occurrences of the search text in the 'name' field."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": [
+                      {
+                        "id": "00x0x0xx-x0x0-0000-0000-00xx0x000x00",
+                        "taskID": "00xx000-0x0x-000x-0xxx-00000x000xxx",
+                        "name": "aliasing.spec.js",
+                        "iteration": 0,
+                        "status": "completed",
+                        "group_number": 2,
+                        "duration": "00:00:23"
+                      }
+                    ],
+                    "metadata": {
+                      "total": 1,
+                      "cursor": "",
+                      "hasmore": false
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "metadata",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Fetch Session-Level details associated with your Job ID.",
+              "method": "GET",
+              "path": "/v2.0/job/{jobID}/sessions",
+              "description": "This API retrieves session-level execution details for all tests that were executed as part of a given Job ID. A session represents an individual test execution instance, providing more granular insights into the execution of test cases.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "jobID",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter your Job ID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Limits the number of sessions shown in the response (default is 10, max is 20)."
+                },
+                {
+                  "name": "cursor",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Helps in moving across pagination. Accepts an \"id\" value and returns sessions with an \"id\" greater than or equal to it.\n"
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Filter sessions based on their execution status."
+                },
+                {
+                  "name": "search_text",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Filter response based on occurrences of the search text in the 'scenario_name' field."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": [
+                      {
+                        "sessionID": "XXXX-XXXX-XXXX-XXXX",
+                        "testID": "XXXX-XXXX-XXXX-XXXX",
+                        "taskID": "00xx000-0x0x-000x-0xxx-00000x000xxx",
+                        "name": "aliasing.spec.js",
+                        "scenario_name": "aliasing.spec.js",
+                        "status": "passed",
+                        "group_number": 2,
+                        "duration": "00:00:16",
+                        "smartUI_enabled": false
+                      }
+                    ],
+                    "metadata": {
+                      "total": 1,
+                      "cursor": "",
+                      "hasmore": false
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "metadata",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "View all stages executed within a specific task",
+              "method": "GET",
+              "path": "/v2.0/stage/{taskID}",
+              "description": "This API allows you to track all the stages that were part of a particular [**Task**](https://www.lambdatest.com/support/docs/hyperexecute-status/#2-task-level-status). By sending a GET request with the `taskID`, you get a complete breakdown of each stage executed.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "taskID",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter your Task ID of the Job"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "search_text",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Implement filtereation based on scenario name"
+                },
+                {
+                  "name": "scenario_only",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": "If set to false, it will render the data of pre, post and scenario level. Else it will show only scenario level data."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "When \"scenario_only\" is set to \"false\"",
+                  "example": {
+                    "data": {
+                      "pre": [
+                        {
+                          "id": "af2ab1dc-55de-4057-9789-d414c2c23fcb",
+                          "task": "085d201b-0fc8-4985-a822-0ef3c46839f3",
+                          "type": "cache-download",
+                          "status": "completed",
+                          "remark": "completed",
+                          "name": "cache-download",
+                          "iteration": 0,
+                          "order": 1,
+                          "link": "cache-download.log",
+                          "createdAt": "2023-01-23T07:50:33Z",
+                          "startedAt": "2023-01-23T07:50:35Z",
+                          "updatedAt": "2023-01-23T07:50:39Z",
+                          "count": 0,
+                          "testType": null
+                        }
+                      ],
+                      "scenario": [
+                        {
+                          "id": "d7b0255e-f469-4e6f-8252-0ac0d95ef958",
+                          "task": "085d201b-0fc8-4985-a822-0ef3c46839f3",
+                          "type": "scenario",
+                          "status": "completed",
+                          "remark": "completed",
+                          "name": "\"Test_1\"",
+                          "iteration": 0,
+                          "order": 4,
+                          "link": "command.1.0.log",
+                          "createdAt": "2023-01-23T07:51:04Z",
+                          "startedAt": "2023-01-23T07:51:06Z",
+                          "updatedAt": "2023-01-23T07:52:30Z",
+                          "count": 0,
+                          "testType": null
+                        }
+                      ],
+                      "post": [
+                        {
+                          "id": "2a9d14a4-fab8-49cb-88cd-0c0a6d22c13c",
+                          "task": "085d201b-0fc8-4985-a822-0ef3c46839f3",
+                          "type": "postrun",
+                          "status": "completed",
+                          "remark": "completed",
+                          "name": "post",
+                          "iteration": 0,
+                          "order": 5,
+                          "link": "post.log",
+                          "createdAt": "2023-01-23T07:51:04Z",
+                          "startedAt": "2023-01-23T07:52:32Z",
+                          "updatedAt": "2023-01-23T07:52:34Z",
+                          "count": 0,
+                          "testType": null
+                        }
+                      ]
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                },
+                "2OO": {
+                  "description": "When \"scenario_only\" is set to \"true\"",
+                  "example": {
+                    "data": {
+                      "scenario": [
+                        {
+                          "id": "d7b0255e-f469-4e6f-8252-0ac0d95ef958",
+                          "task": "085d201b-0fc8-4985-a822-0ef3c46839f3",
+                          "type": "scenario",
+                          "status": "completed",
+                          "remark": "completed",
+                          "name": "\"Test_1\"",
+                          "iteration": 0,
+                          "order": 4,
+                          "link": "command.1.0.log",
+                          "createdAt": "2023-01-23T07:51:04Z",
+                          "startedAt": "2023-01-23T07:51:06Z",
+                          "updatedAt": "2023-01-23T07:52:30Z",
+                          "count": 0,
+                          "testType": null
+                        }
+                      ]
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Get detailed test results within a specific stage.",
+              "method": "GET",
+              "path": "/v1.0/stage-tests/{stageID}",
+              "description": "This API provides a deep dive into the tests conducted in a particular [**Stage**](https://www.lambdatest.com/support/docs/hyperexecute-status/#3-stage-level-status). By specifying the `stageID`, you receive information about each test, including success or failure, making it easier to pinpoint where things went right or wrong during execution.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "stageID",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter the stage ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": [
+                      "D9HTK-NNIT3-STSWP-SNYWK"
+                    ],
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Get logs for a specific stage of a job.",
+              "method": "GET",
+              "path": "/v1.0/stage/{stageID}/logs",
+              "description": "This API provides access to the logs generated during a particular stage within a [**Job**](https://www.lambdatest.com/support/docs/hyperexecute-status/#1-job-level-status). The logs are essential for troubleshooting and understanding the events that took place during that [**Stage**](https://www.lambdatest.com/support/docs/hyperexecute-status/#3-stage-level-status), aiding in quick issue identification and resolution.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "stageID",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter the stage ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": "https://hypertestproduction.blob.core.windows.net/task-logs/60d-a9e7-a4be-637a3/cache-download.log?rscd=attachment%3B+filename%3cc8-a9ea-4ae7-a4be-d182981637a3%2Fcache-download.log&se=2024-10-23T14%Qs9%3D&ske=2024-10-24T12%3A29&skoid=1f80-df57-295e&sks=b&skt=2024-10-39Z&sktid=b4968-80ca8c130456&skv=2020-10-02&sp=rl&spr=https&sr=c&st=2024-10-23T10%3A24%3A29Z&sv=2020-02-10"
+                  },
+                  "type": "object"
+                },
+                "500": {
+                  "description": "Internal Server Error",
+                  "example": {
+                    "error": "non-20x status code 500",
+                    "status": "failed"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Abort an ongoing job execution immediately.",
+              "method": "PUT",
+              "path": "/v1.0/job/{number}/abort",
+              "description": "This API is used to abort a running [**Job**](https://www.lambdatest.com/support/docs/hyperexecute-status/#1-job-level-status) that is no longer required. You can immediately terminate all associated processes, conserving resources and preventing unnecessary execution.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "number",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Write your Job Number to abort that particular Job"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successfull Operation",
+                  "example": {
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "List all the Jobs of your organization.",
+              "method": "GET",
+              "path": "/v1.0/jobs",
+              "description": "This API is used to list all the Jobs of your organization.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "show_test_summary",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Total number of Jobs to be rendered"
+                },
+                {
+                  "name": "is_cursor_base_pagination",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successfull Operation",
+                  "example": {
+                    "data": [
+                      {
+                        "id": "f3e41-42e9-8095-e7cc3f46",
+                        "org_id": "509662",
+                        "status": "aborted",
+                        "job_number": 16311,
+                        "job_label": "",
+                        "remark": "job has been aborted by user",
+                        "created_at": "2024-11-20T08:54:13Z",
+                        "update_at": "2024-11-20T08:54:23Z",
+                        "global_timeout": 0,
+                        "test_suite_timeout": 0,
+                        "retry_on_failure": "false",
+                        "tunnel_name": "",
+                        "runson": "",
+                        "start_time": null,
+                        "end_time": "2024-11-20T08:54:23Z",
+                        "type": "",
+                        "user": "amanc",
+                        "Tasks": 0,
+                        "taskCount": null,
+                        "archived_at": null,
+                        "archived_by": "",
+                        "unarchived_at": null,
+                        "unarchived_by": "",
+                        "is_archived": 0,
+                        "executionTime": "0s",
+                        "execution_time_sec": 0,
+                        "total_tests": 0,
+                        "job_summary": null,
+                        "project_id": "",
+                        "test_type": "",
+                        "workflow_details": {
+                          "workflow_id": null
+                        },
+                        "project_name": ""
+                      }
+                    ],
+                    "metadata": {
+                      "total": 0,
+                      "cursor": 16310,
+                      "hasmore": "true"
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "metadata",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Artifacts",
+          "endpoints": [
+            {
+              "name": "Retrieve the metadata of all artifacts generated by a job.",
+              "method": "GET",
+              "path": "/v2.0/job/{jobID}/artefacts",
+              "description": "This API fetches the metadata of all the [**artifacts**](https://www.lambdatest.com/support/docs/hyperexecute-artifacts/) that were produced during the execution of a Job.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "jobID",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter your Job ID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "data": [
+                      [
+                        {
+                          "id": "56bbe571-221a-4938-967c-2aabe5cdd379",
+                          "name": "Final-Report-2",
+                          "job": "d711f5eb-d629-48d1-9ebf-99cf7f3fa2f4",
+                          "removed": false,
+                          "link": null,
+                          "size": "159195",
+                          "remark": "foreman",
+                          "status": "completed",
+                          "createdAt": "2022-11-11T08:04:13Z",
+                          "expiry": "2022-12-11T08:04:13Z",
+                          "updatedAt": "2022-11-11T08:07:30Z",
+                          "removedAt": null
+                        }
+                      ]
+                    ],
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            },
+            {
+              "name": "Download artifacts from a specific Job",
+              "method": "GET",
+              "path": "/v2.0/artefacts/{jobID}/download",
+              "description": "This API allows you to download a bundle of all [**artifacts**](https://www.lambdatest.com/support/docs/hyperexecute-artifacts/) created during a job by providing the `jobID`. It’s ideal for archiving results or for conducting offline examination of logs and outputs to debug or verify test behavior.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "jobID",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter the Job ID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "Enter the name of the artifact"
+                }
+              ],
+              "responses": {},
+              "responseSchema": []
+            }
+          ]
+        },
+        {
+          "name": "RCA",
+          "endpoints": [
+            {
+              "name": "Fetch RCA of your Task.",
+              "method": "GET",
+              "path": "/v1.0/categorizederrors",
+              "description": "This API is used to fetch the RCA data for your required task id.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "taskId",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "Enter the Task ID of your Job"
+                },
+                {
+                  "name": "order",
+                  "type": "integer",
+                  "in": "query",
+                  "required": true,
+                  "description": "Enter your order number. Example= 4"
+                },
+                {
+                  "name": "iteration",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successfull Operation",
+                  "example": {
+                    "data": [
+                      {
+                        "additional_suggestions": "",
+                        "after": "\n            Thread.sleep(500);\n            test1.log(LogStatus.PASS,  ...",
+                        "before": "\n\n        WebElement temp_element;\n\n        int totalCount = item_count+5;\n ...",
+                        "created_at": "2024-10-03T17:50:23Z",
+                        "error": "[ERROR] Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, ...",
+                        "errorType": "ElementNotFoundError",
+                        "filename": "Test1.java",
+                        "id": "01J99R26XDH1ZVBK4R3ZY29F70",
+                        "iteration": 0,
+                        "lang": "Java",
+                        "lineNumber": 88,
+                        "order": 4,
+                        "patch_diff": "",
+                        "rca": "",
+                        "remediation": "",
+                        "stack_trace_blob_path": "logs/d2698ea8-39bf-4580-aea8-ad625bec1f70/command.1.0/1.log",
+                        "stacktraceFileLink": "",
+                        "stageDetails": {
+                          "createdAt": "0001-01-01T00:00:00Z",
+                          "updatedAt": "0001-01-01T00:00:00Z"
+                        },
+                        "taskId": "d2698ea0-aea8-ad625bec1f70",
+                        "updated_at": "2024-10-03T17:50:23Z"
+                      }
+                    ],
+                    "metadata": {
+                      "cursor": "",
+                      "hasmore": "false",
+                      "next_cursor": ""
+                    },
+                    "status": "success"
+                  },
+                  "type": "object"
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "metadata",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Accessibility Testing",
+      "baseUrl": "https://api.lambdatest.com/accessibility",
+      "servers": [
+        {
+          "url": "https://api.lambdatest.com/accessibility"
+        },
+        {
+          "url": "https://eu-api.lambdatest.com/accessibility"
+        }
+      ],
+      "groups": [
+        {
+          "name": "default",
+          "endpoints": [
+            {
+              "name": "Get Test Issue Data",
+              "method": "GET",
+              "path": "/api/v1/test-issue/{testId}",
+              "description": "This endpoint retrieves accessibility test issues based on the provided test ID with filters such as impact, best practice and needs review parameters in the query string.\n\n### Request\n\n- Method: GET\n- Path Parameter:\n\n    - testId (string): Test ID of the accessibility test.\n\n- Query Parameters:\n        \n    - impact (string): [minor, moderate, critical and serious].\n        \n    - bestPractice (boolean)\n        \n    - needsReview (boolean)\n      ",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "testId",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": ""
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "impact",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "bestPractice",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                },
+                {
+                  "name": "needsReview",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": ""
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "OK",
+                  "example": {
+                    "test_info": {
+                      "total_issues": 18,
+                      "critical_issues": 4,
+                      "minor_issues": 1,
+                      "moderate_issues": 9,
+                      "serious_issues": 4,
+                      "test_id": "LAT-0LO26CZII1HQOO42TCFYY",
+                      "scan_type": "workflow",
+                      "org_id": 33464884,
+                      "status": "completed",
+                      "user_id": 1000137129,
+                      "test_name": "Workflow Scan | 1725000152130",
+                      "created_at": "2024-08-30T06:42:33Z",
+                      "active": true,
+                      "updated_at": "2024-08-30T06:42:33Z",
+                      "username": "amanraj",
+                      "email": "amanraj@lambdatest.com",
+                      "test_type": "manual"
+                    },
+                    "scan_json": [
+                      {
+                        "test_id": "LAT-0LO26CZII1HQOO42TCFYY",
+                        "url": "https://www.google.com/",
+                        "issue_count": 8,
+                        "scan_id": "BZLZFQLT",
+                        "accessibility_score": 98,
+                        "standard": "wcag21aa",
+                        "startDate": "2024-08-30T06:43:14.462Z",
+                        "current_timestamp": 1725000194,
+                        "scanType": "workflow",
+                        "axeVersion": "4.9.1",
+                        "extensionVersion": "1.1.1",
+                        "bestPracticesEnabled": true,
+                        "needsReviewEnabled": true,
+                        "allIssues": [
+                          {
+                            "bestPractice": false,
+                            "class": "",
+                            "description": "Ensure each page has at least one mechanism for a user to bypass navigation and jump straight to the content",
+                            "failureSummary": "Fix any of the following:\n  No valid skip link found\n  Page does not have a heading\n  Page does not have a landmark region",
+                            "helpUrl": "https://dequeuniversity.com/rules/axe/4.10/bypass?application=axeAPI",
+                            "html": "PGh0bWwgaXRlbXNjb3BlPSIiIGl0ZW10eXBlPSJodHRwOi8vc2NoZW1hLm9yZy9XZWJQYWdlIiBsYW5nPSJlbi1JTiI+",
+                            "htmlTagName": "html",
+                            "id": "bypass",
+                            "impact": "serious",
+                            "issueId": "VqHh3wClrw",
+                            "name": "Page must have means to bypass repeated blocks",
+                            "needsReview": true,
+                            "target": "html",
+                            "url": "https://www.google.com/",
+                            "wcagGuideline": "WCAG 2.0",
+                            "wcagVersion": [
+                              "2.4.1"
+                            ],
+                            "xpath": "/html"
+                          }
+                        ],
+                        "failedRules": [
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "aria-allowed-role"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "landmark-one-main"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "page-has-heading-one"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "region"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "aria-valid-attr-value"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "bypass"
+                          }
+                        ],
+                        "issueSummary": {
+                          "bestPractices": 6,
+                          "critical": 1,
+                          "minor": 1,
+                          "moderate": 5,
+                          "needsReview": 2,
+                          "serious": 1
+                        },
+                        "needsReview": [
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "aria-valid-attr-value"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "bypass"
+                          }
+                        ],
+                        "source": {
+                          "productName": "LambdaTest Accessibility DevTools",
+                          "productVersion": "1.1.1"
+                        }
+                      },
+                      {
+                        "test_id": "LAT-0LO26CZII1HQOO42TCFYY",
+                        "url": "https://w3school.com/",
+                        "issue_count": 10,
+                        "scan_id": "IA9EKXIE",
+                        "accessibility_score": 99,
+                        "standard": "wcag21aa",
+                        "startDate": "2024-08-30T06:43:14.462Z",
+                        "current_timestamp": 1725000194,
+                        "scanType": "workflow",
+                        "axeVersion": "4.9.1",
+                        "extensionVersion": "1.1.1",
+                        "bestPracticesEnabled": true,
+                        "needsReviewEnabled": true,
+                        "failedRules": [
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "image-alt"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "landmark-one-main"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "link-name"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "page-has-heading-one"
+                          },
+                          {
+                            "count": 1,
+                            "mode": "automated",
+                            "name": "region"
+                          }
+                        ],
+                        "issueSummary": {
+                          "bestPractices": 4,
+                          "critical": 3,
+                          "minor": 0,
+                          "moderate": 4,
+                          "needsReview": 0,
+                          "serious": 3
+                        },
+                        "source": {
+                          "productName": "LambdaTest Accessibility DevTools",
+                          "productVersion": "1.1.1"
+                        }
+                      }
+                    ]
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Analytics",
+      "baseUrl": "https://api.lambdatest.com/insights/api/v3/public",
+      "servers": [
+        {
+          "url": "https://api.lambdatest.com/insights/api/v3/public"
+        },
+        {
+          "url": "https://eu-api.lambdatest.com/insights/api/v3/public"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Test Data",
+          "endpoints": [
+            {
+              "name": "Get test execution data with AI insights.",
+              "method": "GET",
+              "path": "/tests",
+              "description": "Returns paginated test execution records enriched with AI-powered insights including smart tags, flakiness metrics, and root cause analysis (RCA) category.\n\n**Date range**: Defaults to the last 7 days when no timestamps are provided. Both `from_timestamp` and `to_timestamp` must be supplied together — providing only one returns a 400 error. The maximum allowed span per API call is **31 days**.\n\n**Filters**: At least one filter (`job_ids`, `task_ids`, `stage_ids`, `test_ids`, `build_ids`) OR a date range must implicitly scope the query. Filters are applied with AND logic when combined. The total number of IDs across **all** filter params combined must not exceed **100**.\n\n**Pagination**: Cursor-based via `cursor` + `limit`. Pass the `next_cursor` from the previous response as `cursor` in the next request.\n\n**Sorting**: Control result order with `sort_by` and `sort_order`. Sortable fields: `create_timestamp` (default), `duration`, `status`. Default order is `desc` (newest/largest first).",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "from_timestamp",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Start of the date range in RFC3339 UTC format (e.g. `2026-03-01T00:00:00Z`). Must be provided together with `to_timestamp` — both must be supplied or both omitted. When both are omitted, the range defaults to the last 7 days."
+                },
+                {
+                  "name": "to_timestamp",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "End of the date range in RFC3339 UTC format (e.g. `2026-03-08T00:00:00Z`). Defaults to the current time when both timestamps are omitted. Must be after `from_timestamp`. Cannot be more than 1 hour in the future."
+                },
+                {
+                  "name": "job_ids",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Comma-separated list of job IDs to filter by (HyperExecute jobs). Maximum 100 IDs total across all filter params. Whitespace around values is trimmed."
+                },
+                {
+                  "name": "task_ids",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Comma-separated list of task IDs to filter by (HyperExecute tasks). Maximum 100 IDs total across all filter params."
+                },
+                {
+                  "name": "stage_ids",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Comma-separated list of stage IDs to filter by. Maximum 100 IDs total across all filter params."
+                },
+                {
+                  "name": "test_ids",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Comma-separated list of test execution IDs to fetch directly. Maximum 100 IDs total across all filter params."
+                },
+                {
+                  "name": "build_ids",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Comma-separated list of build IDs to filter by. Maximum 100 IDs total across all filter params."
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Number of records to return per page. Defaults to 100. Maximum is 500. Invalid or non-positive values fall back to 100 with an explanatory note in the response. Values above 500 are silently clamped to 500."
+                },
+                {
+                  "name": "cursor",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Base64-encoded pagination cursor returned as `next_cursor` in the previous response. Omit (or pass an empty string) to fetch the first page."
+                },
+                {
+                  "name": "sort_by",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Field to sort results by. Defaults to `create_timestamp`."
+                },
+                {
+                  "name": "sort_order",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Sort direction. Defaults to `desc` (newest first)."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation. Returns matching test records with pagination state.",
+                  "example": {
+                    "status": "success",
+                    "data": [
+                      {
+                        "test_id": "RMAA-AND-160849-XXXX",
+                        "env_config": {
+                          "os": "Android",
+                          "os_version": "13",
+                          "browser": "",
+                          "browser_version": "",
+                          "device": "Galaxy S23",
+                          "resolution": ""
+                        },
+                        "test_metadata": {
+                          "test_name": "Login with valid credentials",
+                          "status": "failed",
+                          "duration": 12.5,
+                          "create_timestamp": "2026-03-10T08:00:00Z",
+                          "start_timestamp": "2026-03-10T08:00:01Z",
+                          "end_timestamp": "2026-03-10T08:00:13Z",
+                          "tags": [
+                            "smoke",
+                            "login"
+                          ]
+                        },
+                        "build_metadata": {
+                          "build_id": "290136414",
+                          "build_name": "Regression Suite - March Sprint",
+                          "build_tags": [
+                            "regression"
+                          ],
+                          "build_create_timestamp": "2026-03-10T07:55:00Z",
+                          "job_id": "e3251d99-805a-4b3f-a3f5-c0ea9b1d2e3f",
+                          "task_id": "task-abc-12345",
+                          "stage_id": "stage-xyz-67890"
+                        },
+                        "insights": {
+                          "smart_tags": {
+                            "is_always_failing": false,
+                            "is_new_failure": true,
+                            "is_flaky": false,
+                            "is_performance_anomaly": false
+                          },
+                          "flakiness": {
+                            "is_flaky": false,
+                            "flake_rate": 0,
+                            "compared_test_ids": []
+                          },
+                          "rca": {
+                            "category": "Test Data Issue",
+                            "summary": "App could not reach backend server during test execution."
+                          },
+                          "failure_category": "Test Data Issue"
+                        }
+                      }
+                    ],
+                    "pagination": {
+                      "next_cursor": "eyJzb3J0IjpbMTc0MTU5NjAwMDAwMCwiUk1BQS1BTkQtMTYwODQ5LVhYWFgiXX0=",
+                      "has_more": true,
+                      "limit": 100
+                    }
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request. Returns a descriptive error for invalid input.",
+                  "example": {
+                    "error": "to_timestamp must be after from_timestamp",
+                    "status": "failed"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized. Invalid or missing credentials.",
+                  "example": {
+                    "message": "Invalid Token"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Forbidden. Authorization token is missing from the request.",
+                  "example": {
+                    "message": "Authorization token missing."
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Server-side error occurred while processing the request.",
+                  "example": {
+                    "error": "error fetching test data",
+                    "status": "failed"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "Array of test execution records. Empty array if no results match.",
+                  "hasChildren": true
+                },
+                {
+                  "name": "pagination",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "notes",
+                  "type": "array",
+                  "required": false,
+                  "description": "Informational messages (e.g., limit clamping). Omitted when empty.",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Root Cause Analysis",
+          "endpoints": [
+            {
+              "name": "Get AI-powered Root Cause Analysis for test failures.",
+              "method": "GET",
+              "path": "/rca",
+              "description": "This endpoint retrieves the AI-powered Root Cause Analysis (RCA) for the specified test, job, task, or stage IDs. The RCA returned by this API matches the same test-level AI RCA displayed on the UI dashboard.\n\nAt least one of test_ids, job_ids, task_ids, or stage_ids must be provided.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "test_ids",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Comma-separated list of test IDs to fetch RCA for."
+                },
+                {
+                  "name": "job_ids",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Comma-separated list of job IDs to fetch RCA for."
+                },
+                {
+                  "name": "task_ids",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Comma-separated list of task IDs to fetch RCA for."
+                },
+                {
+                  "name": "stage_ids",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Comma-separated list of stage IDs to fetch RCA for."
+                },
+                {
+                  "name": "page",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Page number for paginated results. Default is 1."
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Maximum number of records to return per page. Default is 10."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "status": "success",
+                    "data": [
+                      {
+                        "test_id": "RMAA-AND-160849-XXXX",
+                        "job_id": "e3251d99-805a-4b3f-a3f5-c0ea9b1d2e3f",
+                        "stage_id": "stage-xyz-67890",
+                        "task_id": "task-abc-12345",
+                        "build_id": "290136414",
+                        "rca_category": "Test Data Issue",
+                        "create_timestamp": "2026-03-05T11:13:32Z",
+                        "rca_detail": {
+                          "root_cause_category": "Test Data Issue",
+                          "parent_failure_category": "Infrastructure Issue",
+                          "failure_summary": "App could not reach backend server, so the expected button was not displayed and the test failed.",
+                          "stack_trace": "org.openqa.selenium.NoSuchElementException: no such element...",
+                          "root_cause_failure_stack_trace": "java.net.ConnectException: Connection refused (Connection refused)...",
+                          "analysis": [
+                            "Device logs show the app could not connect to the backend server.",
+                            "Because the server call failed, the expected UI element was never loaded."
+                          ],
+                          "steps_to_fix": [
+                            {
+                              "issue": "Backend server not reachable from the test device.",
+                              "module": "Mobile app backend connection",
+                              "suggested_fix": "Ensure the backend server is accessible from the test environment."
+                            }
+                          ],
+                          "error_timeline": [
+                            {
+                              "step_name": "App connects to backend",
+                              "timestamp": "2026-03-05T11:17:22Z",
+                              "source_log": "Device Logs",
+                              "summary": "Connection to backend server timed out."
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "pagination": {
+                      "limit": 10,
+                      "page": 1,
+                      "total": 1
+                    }
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request error occurred while processing the request.",
+                  "example": {
+                    "error": "at least one of test_ids, job_ids, task_ids, or stage_ids is required",
+                    "status": "failed"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized. Invalid or expired authentication token.",
+                  "example": {
+                    "message": "Invalid Token"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Forbidden. Authorization token is missing from the request.",
+                  "example": {
+                    "message": "Authorization token missing."
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Server-side error occurred while processing the request.",
+                  "example": {
+                    "error": "error getting rca data",
+                    "status": "failed"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "pagination",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Trigger AI-powered RCA generation for failed tests in a scope.",
+              "method": "POST",
+              "path": "/rca/generate",
+              "description": "Resolves all failed tests under the provided scope (HyperExecute jobs/stages/tasks or individual test executions) and dispatches each eligible test to the AI RCA analyzer. Tests whose RCA was already generated or is currently running are skipped — credits are only charged for tests that are newly triggered.\n\n**Scope**: At least one of `job_ids`, `stage_ids`, `task_ids`, or `test_ids` must be provided in the JSON body. Each array is capped at **100 IDs**. A scope that resolves to more than **10,000 failed tests** is rejected with 413 — narrow the scope in that case.\n\n**Product routing**: Jobs/stages/tasks always route to the HyperExecute analyzer. `test_ids` route to the correct analyzer (HyperExecute or Web/Mobile automation) based on each test's stored product, so a mixed `test_ids` payload is supported.\n\n**Credits**: All-or-nothing. If the organization's available credit balance is below `credits_required`, a 402 is returned with the shortfall details and **no tests are dispatched**.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "requestBody": {
+                "contentType": "application/json",
+                "description": "",
+                "properties": [
+                  {
+                    "name": "job_ids",
+                    "type": "array",
+                    "required": false,
+                    "description": "HyperExecute job IDs whose failed tests should be analysed."
+                  },
+                  {
+                    "name": "stage_ids",
+                    "type": "array",
+                    "required": false,
+                    "description": "HyperExecute stage IDs whose failed tests should be analysed."
+                  },
+                  {
+                    "name": "task_ids",
+                    "type": "array",
+                    "required": false,
+                    "description": "HyperExecute task IDs whose failed tests should be analysed."
+                  },
+                  {
+                    "name": "test_ids",
+                    "type": "array",
+                    "required": false,
+                    "description": "Test execution IDs to analyse directly. Supports HyperExecute and Web/Mobile automation tests — each test is routed to the correct analyzer based on its stored product/test_type."
+                  }
+                ],
+                "example": {
+                  "job_ids": [
+                    "e3251d99-805a-4b3f-a3f5-c0ea9b1d2e3f"
+                  ],
+                  "test_ids": [
+                    "RMAA-AND-160849-XXXX"
+                  ]
+                }
+              },
+              "responses": {
+                "200": {
+                  "description": "Successful operation. Returns the dispatch summary.",
+                  "example": {
+                    "status": "success",
+                    "data": {
+                      "total_tests": 25,
+                      "triggered_count": 20,
+                      "skipped_count": 5,
+                      "skipped_already_generated": 3,
+                      "skipped_in_progress": 2,
+                      "credits_estimated": 20,
+                      "test_ids": [
+                        "RMAA-AND-160849-XXXX",
+                        "RMAA-AND-160850-YYYY"
+                      ],
+                      "skipped_test_ids": [
+                        "RMAA-AND-160851-ZZZZ"
+                      ]
+                    }
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request. Returns a descriptive error for invalid input.",
+                  "example": {
+                    "status": "error",
+                    "message": "At least one scope parameter is required (job_ids, stage_ids, task_ids, or test_ids)"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized. Missing, invalid or expired authentication token.",
+                  "example": {
+                    "status": "error",
+                    "message": "Invalid Token"
+                  },
+                  "type": null
+                },
+                "402": {
+                  "description": "Insufficient credits. No tests were triggered.",
+                  "example": {
+                    "status": "error",
+                    "message": "Insufficient credits to generate RCA. Please add credits to your account to access credit-based features.",
+                    "data": {
+                      "total_tests": 25,
+                      "tests_to_trigger": 20,
+                      "credits_required": 20,
+                      "credits_available": 5
+                    }
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Forbidden. Returned when AI capability is not enabled for the organization or the caller is a guest user. Missing or invalid authorization tokens are returned as 401 instead.",
+                  "example": {
+                    "status": "error",
+                    "message": "AI capability is not enabled for this organization"
+                  },
+                  "type": null
+                },
+                "413": {
+                  "description": "Request entity too large. The scope resolves to more failed tests than the per-request maximum.",
+                  "example": {
+                    "status": "error",
+                    "message": "Too many failed tests (12500). Please narrow the scope to under 10000 tests"
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Server-side error occurred while processing the request.",
+                  "example": {
+                    "status": "error",
+                    "message": "Error fetching failed tests"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Get RCA generation progress and completed results for a scope.",
+              "method": "GET",
+              "path": "/rca/status",
+              "description": "Returns a progress summary (counts of completed, in-progress, failed and pending tests) plus a paginated list of completed RCA results for all tests under the provided scope. Useful for polling after calling POST /rca/generate.\n\n**Scope**: At least one of `job_ids`, `stage_ids`, `task_ids`, or `test_ids` must be provided. Each array is capped at **100 IDs**. A scope that resolves to more than **10,000 tests** is rejected with 413.\n\n**Detail enrichment**: Pass `include_detail=true` to hydrate each paginated result with the full `rca_detail` (stack traces, analysis, fix suggestions, error timeline). Omitted by default to keep responses small for polling use-cases.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "job_ids",
+                  "type": "array",
+                  "in": "query",
+                  "required": false,
+                  "description": "HyperExecute job IDs. Serialized as a comma-separated list."
+                },
+                {
+                  "name": "stage_ids",
+                  "type": "array",
+                  "in": "query",
+                  "required": false,
+                  "description": "HyperExecute stage IDs. Serialized as a comma-separated list."
+                },
+                {
+                  "name": "task_ids",
+                  "type": "array",
+                  "in": "query",
+                  "required": false,
+                  "description": "HyperExecute task IDs. Serialized as a comma-separated list."
+                },
+                {
+                  "name": "test_ids",
+                  "type": "array",
+                  "in": "query",
+                  "required": false,
+                  "description": "Test execution IDs. Serialized as a comma-separated list."
+                },
+                {
+                  "name": "include_detail",
+                  "type": "boolean",
+                  "in": "query",
+                  "required": false,
+                  "description": "When `true`, enriches each completed RCA result in the current page with the full `rca_detail` payload (stack traces, analysis, fix suggestions, error timeline). Defaults to `false`."
+                },
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Number of completed RCA records per page."
+                },
+                {
+                  "name": "offset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Zero-based offset into the completed results. Defaults to 0."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation. Returns progress summary and paginated results.",
+                  "example": {
+                    "status": "success",
+                    "data": {
+                      "progress": {
+                        "total_tests": 25,
+                        "completed": 20,
+                        "in_progress": 3,
+                        "failed": 1,
+                        "pending": 1
+                      },
+                      "results": [
+                        {
+                          "test_id": "RMAA-AND-160849-XXXX",
+                          "stage_id": "stage-xyz-67890",
+                          "task_id": "task-abc-12345",
+                          "job_id": "e3251d99-805a-4b3f-a3f5-c0ea9b1d2e3f",
+                          "rca_category": "Test Data Issue",
+                          "parent_failure_category": "Infrastructure Issue",
+                          "status": "active",
+                          "created_at": "2026-03-05T11:13:32Z"
+                        }
+                      ],
+                      "pagination": {
+                        "total": 20,
+                        "limit": 20,
+                        "offset": 0
+                      }
+                    }
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request. Returns a descriptive error for invalid input.",
+                  "example": {
+                    "status": "error",
+                    "message": "At least one scope parameter is required (job_ids, stage_ids, task_ids, or test_ids)"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized. Missing, invalid or expired authentication token.",
+                  "example": {
+                    "status": "error",
+                    "message": "Invalid Token"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Forbidden. Returned when AI capability is not enabled for the organization or the caller is a guest user. Missing or invalid authorization tokens are returned as 401 instead.",
+                  "example": {
+                    "status": "error",
+                    "message": "AI capability is not enabled for this organization"
+                  },
+                  "type": null
+                },
+                "413": {
+                  "description": "Request entity too large. The scope resolves to more tests than the per-request maximum.",
+                  "example": {
+                    "status": "error",
+                    "message": "Too many failed tests (12500). Please narrow the scope to under 10000 tests"
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Server-side error occurred while processing the request.",
+                  "example": {
+                    "status": "error",
+                    "message": "Error fetching tests"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Concurrency",
+          "endpoints": [
+            {
+              "name": "Get time-series concurrency metrics for a product.",
+              "method": "GET",
+              "path": "/concurrency",
+              "description": "Returns time-bucketed concurrency usage metrics for the specified product. Each bucket contains the maximum concurrent sessions, queued sessions, allowed concurrency, and queue limit observed in that interval.\n\n**Product** (required): One of `automation`, `hyperexecute`, `app-automation`, `realtime`, `realdevice`. The value is case-sensitive.\n\n**Date range**: Defaults to the last 7 days when no timestamps are provided. The maximum allowed span per API call is **31 days**.\n\n**Granularity**: Controls the width of each time bucket. Valid values are `10m`, `1h`, `6h`, `12h`, `1d`. Defaults to `10m` if omitted. Coarser values (e.g. `1h`, `6h`) can be passed explicitly for fewer, wider buckets.\n\n**Timezone**: Shifts bucket boundaries to the specified UTC offset (format `+HH:MM` or `-HH:MM`, e.g. `+05:30` for IST). Defaults to `+00:00` (UTC). Named timezones (e.g. `IST`) are not accepted.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "product",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "Product to query concurrency data for. Must be one of: `automation`, `hyperexecute`, `app-automation`, `realtime`, `realdevice`. Case-sensitive."
+                },
+                {
+                  "name": "from_timestamp",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Start of the date range in RFC3339 UTC format. Must be provided together with `to_timestamp` — both must be supplied or both omitted. When both are omitted, the range defaults to the last 7 days. The span between `from_timestamp` and `to_timestamp` must not exceed **31 days**."
+                },
+                {
+                  "name": "to_timestamp",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "End of the date range in RFC3339 UTC format. Defaults to the current time when both timestamps are omitted. Cannot be more than 1 hour in the future. The span between `from_timestamp` and `to_timestamp` must not exceed **31 days**."
+                },
+                {
+                  "name": "granularity",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Time bucket size. Valid values: `10m`, `1h`, `6h`, `12h`, `1d`. Defaults to `10m` if omitted. Coarser values can be passed explicitly for fewer, wider buckets."
+                },
+                {
+                  "name": "timezone",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "UTC offset to apply to bucket boundaries. Format: `+HH:MM` or `-HH:MM` (e.g. `+05:30` for IST, `-08:00` for PST). Hours must be 0–14, minutes must be 0–59. Named timezones are not accepted. Defaults to `+00:00` (UTC)."
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation. Returns time-series concurrency buckets and aggregation metadata.",
+                  "example": {
+                    "status": "success",
+                    "data": [
+                      {
+                        "timestamp": "2026-03-03T00:00:00Z",
+                        "product": "automation",
+                        "max_concurrency": 42,
+                        "max_queued": 3,
+                        "max_allowed_concurrency": 50,
+                        "max_queued_limit": 150
+                      },
+                      {
+                        "timestamp": "2026-03-03T00:10:00Z",
+                        "product": "automation",
+                        "max_concurrency": 38,
+                        "max_queued": 0,
+                        "max_allowed_concurrency": 50,
+                        "max_queued_limit": 150
+                      }
+                    ],
+                    "metadata": {
+                      "granularity": "10m",
+                      "product": "automation",
+                      "total_buckets": 1008,
+                      "date_range": {
+                        "start": "2026-03-03T00:00:00Z",
+                        "end": "2026-03-10T00:00:00Z"
+                      }
+                    }
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request. Returns a descriptive error for invalid input.",
+                  "example": {
+                    "error": "product is required",
+                    "status": "failed"
+                  },
+                  "type": null
+                },
+                "401": {
+                  "description": "Unauthorized. Invalid or missing credentials.",
+                  "example": {
+                    "message": "Invalid Token"
+                  },
+                  "type": null
+                },
+                "403": {
+                  "description": "Forbidden. Authorization token is missing from the request.",
+                  "example": {
+                    "message": "Authorization token missing."
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Server-side error occurred while processing the request.",
+                  "example": {
+                    "error": "error fetching concurrency data",
+                    "status": "failed"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "status",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": false,
+                  "description": "Array of time-bucketed concurrency metrics. Empty if no data exists.",
+                  "hasChildren": true
+                },
+                {
+                  "name": "metadata",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Performance Testing",
+      "baseUrl": "https://api.hyperexecute.cloud",
+      "servers": [
+        {
+          "url": "https://api.hyperexecute.cloud"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Performance Testing",
+          "endpoints": [
+            {
+              "name": "Retrieve a summary of performance testing results for a specific job.",
+              "method": "GET",
+              "path": "/v1.0/performance/summary/{jobId}",
+              "description": "This API provides an overview of performance test results for a given job, including job ID, execution time, duration, request count, bandwidth, throughput, response times, ramp time, and user count. It helps assess the system's overall performance and scalability.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "jobId",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter your HyperExecute JobID"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "type": "summary",
+                    "data": {
+                      "job_id": "493bac0f-e412-445b-b85a-88df79f56de3",
+                      "start_timestamp": "2025-10-16T08:11:21.000000000Z",
+                      "end_timestamp": "2025-10-16T08:13:06.000000000Z",
+                      "duration": 105000,
+                      "total_requests": 669,
+                      "total_errors": 668,
+                      "error_rate": 99.85052316890882,
+                      "avg_bandwidth": 0,
+                      "avg_throughput": 9.416666666666666,
+                      "min_response_time": 0,
+                      "max_response_time": 6127,
+                      "avg_response_time": 570.9144927998836,
+                      "avg_latency": 570.9144927998836,
+                      "ramp_time": 0,
+                      "users": 1
+                    }
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request error occurred while processing the request.",
+                  "example": {
+                    "error": "invalid 'type' query param (use: summary | requestStats | errorStats)",
+                    "status": "failed"
+                  },
+                  "type": null
+                },
+                "404": {
+                  "description": "No data found for the provided jobId.",
+                  "example": {
+                    "error": "job not found or not accessible by this organization",
+                    "status": "failed"
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Server-side error occurred while processing the request.",
+                  "example": {
+                    "error": "error getting summary",
+                    "status": "failed"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": true,
+                  "description": "Type of response data",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "object",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Fetch detailed request statistics for a performance test within a specific job.",
+              "method": "GET",
+              "path": "/v1.0/performance/requestStats/{jobId}",
+              "description": "This API retrieves detailed performance data for requests made during a test, including throughput, bandwidth, response times, and error counts, helping identify bottlenecks and analyze system performance under load.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "jobId",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter your HyperExecute JobID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Maximum number of records to return. Default value is 100"
+                },
+                {
+                  "name": "offset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Number of records to skip before starting to return. Default-0, Max - 10,000"
+                },
+                {
+                  "name": "sortBy",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Sort the records by a specific field."
+                },
+                {
+                  "name": "order",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Sort order for the records."
+                },
+                {
+                  "name": "timeRange",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Time range for filtering records in the format \"startTimestamp,endTimestamp\" (e.g., 2023-01-01T00:00:00,2023-02-01T00:00:00)."
+                },
+                {
+                  "name": "timeZone",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Time zone for filtering records. Must be in the format [+/-]HH:mm. Required when timeRange is provided. Example: +05:30"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "type": "requestStats",
+                    "data": [
+                      {
+                        "label": "HTTP: This is label",
+                        "avg_throughput": 1.9142857142857144,
+                        "avg_bandwidth": 194.6,
+                        "#samples": 134,
+                        "start_timestamp": "2025-10-16T08:12:11.104000000Z",
+                        "end_timestamp": "2025-10-16T08:13:03.044000000Z",
+                        "response_time_stats": {
+                          "min": 64,
+                          "max": 284,
+                          "avg": 88.82213047398498
+                        },
+                        "response_time_percentiles": {
+                          "50.0": 0,
+                          "90.0": 105.13636363636364,
+                          "95.0": 116.34090909090911,
+                          "99.0": 169.53090909090895
+                        },
+                        "error_count": 134,
+                        "latency_stats": {
+                          "min": 64,
+                          "max": 284,
+                          "avg": 85.65517241379311
+                        },
+                        "duration": 51940,
+                        "error_rate_in_current_sample": 100,
+                        "error_rate_in_all_samples": 20.029895366218238
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request error occurred while processing the request.",
+                  "example": {
+                    "error": "invalid 'limit' query param: must be a positive integer",
+                    "status": "failed"
+                  },
+                  "type": null
+                },
+                "404": {
+                  "description": "Job not found or not accessible",
+                  "example": {
+                    "error": "job not found or not accessible by this organization",
+                    "status": "failed"
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Server-side error occurred while processing the request.",
+                  "example": {
+                    "error": "error getting request stats",
+                    "status": "failed"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": true,
+                  "description": "Type of response data",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Fetch detailed error statistics for a performance test within a specific job.",
+              "method": "GET",
+              "path": "/v1.0/performance/errorStatsByLabel/{jobId}",
+              "description": "This API retrieves detailed error statistics for requests made during a test, including error counts, error rates, and response times, helping identify bottlenecks and analyze system performance under load.",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "jobId",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Enter your HyperExecute JobID"
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "limit",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Maximum number of records to return. Default value is 100"
+                },
+                {
+                  "name": "offset",
+                  "type": "integer",
+                  "in": "query",
+                  "required": false,
+                  "description": "Number of records to skip before starting to return. Default-0, Max - 10,000"
+                },
+                {
+                  "name": "sortBy",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Sort the records by a specific field."
+                },
+                {
+                  "name": "order",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Sort order for the records. Default is ascending."
+                },
+                {
+                  "name": "timeRange",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Time range for filtering records in the format \"startTimestamp,endTimestamp\" (e.g., 2023-01-01T00:00:00,2023-02-01T00:00:00)."
+                },
+                {
+                  "name": "timeZone",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "Time zone for filtering records. Must be in the format [+/-]HH:mm. Required when timeRange is provided. Example: +05:30"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Successful operation",
+                  "example": {
+                    "type": "errorStats",
+                    "data": [
+                      {
+                        "label": "HTTP:1 - This is label",
+                        "response_code": "404",
+                        "error_count": 134,
+                        "error_rate_in_current_sample": 100,
+                        "error_rate_in_all_samples": 20.029895366218238
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Bad request error occurred while processing the request.",
+                  "example": {
+                    "error": "invalid 'type' query param (use: summary | requestStats | errorStats)",
+                    "status": "failed"
+                  },
+                  "type": null
+                },
+                "404": {
+                  "description": "Job not found or not accessible",
+                  "example": {
+                    "error": "job not found or not accessible by this organization",
+                    "status": "failed"
+                  },
+                  "type": null
+                },
+                "500": {
+                  "description": "Server-side error occurred while processing the request.",
+                  "example": {
+                    "error": "error getting error stats",
+                    "status": "failed"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "type",
+                  "type": "string",
+                  "required": true,
+                  "description": "Type of response data",
+                  "hasChildren": false
+                },
+                {
+                  "name": "data",
+                  "type": "array",
+                  "required": true,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Audit logs",
+      "baseUrl": "https://audit-logs.lambdatest.com/",
+      "servers": [
+        {
+          "url": "https://audit-logs.lambdatest.com/"
+        },
+        {
+          "url": "https://eu-audit-logs.lambdatest.com/"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Audit logs",
+          "endpoints": [
+            {
+              "name": "Get Audit logs",
+              "method": "GET",
+              "path": "/api/logs",
+              "description": "Get Audit logs",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "queryParams": [
+                {
+                  "name": "limit",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "limit number of events"
+                },
+                {
+                  "name": "offset",
+                  "type": "string",
+                  "in": "query",
+                  "required": false,
+                  "description": "beginning index of result"
+                },
+                {
+                  "name": "start",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "Starting date"
+                },
+                {
+                  "name": "end",
+                  "type": "string",
+                  "in": "query",
+                  "required": true,
+                  "description": "End date"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "Success",
+                  "example": {
+                    "PageCount": 2,
+                    "Result": [
+                      {
+                        "activity_description": "Admin changed user's password",
+                        "activity_name": "Organization - User Password Changed",
+                        "changes": null,
+                        "email": "pawanr@lambdatest.com",
+                        "event": "org.user.password.changed",
+                        "event_id": "9fa69cb3-e102-4a25-80ce-d1aa1705288a",
+                        "event_time": "2023-11-07T12:16:47Z",
+                        "ip": "143.110.182.88",
+                        "metadata": null,
+                        "name": "pawan1235",
+                        "organization_name": "",
+                        "original": null,
+                        "target_identifier": {
+                          "email": "pawanr@lambdatest.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "User - Logged In",
+                        "activity_name": "User - Logged In",
+                        "changes": null,
+                        "email": "pawanr124@ltqa.lambdatestautomation.com",
+                        "event": "user.login",
+                        "event_id": "adb47d4c-1338-457a-b962-97595fa4c3e2",
+                        "event_time": "2023-11-07T08:28:26Z",
+                        "ip": "143.110.182.88",
+                        "metadata": null,
+                        "name": "Pawan Rai",
+                        "organization_name": "",
+                        "original": null,
+                        "target_identifier": {
+                          "email": "pawanr124@ltqa.lambdatestautomation.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "User - Logged In",
+                        "activity_name": "User - Logged In",
+                        "changes": null,
+                        "email": "pawanr124@ltqa.lambdatestautomation.com",
+                        "event": "user.login",
+                        "event_id": "0c2ef83a-e70d-4fc8-8a99-4e6164708097",
+                        "event_time": "2023-11-03T12:54:14Z",
+                        "ip": "14.97.133.26",
+                        "metadata": null,
+                        "name": "Pawan Rai",
+                        "organization_name": "",
+                        "original": null,
+                        "target_identifier": {
+                          "email": "pawanr124@ltqa.lambdatestautomation.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "User - Logged In",
+                        "activity_name": "User - Logged In",
+                        "changes": null,
+                        "email": "pawanr124@ltqa.lambdatestautomation.com",
+                        "event": "user.login",
+                        "event_id": "3ee12e5d-458a-481f-a473-44e298a06b0b",
+                        "event_time": "2023-11-03T11:49:30Z",
+                        "ip": "103.90.204.46",
+                        "metadata": null,
+                        "name": "Pawan Rai",
+                        "organization_name": "",
+                        "original": null,
+                        "target_identifier": {
+                          "email": "pawanr124@ltqa.lambdatestautomation.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "Admin updated user's role",
+                        "activity_name": "Organization - User Role Updated",
+                        "changes": {
+                          "organization_role": "User"
+                        },
+                        "email": "pawanr@lambdatest.com",
+                        "event": "org.user.role.updated",
+                        "event_id": "33b3a96a-9f1d-4f39-be31-ded45a4872d6",
+                        "event_time": "2023-11-03T11:49:08Z",
+                        "ip": "103.90.204.46",
+                        "metadata": null,
+                        "name": "pawan1235",
+                        "organization_name": "",
+                        "original": {
+                          "organization_role": "Admin"
+                        },
+                        "target_identifier": {
+                          "email": "pawanr124@ltqa.lambdatestautomation.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "User - Logged In",
+                        "activity_name": "User - Logged In",
+                        "changes": null,
+                        "email": "pawanr124@ltqa.lambdatestautomation.com",
+                        "event": "user.login",
+                        "event_id": "c97da1fd-6fdb-477c-870d-6847a7566675",
+                        "event_time": "2023-11-03T11:48:31Z",
+                        "ip": "103.90.204.46",
+                        "metadata": null,
+                        "name": "Pawan Rai",
+                        "organization_name": "",
+                        "original": null,
+                        "target_identifier": {
+                          "email": "pawanr124@ltqa.lambdatestautomation.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "Invitation was accepted",
+                        "activity_name": "Organization - Invitation Accepted",
+                        "changes": null,
+                        "email": "pawanr124@ltqa.lambdatestautomation.com",
+                        "event": "org.invitation.accepted",
+                        "event_id": "00f1d32b-bd9e-4c1c-9824-47a31fe3ddeb",
+                        "event_time": "2023-11-03T11:48:03Z",
+                        "ip": "103.90.204.46",
+                        "metadata": null,
+                        "name": "Pawan Rai",
+                        "organization_name": "",
+                        "original": null,
+                        "target_identifier": {
+                          "email": "pawanr124@ltqa.lambdatestautomation.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "User - Logged In",
+                        "activity_name": "User - Logged In",
+                        "changes": null,
+                        "email": "pawanr124@ltqa.lambdatestautomation.com",
+                        "event": "user.login",
+                        "event_id": "e7a71f57-9377-4716-b488-1fc3018ba2fc",
+                        "event_time": "2023-11-03T11:48:03Z",
+                        "ip": "103.90.204.46",
+                        "metadata": null,
+                        "name": "Pawan Rai",
+                        "organization_name": "",
+                        "original": null,
+                        "target_identifier": {
+                          "email": "pawanr124@ltqa.lambdatestautomation.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "Admin invited users to their organization",
+                        "activity_name": "Organization - Invitation Sent",
+                        "changes": null,
+                        "email": "pawanr@lambdatest.com",
+                        "event": "org.invitation.sent",
+                        "event_id": "4f764665-8aaa-472d-a840-2b5b6dbc6d57",
+                        "event_time": "2023-11-03T11:47:18Z",
+                        "ip": "103.90.204.46",
+                        "metadata": null,
+                        "name": "pawan1235",
+                        "organization_name": "",
+                        "original": null,
+                        "target_identifier": {
+                          "email": "pawanr124@ltqa.lambdatestautomation.com",
+                          "role": "Admin"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "User updated their email preferenece",
+                        "activity_name": "User - Email Preference Updated",
+                        "changes": {
+                          "automation": true,
+                          "event": true,
+                          "feedback": true,
+                          "maintenance": true,
+                          "marketing": true,
+                          "newsletter": true,
+                          "offer": true,
+                          "product": true,
+                          "product_onboarding": true,
+                          "report": true,
+                          "weekly": true
+                        },
+                        "email": "pawanr@lambdatest.com",
+                        "event": "user.email-preference.updated",
+                        "event_id": "085b3823-5df2-482f-9026-0ecd7f9eb967",
+                        "event_time": "2023-10-26T08:38:27Z",
+                        "ip": "143.110.182.88",
+                        "metadata": null,
+                        "name": "pawan1235",
+                        "organization_name": "",
+                        "original": {
+                          "automation": true,
+                          "event": true,
+                          "feedback": true,
+                          "maintenance": true,
+                          "marketing": true,
+                          "newsletter": true,
+                          "offer": true,
+                          "product": true,
+                          "product_onboarding": true,
+                          "report": true,
+                          "weekly": true
+                        },
+                        "target_identifier": {
+                          "email": "pawanr@lambdatest.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "User updated their email preferenece",
+                        "activity_name": "User - Email Preference Updated",
+                        "changes": {
+                          "automation": true,
+                          "event": true,
+                          "feedback": true,
+                          "maintenance": true,
+                          "marketing": true,
+                          "newsletter": true,
+                          "offer": true,
+                          "product": true,
+                          "product_onboarding": true,
+                          "report": true,
+                          "weekly": true
+                        },
+                        "email": "pawanr@lambdatest.com",
+                        "event": "user.email-preference.updated",
+                        "event_id": "7bcb8eb0-b5f6-4c38-aee1-04ab643dd8a7",
+                        "event_time": "2023-10-26T08:38:19Z",
+                        "ip": "143.110.182.88",
+                        "metadata": null,
+                        "name": "pawan1235",
+                        "organization_name": "",
+                        "original": {
+                          "automation": false,
+                          "event": true,
+                          "feedback": true,
+                          "maintenance": true,
+                          "marketing": false,
+                          "newsletter": true,
+                          "offer": true,
+                          "product": true,
+                          "product_onboarding": true,
+                          "report": true,
+                          "weekly": true
+                        },
+                        "target_identifier": {
+                          "email": "pawanr@lambdatest.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      },
+                      {
+                        "activity_description": "User updated their email preferenece",
+                        "activity_name": "User - Email Preference Updated",
+                        "changes": {
+                          "marketing": false
+                        },
+                        "email": "pawanr@lambdatest.com",
+                        "event": "user.email-preference.updated",
+                        "event_id": "3108990a-9c21-4b7c-b4f2-ca32321b8015",
+                        "event_time": "2023-10-26T08:38:18Z",
+                        "ip": "143.110.182.88",
+                        "metadata": null,
+                        "name": "pawan1235",
+                        "organization_name": "",
+                        "original": {
+                          "marketing": true
+                        },
+                        "target_identifier": {
+                          "email": "pawanr@lambdatest.com"
+                        },
+                        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36"
+                      }
+                    ]
+                  },
+                  "type": null
+                },
+                "400": {
+                  "description": "Invalid date / Invalid limit",
+                  "example": {
+                    "message": "Invalid End Date",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "PageCount",
+                  "type": "number",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "Result",
+                  "type": "array",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                }
+              ]
+            },
+            {
+              "name": "Get Logs by event ID",
+              "method": "GET",
+              "path": "/api/logs/{event_id}",
+              "description": "Get Audit logs",
+              "auth": [
+                {
+                  "name": "Authorization",
+                  "type": "string",
+                  "in": "header",
+                  "required": true,
+                  "description": "Basic authentication header of the form `Basic <encoded-value>`, where `<encoded-value>` is the base64-encoded string `username:password`."
+                }
+              ],
+              "pathParams": [
+                {
+                  "name": "event_id",
+                  "type": "string",
+                  "in": "path",
+                  "required": true,
+                  "description": "Event id of logs"
+                }
+              ],
+              "responses": {
+                "200": {
+                  "description": "success",
+                  "example": {
+                    "activity_description": "User updated their email preferenece",
+                    "activity_name": "User - Email Preference Updated",
+                    "changes": {
+                      "marketing": false
+                    },
+                    "email": "pawanr@lambdatest.com",
+                    "event": "user.email-preference.updated",
+                    "event_id": "3108990a-9c21-4b7c-b4f2-ca32321b8015",
+                    "event_time": "2023-10-26T08:38:18Z",
+                    "ip": "143.110.182.88",
+                    "metadata": null,
+                    "name": "pawan1235",
+                    "organization_name": "",
+                    "original": {
+                      "marketing": true
+                    },
+                    "target_identifier": {
+                      "email": "pawanr@lambdatest.com"
+                    },
+                    "user_agent": "Mozilla/5.0(Macintosh;IntelMacOSX10_15_7)AppleWebKit/537.36(KHTML,likeGecko)Chrome/106.0.0.0Safari/537.36"
+                  },
+                  "type": null
+                },
+                "422": {
+                  "description": "Invalid event",
+                  "example": {
+                    "message": "Invalid Event ID",
+                    "title": "Bad Request Error",
+                    "type": "error"
+                  },
+                  "type": null
+                }
+              },
+              "responseSchema": [
+                {
+                  "name": "activity_description",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "activity_name",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "changes",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "email",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "event",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "event_id",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "event_time",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "ip",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "metadata",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "organization_name",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                },
+                {
+                  "name": "original",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "target_identifier",
+                  "type": "object",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": true
+                },
+                {
+                  "name": "user_agent",
+                  "type": "string",
+                  "required": false,
+                  "description": "",
+                  "hasChildren": false
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Regenerated `all-apis.json` from latest OpenAPI specs to include new download app endpoints.

### New endpoints added

- `GET /app/{appId}/download` - Download App by ID (Server 1)
- `GET /app/custom_id/{customId}/download` - Download App by Custom ID (Server 1)

### Source

YAML deployed from: https://github.com/LambdatestIncPrivate/real-mobile-apis-automation/pull/2136

## Test plan

- [ ] Verify new endpoints appear under "App Automation API (Real Devices)" > "Application (Appium)"
- [ ] Check endpoint details render correctly (path params, responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)