### PR TITLE
docs(smartui-hooks): align formatting, remove red admonition and em dashes

### DIFF
--- a/docs/smartui-hooks-layout-fullpage-smartignore.md
+++ b/docs/smartui-hooks-layout-fullpage-smartignore.md
@@ -2,7 +2,7 @@
 id: smartui-hooks-layout-fullpage-smartignore
 title: SmartUI Hooks - Layout, Full Page, and Smart Ignore
 sidebar_label: Hooks Layout + Full Page
-description: SmartUI Hooks on LambdaTest—layout comparison via screenshot hook options, Smart Ignore via smartUI.smartIgnore in LT:Options, and full-page capture.
+description: SmartUI Hooks on LambdaTest covering layout comparison via screenshot hook options, Smart Ignore via smartUI.smartIgnore in LT:Options, and full-page capture.
 keywords:
   - smartui hooks
   - layout testing hooks
@@ -16,24 +16,50 @@ slug: smartui-hooks-layout-fullpage-smartignore/
 canonical: https://www.testmuai.com/support/docs/smartui-hooks-layout-fullpage-smartignore/
 ---
 
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "TestMu AI",
+          "item": BRAND_URL
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": `${BRAND_URL}/support/docs/`
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "SmartUI Hooks: Layout, Full-Page Screenshots, and Smart Ignore",
+          "item": `${BRAND_URL}/support/docs/smartui-hooks-layout-fullpage-smartignore/`
+        }]
+      })
+    }}
+></script>
+
 # SmartUI Hooks: Layout, Full-Page Screenshots, and Smart Ignore
 
 Use this page when you run **SmartUI Hooks** on LambdaTest (for example Selenium `executeScript` without the `smartui exec` CLI wrapper) and need **layout** comparison, **full-page** capture, or **Smart Ignore**.
 
-:::danger Capability vs hook—read this first
+:::info Capability vs hook, read this first
 For **Hooks**, engineering behavior is:
 
 | Goal | Where to configure | Notes |
 |------|-------------------|--------|
-| **Layout** comparison | **`smartui.takeScreenshot` hook options** (per screenshot) | Pass `ignoreType: ["layout"]` (and related layout flags) in the **Map/object** passed to `executeScript("smartui.takeScreenshot", options)`. **Layout is not enabled for Hooks by setting layout fields only in `LT:Options` capabilities**—that path is not supported the way teams often expect. |
+| **Layout** comparison | **`smartui.takeScreenshot` hook options** (per screenshot) | Pass `ignoreType: ["layout"]` (and related layout flags) in the **Map/object** passed to `executeScript("smartui.takeScreenshot", options)`. **Layout is not enabled for Hooks by setting layout fields only in `LT:Options` capabilities**. That path is not supported the way teams often expect. |
 | **Smart Ignore** | **`LT:Options`** | Set **`smartUI.smartIgnore`: `true`** on the session for baseline and comparison runs. |
 | **Project** | **`LT:Options`** | Set **`smartUI.project`** (and `visual`, auth) as usual. |
 
-If you need **layout via capabilities alone** (no hook options), treat that as a **product / roadmap** ask—track with your account team (for example internal idea **LTPM-3632**). This doc reflects **current** Hooks behavior.
+If you need **layout via capabilities alone** (no hook options), treat that as a **product / roadmap** ask, and track it with your account team (for example internal idea **LTPM-3632**). This doc reflects **current** Hooks behavior.
 :::
 
 :::info Smart Ignore vs Ignore DOM / Select DOM
-With **Smart Ignore**, use either **Ignore DOM** or **Select DOM** in the dashboard where applicable—not both on the same flow.
+With **Smart Ignore**, use either **Ignore DOM** or **Select DOM** in the dashboard where applicable, not both on the same flow.
 :::
 
 ## 1. Session capabilities (`LT:Options`)
@@ -90,13 +116,13 @@ These patterns **do not** turn on Smart Ignore reliably:
 Use **`smartUI.smartIgnore`: `true`** only.
 :::
 
-### Layout — not via standalone layout capabilities for Hooks
+### Layout: not via standalone layout capabilities for Hooks
 
 Do **not** expect **`ignoreType: ["layout"]`**, **`smartUI.layout`**, or nested **`smartUI.options`** layout blocks **alone** in `LT:Options` to enable layout comparison for Hooks. Validated behavior is: **pass layout in the hook** (next section).
 
 ---
 
-## 2. Layout comparison — pass options to `smartui.takeScreenshot`
+## 2. Layout comparison: pass options to `smartui.takeScreenshot`
 
 Pass a **single map** to `executeScript("smartui.takeScreenshot", options)` including **`screenshotName`** and **`ignoreType`**.
 
@@ -115,7 +141,7 @@ options.put("screenshotName", "my-layout-screenshot-01");
 ((JavascriptExecutor) driver).executeScript("smartui.takeScreenshot", options);
 ```
 
-Session **`LT:Options`** for this flow typically needs at least **`smartUI.project`** (and `visual`, credentials)—**not** a separate layout capability block for the same effect.
+Session **`LT:Options`** for this flow typically needs at least **`smartUI.project`** (and `visual`, credentials), **not** a separate layout capability block for the same effect.
 
 ### JavaScript
 
@@ -176,7 +202,7 @@ Runs using a **project token** may show the **project creator**. Use the intende
 
 ---
 
-## 6. Troubleshooting
+## 7. Troubleshooting
 
 | Problem | What to do |
 |--------|------------|
@@ -187,7 +213,7 @@ Runs using a **project token** may show the **project creator**. Use the intende
 
 ## Related Docs
 
-- [Layout Comparison in SmartUI SDK](/support/docs/smartui-layout-testing/) — SDK `smartuiSnapshot` path (different from Hooks).
+- [Layout Comparison in SmartUI SDK](/support/docs/smartui-layout-testing/) (SDK `smartuiSnapshot` path, different from Hooks).
 - [Smart Ignore](/support/docs/smartui-smartignore/)
 - [SmartUI SDK Config Options](/support/docs/smartui-sdk-config-options/)
 - [Troubleshooting Guide](/support/docs/smartui-troubleshooting-guide/)

--- a/docs/smartui-hooks-layout-fullpage-smartignore.md
+++ b/docs/smartui-hooks-layout-fullpage-smartignore.md
@@ -55,7 +55,7 @@ For **Hooks**, engineering behavior is:
 | **Smart Ignore** | **`LT:Options`** | Set **`smartUI.smartIgnore`: `true`** on the session for baseline and comparison runs. |
 | **Project** | **`LT:Options`** | Set **`smartUI.project`** (and `visual`, auth) as usual. |
 
-If you need **layout via capabilities alone** (no hook options), treat that as a **product / roadmap** ask, and track it with your account team (for example internal idea **LTPM-3632**). This doc reflects **current** Hooks behavior.
+If you need **layout via capabilities alone** (no hook options), treat that as a feature request and raise it with your account team. This doc reflects **current** Hooks behavior.
 :::
 
 :::info Smart Ignore vs Ignore DOM / Select DOM
@@ -209,7 +209,7 @@ Runs using a **project token** may show the **project creator**. Use the intende
 | Layout never activates; only tried `LT:Options` | Move **`ignoreType: ["layout"]`** into **`smartui.takeScreenshot`** options (§2). |
 | Smart Ignore never activates | Set **`smartUI.smartIgnore`: true** in **`LT:Options`**; verify in session metadata. |
 | Tried `smartUI.layout` | Not the supported Hooks switch for layout; use hook **options** instead. |
-| Prospect cannot use dashboard toggles only | Hooks still need correct **hook** + **capability** split per this page. |
+| Want to rely on dashboard toggles only | Hooks still need the correct **hook** + **capability** split per this page. |
 
 ## Related Docs
 


### PR DESCRIPTION
## What
Updates `docs/smartui-hooks-layout-fullpage-smartignore.md` to match current documentation formatting, remove the red table styling, and remove em dashes.

### Changes
- **Formatting alignment:** added the standard `BrandName` import + `BreadcrumbList` JSON-LD schema (consistent with sibling SmartUI Hooks docs); fixed a duplicate `## 6.` heading so sections run 1→7.
- **Removed red from the table:** the capability-vs-hook table was inside a red `:::danger` admonition; converted to a neutral `:::info`. (The remaining `:::warning` is an orange "do not use" anti-pattern callout, intentionally kept.)
- **Removed em dashes:** 9 → 0, replaced with standard punctuation (colons in headings, commas/periods in prose, parentheses in Related Docs).

### Syntax verification (LTPM-3632 / TE-13439)
- **Layout (LTPM-3632):** doc continues to document layout as **screenshot-level only** via `ignoreType: ["layout"]` passed to `smartui.takeScreenshot`, and keeps capability-level `smartUI.layout` flagged as **roadmap/unsupported** for Hooks. No unsupported capability syntax is presented as working.
- **Region ignore (TE-13439):** no claim added that `ignoreDOM.coordinates` works on Web Hooks (only the dashboard Ignore/Select DOM UI is referenced, which is supported).

No functional/code-sample content changed — formatting and copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)