### PR TITLE
chore(ci): swap notify dispatch token to GitHub App token

### DIFF
--- a/.github/workflows/documentation-notify.yml
+++ b/.github/workflows/documentation-notify.yml
@@ -72,10 +72,20 @@ jobs:
           echo "Mapped products: $PRODUCTS"
           echo "list=$PRODUCTS" >> "$GITHUB_OUTPUT"
 
+      - name: Generate GitHub App Token
+        uses: LambdatestIncPrivate/create_github_app_token@v1
+        id: token
+        with:
+          app-id: ${{ vars.LT_USER_ACCESS_TOKEN_APP_ID }}
+          private-key: ${{ secrets.LT_USER_ACCESS_TOKEN_PRIVATE_KEY }}
+          installation-id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          repositories: "product-context"
+          permissions: "write"
+
       - name: Dispatch to product-context
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.PRODUCT_CONTEXT_DISPATCH_TOKEN }}
+          token: ${{ steps.token.outputs.token }}
           repository: LambdatestIncPrivate/product-context
           event-type: documentation-updated
           client-payload: |


### PR DESCRIPTION
Replaces the static PAT (`PRODUCT_CONTEXT_DISPATCH_TOKEN`) with a runtime-generated GitHub App token via `LambdatestIncPrivate/create_github_app_token@v1`. No other changes.