### PR TITLE
docs(smartui): region-ignore validation fixes + drop webElement mode (follow-up to #3165)

### DIFF
--- a/docs/smartui-hooks-region-ignore.md
+++ b/docs/smartui-hooks-region-ignore.md
@@ -277,14 +277,14 @@ config["ignoreDOM"] = {
 
 ## Validation and errors
 
-Coordinates are validated at two levels:
+Coordinates are validated at two levels — note that only the **format** check happens on the hooks ingestion path; **page-bounds** elimination is a downstream comparison-engine behaviour, not part of the hooks request validation:
 
-| Level | Checks | On failure |
-|-------|--------|------------|
-| Format | Exactly four numeric components, all non-negative, `top < bottom`, `left < right`. | The `smartui.takeScreenshot` call returns a clear error and the screenshot is not taken. |
-| Page bounds | The rectangle lies inside the rendered page / viewport. | An out-of-page rectangle is dropped with a warning; it simply produces no ignore/select box. |
+| Level | Where | Checks | On failure |
+|-------|-------|--------|------------|
+| Format | Hooks ingestion | A `coordinates` entry must parse to **exactly four numeric components**, all **non-negative**, with `left < right` and `top < bottom`. | The `smartui.takeScreenshot` call returns a clear `400` error and the screenshot is **not taken** at all (the whole call is rejected, not just the one region). |
+| Page bounds | Downstream (comparison engine) | The rectangle lies inside the rendered page / viewport. | A rectangle that falls outside the page is handled downstream — it simply produces no ignore/select box. This elimination is performed by the comparison engine, not by the hooks request validation. |
 
-`WebElement` regions are not coordinate-validated; if the element cannot be resolved it yields no box.
+`WebElement` regions are not coordinate-validated; if the element cannot be resolved it yields no box. The element handle is read from the standard W3C `webElement` key, with a legacy `ELEMENT` key accepted as a fallback.
 
 ## Notes
 


### PR DESCRIPTION
Follow-up corrections to #3165, verified against HPS code on `main`.

### Changes
1. **Drop the `webElement` region mode from the public doc.** `webElement` was an additional add-on that we are not shipping in docs yet. Removed it entirely — title, description, keywords, the dedicated "Ignore a region by WebElement" section, the `selectDOM` / combine examples, the behaviour-summary row, and the notes — leaving only **coordinates** and **DOM selectors** (`cssSelector` / `id` / `class` / `xpath`). Sections renumbered. It can be added back once we pick the feature up again.
2. **Format vs page-bounds attribution.** HPS validates only the coordinate **format** on the hooks ingestion path (exactly four non-negative numbers with `left < right` and `top < bottom`; on failure a `400` is returned and the whole `smartui.takeScreenshot` call is rejected). The "out-of-page rectangle dropped with a warning → no box" behaviour is **not** an HPS behaviour — geometry / page-bounds elimination happens **downstream** in the comparison engine. Reworded the validation table so that row is no longer attributed to hooks request validation.

> Note on the earlier "not in prod yet" remark about `ignoreDOM`: that is outdated — `ignoreDOM` is live in prod (rolled out 100%, feature flag dropped). The separate `smartUI.ignoreRegions` correction (it is the per-call `ignoreDOM` arg, not a capability) is handled in #3166.