### PR TITLE
docs(kane-cli): sync public docs with GitHub source of truth

### DIFF
--- a/docs/kane-cli-api-calls.md
+++ b/docs/kane-cli-api-calls.md
@@ -1,0 +1,98 @@
+---
+id: kane-cli-api-calls
+title: API Calls
+sidebar_label: API Calls
+description: "Have the Kane CLI agent make HTTP API calls directly inside an objective to seed data, hit a backend, then assert on or reuse the response."
+keywords:
+  - api calls
+  - kane cli
+  - http request
+  - seed data
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-api-calls/
+site_name: TestMu AI
+slug: kane-cli-api-calls/
+canonical: https://www.testmuai.com/support/docs/kane-cli-api-calls/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "API Calls",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-api-calls/"
+        }]
+      }) }}
+></script>
+
+Objectives can have the agent **make an API call directly** — not just observe the requests a page makes. This is useful for seeding data before a flow, hitting a backend to set up state, or checking a service, then asserting on or reusing the response.
+
+## Making a call
+
+Phrase an explicit HTTP request and name its response with "save the response as …":
+
+```
+Call POST https://api.example.com/orders with body {"item": "sku_42", "qty": 1}, save the response as order
+Hit GET https://api.example.com/orders/123, save the response as fetched
+Call DELETE https://api.example.com/orders/123
+```
+
+A pasted `curl` works too and is kept exactly as written — method, headers, body, and auth:
+
+```
+curl -X POST https://api.example.com/login -H 'Content-Type: application/json' -d '{"u":"a","p":"b"}', save the response as login
+```
+
+## Using the response
+
+Once you've saved a response under a name, reference it elsewhere in the objective:
+
+| Reference | Resolves to |
+|-----------|-------------|
+| `{{order.status}}` | the HTTP status code (e.g. `201`) |
+| `{{order.response_body}}` | the whole response body |
+| `{{order.response_body.<field>}}` | a field from the JSON response body |
+
+Assert on it, or feed it into later actions — API calls and browser actions mix freely in one objective:
+
+```
+Call POST https://api.example.com/login with body {"u": "{{user}}", "p": "{{password}}"}, save the response as login,
+assert {{login.status}} is 200,
+then open https://app.example.com and verify the dashboard loads
+```
+
+```
+Call POST https://api.example.com/orders with body {"item": "sku_42", "qty": 1}, save the response as order,
+assert {{order.status}} is 201,
+then open https://app.example.com/orders and verify an order for "sku_42" is visible
+```
+
+## Tokens and secrets
+
+Put any API token or credential in a variable marked `secret: true` (see [Variables and Context](/support/docs/kane-cli-variables-and-context/)) so it is masked in logs and never stored in plain text:
+
+```
+curl -X DELETE https://api.example.com/records/42 -H "Authorization: Bearer {{api_token}}"
+```
+
+## Make a call vs. observe page traffic
+
+These are two different things:
+
+- **Make a call (this page)** — *you* tell the agent to send a request: seed a record, call a backend, set up state.
+- **[Network assertions](/support/docs/kane-cli-checkpoint-devtools-network/)** — *observe* the requests the page itself makes during a UI flow (status codes, bodies, timing).
+
+They compose: seed state with a direct call, drive the UI, then assert on the page's own network traffic.

--- a/docs/kane-cli-browser-state.md
+++ b/docs/kane-cli-browser-state.md
@@ -1,0 +1,92 @@
+---
+id: kane-cli-browser-state
+title: Browser State Actions
+sidebar_label: Browser State
+description: "Set cookies, localStorage, and the clipboard directly from a Kane CLI objective to seed state before a flow or test copy and paste behavior."
+keywords:
+  - browser state
+  - set cookies
+  - localstorage
+  - clipboard
+  - kane cli
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-browser-state/
+site_name: TestMu AI
+slug: kane-cli-browser-state/
+canonical: https://www.testmuai.com/support/docs/kane-cli-browser-state/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Browser State Actions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-browser-state/"
+        }]
+      }) }}
+></script>
+
+Objectives can directly manage cookies, localStorage, and the clipboard — useful for seeding state before a flow (skip a login, dismiss a consent banner) and for testing copy/paste behavior.
+
+## Cookies
+
+```
+Set a cookie named session with value abc123
+Set cookies consent=yes and tracking=off, then reload the page
+Delete the consent cookie
+Clear all cookies
+```
+
+- Values accept `{{variables}}`: `set a cookie named session with value {{auth_token}}`
+- A cookie without an explicit domain applies to the **current page's site** — navigate first
+- Reload or navigate after setting if the page must pick the cookie up
+- Provide `path` together with a domain; a path alone is rejected by the browser
+
+## localStorage
+
+```
+Set localStorage keys theme=dark and lang=en
+Delete the lang key from localStorage
+Clear localStorage
+```
+
+- Storage is **per-site** — navigate to the target site before setting
+- Reload after setting if the app only reads storage on page load
+- Values accept `{{variables}}`
+
+## Clipboard
+
+The run uses an **isolated test clipboard** — your real OS clipboard is never read or written. Site Copy buttons are captured into it automatically.
+
+```
+Write "John Tester" to the clipboard
+Click the message field, then paste from the clipboard
+Clear the clipboard
+```
+
+- **Paste targets the focused field** — click or focus the field first, then paste (`Ctrl/Cmd+V` in an objective works the same way)
+- Text and images both paste; rich editors receive a real paste event
+- Typical flows: *write → click field → paste*, or *click the site's Copy button → click field → paste*
+
+## Verifying state
+
+Each of these has a matching assertion family — see [Cookies](/support/docs/kane-cli-checkpoint-devtools-cookies/), [localStorage](/support/docs/kane-cli-checkpoint-devtools-localstorage/), and [Clipboard](/support/docs/kane-cli-checkpoint-devtools-clipboard/):
+
+```
+Set a cookie named session with value abc123, reload, and verify the page shows you as logged in
+Set localStorage theme=dark, reload, and verify the dark theme is active
+Click the Copy link button, then verify the clipboard contains "/invoice/42"
+```

--- a/docs/kane-cli-checkpoint-devtools-clipboard.md
+++ b/docs/kane-cli-checkpoint-devtools-clipboard.md
@@ -1,0 +1,99 @@
+---
+id: kane-cli-checkpoint-devtools-clipboard
+title: Clipboard Assertions
+sidebar_label: Clipboard
+description: "Verify what a Copy button actually copied, extract copied values into variables, and confirm clipboard state, using an isolated test clipboard."
+keywords:
+  - clipboard assertion
+  - copy button
+  - kane cli
+  - devtools
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-clipboard/
+site_name: TestMu AI
+slug: kane-cli-checkpoint-devtools-clipboard/
+canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-clipboard/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Clipboard Assertions",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-clipboard/"
+        }]
+      }) }}
+></script>
+
+Clipboard assertions let you verify what a "Copy" button actually copied, extract copied values into variables, and confirm clipboard state after your test writes or clears it.
+
+## The Test Clipboard
+
+Every run uses an **isolated test clipboard**:
+
+- **Your real clipboard is safe**: the OS clipboard is never read and never written — tests can't leak your copied data into results, and nothing you copy mid-run interferes with the test
+- **Automatic capture**: when the page copies something (a Copy button, Ctrl/Cmd+C on a selection), it lands in the test clipboard
+- **One current entry**: like a real clipboard, every copy or clipboard write **replaces** the previous content
+- **Multi-format**: a single entry can carry plain text, HTML, and an image together (e.g. a "Copy image" button)
+- **Same behavior everywhere**: headless, headed, and CI runs all behave identically
+
+### Planning for Multi-Step Tests
+
+Because the clipboard holds one entry at a time:
+
+- Verify a copied value **immediately after** the copy or write that produced it — a later clipboard write/clear replaces it
+- To check several copies, interleave: copy A → verify → copy B → verify
+
+## What You Can Query
+
+| Query | Description |
+|-------|-------------|
+| text content | The plain-text content of the clipboard ("" when empty) |
+| HTML content | The rich-text representation, when present |
+| formats present | Which content types the entry carries (text, HTML, image) |
+| image presence/size | Whether an image was copied, and its byte size |
+
+## Example Assertions
+
+```
+Click the "Copy link" button, then verify the clipboard contains "/invoice/42"
+Verify the clipboard text is "INV-2026-042"
+Verify an image was copied to the clipboard
+Verify the clipboard text is empty
+```
+
+## Example Extractions
+
+```
+Click the Copy button, store the copied coupon code as 'coupon'
+Store the clipboard text as 'copied_link'
+```
+
+Stored values work like any other variable — fill `{{coupon}}` into a field later, or assert on it.
+
+## Writing and Pasting (actions)
+
+The clipboard isn't read-only — objectives can also drive it. See [Browser State Actions](/support/docs/kane-cli-browser-state/):
+
+```
+Write "John Tester" to the clipboard, click the message field, then paste from the clipboard
+```
+
+## Tips
+
+- **Don't paste to verify** — assert on the clipboard directly instead of pasting into a field and reading it back
+- **Prefer positive phrasing** for empties: "verify the clipboard text is empty" rather than "verify X is not on the clipboard"
+- Clipboard actions need a page loaded first — navigate before writing or pasting

--- a/docs/kane-cli-checkpoint-devtools.md
+++ b/docs/kane-cli-checkpoint-devtools.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-devtools
 title: DevTools Assertions
 sidebar_label: Overview
-description: "Verify data that is not visible on the page — HTTP network traffic, console output, performance metrics, cookies, and localStorage."
+description: "Verify data that is not visible on the page — HTTP network traffic, console output, performance metrics, cookies, localStorage, and clipboard."
 keywords:
   - devtools assertion
   - network
@@ -41,7 +41,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools/
       }) }}
 ></script>
 
-DevTools assertions let you verify data that isn't visible on the page — HTTP network traffic, browser console output, performance metrics, cookies, and localStorage. KaneAI captures this data automatically in the background; you just write what to check.
+DevTools assertions let you verify data that isn't visible on the page — HTTP network traffic, browser console output, performance metrics, cookies, localStorage, and clipboard. KaneAI captures this data automatically in the background; you just write what to check.
 
 ## Available Domains
 
@@ -52,6 +52,7 @@ DevTools assertions let you verify data that isn't visible on the page — HTTP 
 | [Performance](/support/docs/kane-cli-checkpoint-devtools-performance/) | Core Web Vitals | LCP, CLS, INP, FCP, TTFB |
 | [Cookies](/support/docs/kane-cli-checkpoint-devtools-cookies/) | Browser cookies | Names, values, flags (httpOnly, secure, sameSite) |
 | [localStorage](/support/docs/kane-cli-checkpoint-devtools-localstorage/) | Browser localStorage | Key-value pairs stored in the browser |
+| [Clipboard](/support/docs/kane-cli-checkpoint-devtools-clipboard/) | Browser clipboard | Copied text, HTML, image, and formats present |
 
 ## How It Works
 

--- a/docs/kane-cli-checkpoints.md
+++ b/docs/kane-cli-checkpoints.md
@@ -61,7 +61,7 @@ Each checkpoint uses an analyze method to determine *where* to look for the data
 | [Textual (DOM)](/support/docs/kane-cli-checkpoint-textual/) | Page DOM elements | Element states (disabled, checked), CSS properties, HTML attributes |
 | [URL](/support/docs/kane-cli-checkpoint-url/) | Browser URL bar | URL path, query params, redirects |
 | [Title](/support/docs/kane-cli-checkpoint-title/) | Page title | Document title verification |
-| [DevTools](/support/docs/kane-cli-checkpoint-devtools/) | Browser internals | Network traffic, console logs, performance, cookies, localStorage |
+| [DevTools](/support/docs/kane-cli-checkpoint-devtools/) | Browser internals | Network traffic, console logs, performance, cookies, localStorage, clipboard |
 
 ## How to Use
 
@@ -77,6 +77,7 @@ Assert: no console errors                      → DevTools (Console)
 Assert: page LCP is under 2500ms               → DevTools (Performance)
 Assert: session cookie exists                  → DevTools (Cookies)
 Assert: auth_token exists in localStorage      → DevTools (localStorage)
+Assert: the clipboard has the copied link      → DevTools (Clipboard)
 ```
 
 Extractions work the same way:
@@ -107,4 +108,4 @@ Assertions support these comparison operators:
 - [Textual (DOM) Assertions](/support/docs/kane-cli-checkpoint-textual/) — element states and attributes
 - [URL Assertions](/support/docs/kane-cli-checkpoint-url/) — URL-based checks
 - [Title Assertions](/support/docs/kane-cli-checkpoint-title/) — page title checks
-- [DevTools Assertions](/support/docs/kane-cli-checkpoint-devtools/) — network, console, performance, cookies, localStorage
+- [DevTools Assertions](/support/docs/kane-cli-checkpoint-devtools/) — network, console, performance, cookies, localStorage, clipboard

--- a/docs/kane-cli-configuration.md
+++ b/docs/kane-cli-configuration.md
@@ -95,7 +95,7 @@ Empty fields are shown as `(none)`. The `chrome` path is empty by default, in wh
 | `window_size.width` | integer | `1920` | Chrome window width in pixels (800–3840) | `kane-cli config set-window <WxH>` |
 | `window_size.height` | integer | `1080` | Chrome window height in pixels (600–2160) | `kane-cli config set-window <WxH>` |
 | `chrome_profile_path` | string | `""` | Path to a Chrome user-data dir. Empty means a fresh profile per run. | `kane-cli config chrome-profile [path]` |
-| `default_url` | string \| null | `https://kaneai-playground.lambdatest.io` | Starting URL when a run begins. | Internal default |
+| `default_url` | string \| null | `https://kaneai-playground.lambdatest.io` | Starting URL when a run begins. | `kane-cli config set-url <url>` |
 | `model` | string | `"v16-alpha"` | Reasoning + vision model used by the agent. | Internal default |
 | `project_id` | string \| null | `null` | <BrandName /> Test Manager project ID for upload | `kane-cli config project [id]` |
 | `project_name` | string \| null | `null` | Display name of the selected project | Set by `kane-cli config project` |

--- a/docs/kane-cli-error-codes.md
+++ b/docs/kane-cli-error-codes.md
@@ -297,7 +297,7 @@ An external obstacle on the target website prevented the agent from completing t
 ```bash
 kane-cli run "Log in and navigate to dashboard" \
   --url https://myapp.com/login \
-  --variables '{"username": {"value": "test@example.com"}, "password": {"value": "s3cret", "sensitive": true}}' \
+  --variables '{"username": {"value": "test@example.com"}, "password": {"value": "s3cret", "secret": true}}' \
   --agent
 ```
 

--- a/docs/kane-cli-generate.md
+++ b/docs/kane-cli-generate.md
@@ -51,7 +51,7 @@ A generation produces:
 You generate, review the result, **refine** it in plain language as many times as you like, and optionally **save** the functional cases as runnable `_test.md` files that [`kane-cli testmd`](/support/docs/kane-cli-testmd/) can execute and replay.
 
 :::note
-For the full picture of AI test-case generation — including richer inputs (files, PDFs, issue links) and pushing cases into Test Manager or automation — see the [AI test-case generation guide](https://www.testmuai.com/support/docs/generate-test-cases-with-ai/). The **CLI here takes a text description** and writes local `_test.md` files. See [Limits and scope](#limits-and-scope).
+For the full picture of AI test-case generation — including richer inputs (files, PDFs, issue links) and pushing cases into Test Manager or automation — see the [AI test-case generation guide](https://www.testmuai.com/support/docs/generate-test-cases-with-ai/). The **CLI here takes a text description** (optionally with local files attached via [`--files`](#attaching-files-for-context)) and writes local `_test.md` files. See [Limits and scope](#limits-and-scope).
 :::
 
 ## Quick start
@@ -95,9 +95,27 @@ The request id (`23271` above) is printed at the end of each generation and is h
 | `--scenario-limit <n>` | Maximum number of scenarios to generate. |
 | `--per-scenario-limit <n>` | Maximum test cases per scenario. |
 | `--memory` | Use the **memory layer** — reuse relevant existing test cases and reduce duplicates. |
+| `--files <paths>` | Comma-separated local files to attach as context (new generations and refines only). See [Attaching files for context](#attaching-files-for-context). |
 | `--project <id>` / `--folder <id>` | Test Manager project / folder. |
 | `--agent` | Emit structured NDJSON on stdout (auto-on when run non-interactively / piped). |
 | `--env`, `--username`, `--access-key` | Environment and authentication — same as [`kane-cli run`](/support/docs/kane-cli-quickstart/). See [Authentication](/support/docs/kane-cli-authentication/). |
+
+## Attaching files for context
+
+Give the generator more to work from by attaching local files with `--files` — a comma-separated list of paths — on a **new** generation or a **refine**:
+
+```bash
+kane-cli generate "test the login flow described in the attached spec" --files ./login-spec.pdf,./wireframe.png
+```
+
+The files are sent along with your description and reflected in the generated scenarios and cases — attach a spec, a screenshot of the UI, a PDF or Word document, or a CSV of inputs.
+
+- **Supported types** — documents (`.txt`, `.json`, `.xml`, `.csv`, `.pdf`, `.docx`, `.xlsx`), images (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.webp`), audio (`.mp3`, `.wav`, `.m4a`), and video (`.mp4`, `.mov`, `.webm`, `.mpeg`, `.mpga`).
+- **Limits** — up to **10 files**, each **50 MB** or smaller.
+- **Checked before anything is sent** — all paths are validated as a set. If any is missing, an unsupported type, too large, or over the count, the command stops and lists the offending paths so nothing is uploaded by mistake. Files outside the current directory are allowed but flagged with a warning.
+- **Not with `--save`** — files attach to a generation or refine, not a save (`--files` with `--save` is rejected).
+
+In the interactive TUI, type `@` in the generate prompt to attach a file inline instead of passing `--files`.
 
 ## Interactive mode (TUI)
 
@@ -108,6 +126,7 @@ Unlike the one-turn command-line surface, the TUI is a **live session** — gene
 | Input | Action |
 |---|---|
 | *(type any text)* | **Refine** — describe a change in plain language; the set updates in place |
+| `@<file>` | **Attach a file** — type `@` to pick a local file to add as context (same files as `--files`) |
 | `/view [S<n>]` | Open the **scenario browser** — drill scenarios → cases → case detail |
 | `/save` | Save the functional cases to `<cwd>/.testmuai/tests/…` |
 | `/cancel` | Cancel the current generation |
@@ -138,7 +157,7 @@ This is the intended path: **generate authors test cases → testmd runs them.**
 
 ## Limits and scope
 
-- **Input is a text description.** File, PDF, audio, and issue-link inputs (and the web product's "Create / Create and Automate") are not part of the CLI.
+- **Input is a text description, optionally with attached files.** Attach local files with `--files` (a spec, screenshot, PDF, or CSV) to give the generator more context. Issue-link inputs and the web product's "Create / Create and Automate" are not part of the CLI.
 - **Refinement is whole-request.** You refine the request as a whole in plain language; targeting an individual scenario or case from the CLI is not yet supported.
 - **Scenario and per-scenario counts** are bounded by `--scenario-limit` / `--per-scenario-limit`.
 

--- a/docs/kane-cli-installation.md
+++ b/docs/kane-cli-installation.md
@@ -2,7 +2,7 @@
 id: kane-cli-installation
 title: Installing Kane CLI
 sidebar_label: Installation
-description: Install Kane CLI using npm. Supports macOS (Apple Silicon and Intel), Linux (x64), and Windows (x64).
+description: Install Kane CLI using npm. Supports macOS (Apple Silicon and Intel), Linux (x64 and arm64), and Windows (x64).
 keywords:
   - kane cli
   - install kane cli

--- a/docs/kane-cli-modes.md
+++ b/docs/kane-cli-modes.md
@@ -95,7 +95,7 @@ Typing `/` in chat mode opens an autocomplete palette. Continue typing to filter
 | `/whoami` | `[--profile name]` | Show profile info |
 | `/balance` | | Show credit balance |
 | `/profiles` | `list\|switch\|delete` | Manage profiles |
-| `/config` | `show\|set-window\|set-mode\|chrome-profile\|project\|folder` | Manage configuration |
+| `/config` | `show\|set-window\|set-url\|set-mode\|chrome-profile\|project\|folder` | Manage configuration |
 | `/new` | | Start a fresh session (uploads the current session first) |
 | `/summary` | `[index]` | View detailed run summaries |
 | `/cancel` | | Abort the current run |
@@ -200,7 +200,7 @@ When stdin is not a TTY, Kane CLI automatically switches to plain NDJSON mode (t
 | Exit Code | Meaning |
 |-----------|---------|
 | `0` | Test passed |
-| `1` | Test failed (assertion not met) |
+| `1` | Test failed (agent reached an unrecoverable failure, or the upload failed) |
 | `2` | Error (auth failure, Chrome crash) |
 | `3` | Timeout or cancelled |
 

--- a/docs/kane-cli-skills.md
+++ b/docs/kane-cli-skills.md
@@ -231,4 +231,4 @@ When you ask your AI agent to test something on the web, the skill:
 | Codex CLI | `~/.codex/AGENTS.md` (appended section) | `AGENTS.md` (appended section) |
 | Gemini CLI | `~/.gemini/skills/kane-cli/SKILL.md` | `.gemini/skills/kane-cli/SKILL.md` |
 
-Source files: [github.com/LambdaTest/kane-cli/tree/main/skills](https://github.com/LambdaTest/kane-cli/blob/main/docs/user-guide/getting-started.md)
+Source files: [github.com/LambdaTest/kane-cli/tree/main/skill-installer/skills](https://github.com/LambdaTest/kane-cli/tree/main/skill-installer/skills)

--- a/docs/kane-cli-testmd.md
+++ b/docs/kane-cli-testmd.md
@@ -357,11 +357,13 @@ Click "Proceed to Checkout", fill in shipping details, and assert the order conf
 **`tests/helpers/login.md`:**
 
 ```markdown
+# Login helper
+
+## Open the login page
 Go to https://app.example.com/login.
-Enter {{username}} in the email field.
-Enter {{password}} in the password field.
-Click "Sign In".
-Assert the dashboard loads.
+
+## Sign in
+Enter {{username}} in the email field and {{password}} in the password field, then click "Sign In". Assert the dashboard loads.
 ```
 
 **Run:**

--- a/docs/kane-cli-troubleshooting.md
+++ b/docs/kane-cli-troubleshooting.md
@@ -276,6 +276,32 @@ echo 'export PATH="$(npm config get prefix)/bin:$PATH"' >> ~/.zshrc
 node --version   # Must be 18 or higher
 ```
 
+### Install fails with "sharp: Please add node-addon-api"
+
+**Symptom:** `npm install -g @testmuai/kane-cli` fails with `sharp: Please add node-addon-api to your dependencies` (any Node version, any platform).
+
+:::note
+Kane CLI 0.3.4+ treats `sharp` as an optional dependency, so the install still succeeds even if sharp fails. Screenshots simply upload as PNG instead of WebP (about 30% larger, no functional impact). On an older version, upgrade first with `npm install -g @testmuai/kane-cli@latest`.
+:::
+
+**Cause:** `sharp` powers optional PNG to WebP screenshot compression. When it cannot load its prebuilt binary it tries to build from source, which fails. The most common trigger on macOS is a system-wide libvips (often pulled in by `brew install appium`, `imagemagick`, or `gdal`).
+
+**Fix (most common, macOS):**
+```bash
+# Diagnose: a printed version means libvips is the cause
+pkg-config --modversion vips-cpp
+
+# Bypass libvips detection. Uninstall first, since npm considers
+# kane-cli already installed and will not re-resolve sharp otherwise.
+npm uninstall -g @testmuai/kane-cli
+SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g @testmuai/kane-cli
+
+# Make it permanent
+echo 'export SHARP_IGNORE_GLOBAL_LIBVIPS=1' >> ~/.zshrc && source ~/.zshrc
+```
+
+Two other triggers: npm configured to skip optional dependencies (`npm config get omit` should not contain `optional`, so clear it with `npm config delete omit` and reinstall), and a proxy or private registry that does not forward the `@img` scope (add an `@img:registry=https://registry.npmjs.org/` pass-through). If you are fine with PNG screenshots, no action is needed.
+
 ---
 
 ## "Update available" Notice

--- a/sidebars.js
+++ b/sidebars.js
@@ -5020,6 +5020,16 @@ module.exports = {
           },
           {
             type: "doc",
+            label: "API Calls",
+            id: "kane-cli-api-calls",
+          },
+          {
+            type: "doc",
+            label: "Browser State",
+            id: "kane-cli-browser-state",
+          },
+          {
+            type: "doc",
             label: "Variables & Context",
             id: "kane-cli-variables-and-context",
           },
@@ -5121,6 +5131,11 @@ module.exports = {
                 type: "doc",
                 label: "localStorage",
                 id: "kane-cli-checkpoint-devtools-localstorage",
+              },
+              {
+                type: "doc",
+                label: "Clipboard",
+                id: "kane-cli-checkpoint-devtools-clipboard",
               },
             ],
           },


### PR DESCRIPTION
## What

Brings the public Kane CLI documentation back in sync with the source of truth: **`LambdaTest/kane-cli` `docs/user-guide/`**. Every change below was verified against that repo.

These came out of a full parity sweep of all 33 public `kane-cli-*` pages. This PR ships the confirmed factual/format fixes plus the missing pages.

## Fixes (public doc was wrong vs GitHub)

| Page | Fix | GitHub source |
|---|---|---|
| generate | `--files` accepts file/PDF/audio inputs (public said "not part of the CLI"); adds the "Attaching files for context" section, the `--files` option row, and the TUI `@<file>` row | generate-test-cases/overview.md |
| testmd | import helper example now has `##` step headings (without them it parses to **zero steps**, so the `@import` silently does nothing) | testmd/overview.md + composition.md |
| modes | `/config` lists `set-url`; exit code `1` = agent reached an unrecoverable failure or upload failed | running-tests.md |
| configuration | `default_url` is changeable via `kane-cli config set-url` (was "Internal default") | configuration.md |
| error-codes | secret variable key is `secret`, not `sensitive` | variables-and-context.md |
| installation | Linux **arm64** noted alongside x64 | installation.md |
| skills | source-files link points to `skill-installer/skills` (the `/tree/main/skills` path does not exist) | repo tree |

## New pages (ported from GitHub, with Docusaurus frontmatter + breadcrumb + site-relative links)

- **API Calls** (`features/api-calls.md`)
- **Browser State** (`features/browser-state.md`)
- **Clipboard Assertions** (`features/checkpoints/devtools/clipboard.md`)

Plus: clipboard rows added to the DevTools and Checkpoints overview tables, and a `sharp` install-failure section in troubleshooting. Sidebar updated (API Calls + Browser State under Core Concepts, Clipboard under DevTools).

## Scope notes

- All new pages and their cross-links are added in this PR, so the broken-link build check stays green.
- One additional fix (troubleshooting "project auto-defaults on upload") is intentionally **held out** pending confirmation, so it is not in this PR.
- Reviewed locally on the Docusaurus dev server before raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
