### PR TITLE
docs(kane-cli): remove syntax row from Variables format table

### DIFF
--- a/docs/kane-cli-variables-and-context.md
+++ b/docs/kane-cli-variables-and-context.md
@@ -65,7 +65,6 @@ Variables are JSON objects keyed by name. Each entry describes a single variable
 |-------|----------|------|---------|-------------|
 | `value` | Yes | string | — | The variable's value. Entries without `value` are ignored. |
 | `secret` | No | boolean | `false` | When `true`, the value is masked in logs and routed to the <BrandName /> secrets store instead of being synced as plain Test Manager variables. |
-| `syntax` | No | string | `{{<name>}}` | Custom placeholder syntax. Defaults to the double-brace form using the variable name. |
 
 ### Usage in Objectives
 


### PR DESCRIPTION
## What

Removes the `syntax` row from the **Variables format** table on the [Variables & Context](https://www.testmuai.com/support/docs/kane-cli-variables-and-context/) page (Kane CLI docs).

The removed row:

> \| `syntax` \| No \| string \| `{{<name>}}` \| Custom placeholder syntax. Defaults to the double-brace form using the variable name. \|

The `syntax` field is not a supported variable property, so it should not be documented as one.

## Scope

- One-line deletion in `docs/kane-cli-variables-and-context.md`.
- The `value` and `secret` rows are unchanged; the rest of the page is untouched.
- No link, frontmatter, or sidebar changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)