### PR TITLE
docs(playwright-ios): update supported version to v1.6.0 and remove em dashes

### DIFF
--- a/docs/playwright-ios-guide.md
+++ b/docs/playwright-ios-guide.md
@@ -61,8 +61,8 @@ Playwright testing on real iOS devices is currently in **Beta**. To enable this 
 :::
 
 :::tip Supported Versions
-- Playwright versions **v1.53.0** and above (until **v1.57.0**) are supported for iOS real device testing.
-- All languages use the **stock Playwright packages** — no custom forks or client-side changes required.
+- Playwright versions **v1.53.0** and above (until **v1.6.0**) are supported for iOS real device testing.
+- All languages use the **stock Playwright packages**, with no custom forks or client-side changes required.
 - Playwright v1.53.0 is currently supported for Playwright C# (for Android & iOS).
 :::
 
@@ -443,7 +443,7 @@ The below screenshot of <BrandName /> Automation Dashboard shows the Playwright 
 
 :::note
 
-- Safari is the supported browser for iOS real device testing. All four languages — **Node.js, Java, C#, and Python** — are supported using stock Playwright packages.
+- Safari is the supported browser for iOS real device testing. All four languages (**Node.js, Java, C#, and Python**) are supported using stock Playwright packages.
 
 - Playwright testing on real iOS devices is currently supported on latest iOS versions (iOS 17, iOS 18, and iOS 26) across both iPhones and iPads.
 


### PR DESCRIPTION
## What
- Update the Playwright iOS real device guide (`docs/playwright-ios-guide.md`):
  - Supported Playwright version ceiling changed from **v1.57.0** → **v1.6.0**.
  - Removed em dashes (—), replacing them with standard punctuation.

## Files
- `docs/playwright-ios-guide.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)