### PR TITLE
docs(smartui): tab code samples, replace takeFullPageScreenshot, clean notes

### DIFF
--- a/docs/selenium-visual-regression.md
+++ b/docs/selenium-visual-regression.md
@@ -338,7 +338,7 @@ Add the following **Webhook** to your test cases where we need to capture the sc
 <TabItem value="nodejs" label="NodeJS" default>
 
 ```javascript
-driver.executeScript("smartui.takeFullPageScreenshot=<Your Screenshot Name>")
+await driver.executeScript("smartui.takeScreenshot", { screenshotName: "<Your Screenshot Name>", fullPage: true });
 ```
 
 </TabItem>
@@ -346,28 +346,31 @@ driver.executeScript("smartui.takeFullPageScreenshot=<Your Screenshot Name>")
 <TabItem value="python" label="Python" default>
 
 ```python
-driver.execute_script("smartui.takeFullPageScreenshot=<Your Screenshot Name>")
+driver.execute_script("smartui.takeScreenshot", {"screenshotName": "<Your Screenshot Name>", "fullPage": True})
 ```
 
 </TabItem>
 <TabItem value="ruby" label="Ruby" default>
 
 ```ruby
-driver.execute_script("smartui.takeFullPageScreenshot=<Your Screenshot Name>")
+driver.execute_script("smartui.takeScreenshot", {"screenshotName" => "<Your Screenshot Name>", "fullPage" => true})
 ```
 
 </TabItem>
 <TabItem value="csharp" label="C#" default>
 
 ```csharp
-driver.ExecuteScript("smartui.takeFullPageScreenshot=<Your Screenshot Name>");
+driver.ExecuteScript("smartui.takeScreenshot", new Dictionary<string, object> { { "screenshotName", "<Your Screenshot Name>" }, { "fullPage", true } });
 ```
 
 </TabItem>
 <TabItem value="java" label="Java" default>
 
 ```java
-((JavascriptExecutor)driver).executeScript("smartui.takeFullPageScreenshot=<Your Screenshot Name>");
+Map<String, Object> config = new HashMap<>();
+config.put("screenshotName", "<Your Screenshot Name>");
+config.put("fullPage", true);
+((JavascriptExecutor)driver).executeScript("smartui.takeScreenshot", config);
 ```
 
 </TabItem>
@@ -386,34 +389,38 @@ For browsers other than chrome (Mozilla, Safari etc.) and for websites `Full Pag
 <TabItem value="nodejs" label="NodeJS" default>
 
 ```javascript
-await driver.executeScript("smartui.takeFullPageScreenshot,{\"screenshotName\":\"<screenshot-name>\", \"smartScroll\":true }");
+await driver.executeScript("smartui.takeScreenshot", { screenshotName: "<screenshot-name>", fullPage: true, smartScroll: true });
 ```
 </TabItem>
 
 <TabItem value="python" label="Python" default>
 
 ```python
-driver.execute_script("smartui.takeFullPageScreenshot,{\"screenshotName\":\"<screenshot-name>\", \"smartScroll\":true }")
+driver.execute_script("smartui.takeScreenshot", {"screenshotName": "<screenshot-name>", "fullPage": True, "smartScroll": True})
 ```
 </TabItem>
 <TabItem value="ruby" label="Ruby" default>
 
 ```ruby
-driver.execute_script("smartui.takeFullPageScreenshot,{\"screenshotName\":\"<screenshot-name>\", \"smartScroll\":true }")
+driver.execute_script("smartui.takeScreenshot", {"screenshotName" => "<screenshot-name>", "fullPage" => true, "smartScroll" => true})
 ```
 </TabItem>
 
 <TabItem value="csharp" label="C#" default>
 
 ```csharp
-driver.ExecuteScript("smartui.takeFullPageScreenshot,{\"screenshotName\":\"<screenshot-name>\", \"smartScroll\":true }");
+driver.ExecuteScript("smartui.takeScreenshot", new Dictionary<string, object> { { "screenshotName", "<screenshot-name>" }, { "fullPage", true }, { "smartScroll", true } });
 ```
 
 </TabItem>
 <TabItem value="java" label="Java" default>
 
 ```java
-((JavascriptExecutor)driver).executeScript("smartui.takeFullPageScreenshot,{\"screenshotName\":\"<screenshot-name>\", \"smartScroll\":true }");
+Map<String, Object> config = new HashMap<>();
+config.put("screenshotName", "<screenshot-name>");
+config.put("fullPage", true);
+config.put("smartScroll", true);
+((JavascriptExecutor)driver).executeScript("smartui.takeScreenshot", config);
 ```
 
 </TabItem>

--- a/docs/smartui-ab-testing-variations.md
+++ b/docs/smartui-ab-testing-variations.md
@@ -49,7 +49,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # A/B Testing and Baseline Variations
 
-In <BrandName /> **SmartUI**, **A/B testing** lets one **screenshot or PDF page** keep **multiple approved reference images** (called **variations**). Each new capture is compared against **every active variation**; the UI shows which one **matched** (closest visual agreement). That cuts false failures when the same page can look different but still be correct—A/B tests, feature flags, themes, locales, or PDF layout variants—without splitting into separate names in automation or upload flows.
+In <BrandName /> **SmartUI**, **A/B testing** lets one **screenshot or PDF page** keep **multiple approved reference images** (called **variations**). Each new capture is compared against **every active variation**; the UI shows which one **matched** (closest visual agreement). That cuts false failures when the same page can look different but still be correct (A/B tests, feature flags, themes, locales, or PDF layout variants) without splitting into separate names in automation or upload flows.
 
 This guide walks through the **review** flow in the SmartUI dashboard: the **A/B** panel, the **default** variation, **Add new**, **Matched with**, managing variations, and **ending** A/B by picking a single winner.
 
@@ -60,7 +60,7 @@ A/B variations use the **same in-product panel** whether the asset is a **standa
 | Capture type | Typical source | Notes |
 |--------------|----------------|--------|
 | **Web / app screenshots** | Automation (Selenium, Playwright, Cypress, Hooks, SDK, CLI), manual capture, Storybook, and similar | Use a stable **screenshot name** per page or state; open that screenshot in a build to manage variations. |
-| **PDF pages** | [PDF comparison](/support/docs/smartui-pdf-comparison/) projects (upload, Java SDK, CLI, or API) | A/B applies **per PDF page** in the build—the same **Add new**, **Matched with**, and **End A/B testing** controls as for web screenshots. |
+| **PDF pages** | [PDF comparison](/support/docs/smartui-pdf-comparison/) projects (upload, Java SDK, CLI, or API) | A/B applies **per PDF page** in the build: the same **Add new**, **Matched with**, and **End A/B testing** controls as for web screenshots. |
 
 You do **not** need a separate project type for A/B. Create or open the screenshot or PDF page in your existing SmartUI build, then use the **A/B** icon on that asset’s review screen.
 
@@ -73,7 +73,7 @@ Set up PDF ingestion first if you are new to PDF comparison: [PDF Comparison in 
 | Term | Meaning |
 |------|--------|
 | **Variation** | An approved reference image for this screenshot. The **default** variation tracks the platform baseline; you can add up to **19** more. |
-| **Default variation** | The reference tied to the **current SmartUI baseline** for this build (dynamic—not a user-created slot you rename as “default”). |
+| **Default variation** | The reference tied to the **current SmartUI baseline** for this build (dynamic, not a user-created slot you rename as “default”). |
 | **Matched with** | The variation that best matches the latest capture (typically lowest diff % within threshold). |
 | **End A/B testing** | Pick one variation as the **only** baseline going forward; other variations are removed. |
 
@@ -121,7 +121,7 @@ For **build-level** baselines (branches, approvals, Smart Git), see [Baseline Ma
 - A <BrandName /> account with **SmartUI** access and an existing **project** with at least one build.
 - At least one **screenshot** or **PDF page** in that build to open in review.
 - Permission to **review** and update baselines in that project.
-- No extra automation flags are required to **start** A/B from the UI—for web tests, keep the same **`screenshotName`**; for PDFs, keep the same page identity in your upload or SDK flow.
+- No extra automation flags are required to **start** A/B from the UI: for web tests, keep the same **`screenshotName`**; for PDFs, keep the same page identity in your upload or SDK flow.
 
 ---
 
@@ -144,7 +144,7 @@ When the pane opens, you see the **default variation**:
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/a-b-testing/a-b-test-defaultvariation.png').default} alt="A/B testing panel showing the default variation derived from the current build baseline" width="960" className="doc_img" />
 
 - It reflects the **current baseline** for this screenshot in this **build context**, per your project’s **SmartUI baseline rules** (for example the latest **approved** reference for that build strategy).
-- It is **dynamic**: if the governing baseline changes (approval, move to baseline, branch rules), the default variation **follows** that reference—it is not a separate image you pin manually.
+- It is **dynamic**: if the governing baseline changes (approval, move to baseline, branch rules), the default variation **follows** that reference; it is not a separate image you pin manually.
 
 You **cannot** assign another variation to replace this **default** slot. **Default** means the **platform baseline** for this screenshot, not a renameable card in your list.
 
@@ -172,7 +172,7 @@ When a new build processes this screenshot, the pane shows **Matched with** and 
 
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/a-b-testing/a-b-test-matchedwithvariation.png').default} alt="Matched with label in the A/B panel showing which variation the latest capture matched" width="960" className="doc_img" />
 
-Only **one** variation is shown as the match for triage at a time—the best fit for that capture.
+Only **one** variation is shown as the match for triage at a time, the best fit for that capture.
 
 :::note Unmatched captures
 If **no** variation is within threshold, the screenshot may still show as **changes found** or unmatched. Add a new variation from that capture, adjust thresholds, or **end A/B** once you know the intended winner. See [Mismatch Thresholds](/support/docs/smartui-mismatch-thresholds/).

--- a/docs/smartui-appium-hooks.md
+++ b/docs/smartui-appium-hooks.md
@@ -388,7 +388,7 @@ driver.execute_script("smartui.takeScreenshot", config)
 :::note Best Practices
 - Use `ignoreBoxes` for elements that change frequently (e.g., ads, timestamps, user avatars).
 - Use `selectBoxes` when you want to focus comparison only on critical UI sections.
-- Avoid using both `ignoreBoxes` and `selectBoxes` in the same config — they are mutually exclusive.
+- Avoid using both `ignoreBoxes` and `selectBoxes` in the same config; they are mutually exclusive.
 - Ensure XPath expressions are unique and stable across test runs.
 - Test your XPath locators using Appium Inspector or similar tools before integrating.
 :::

--- a/docs/smartui-appium-java-sdk.md
+++ b/docs/smartui-appium-java-sdk.md
@@ -294,7 +294,7 @@ config.put("selectBoxes", gson.toJson(selectBoxesMap));
 :::note Best Practices
 - Use `ignoreBoxes` for elements that change frequently (e.g., ads, timestamps, user avatars).
 - Use `selectBoxes` when you want to focus comparison only on critical UI sections.
-- Avoid using both `ignoreBoxes` and `selectBoxes` in the same config — they are mutually exclusive.
+- Avoid using both `ignoreBoxes` and `selectBoxes` in the same config; they are mutually exclusive.
 - Ensure XPath expressions are unique and stable across test runs.
 :::
 

--- a/docs/smartui-audit-logs.md
+++ b/docs/smartui-audit-logs.md
@@ -43,7 +43,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-**Audit Logs** give you a permanent, searchable record of every important action in your SmartUI projects—who did it, when, and what changed. Use them for compliance, accountability, and tracing baseline history across projects, builds, and individual screenshots.
+**Audit Logs** give you a permanent, searchable record of every important action in your SmartUI projects: who did it, when, and what changed. Use them for compliance, accountability, and tracing baseline history across projects, builds, and individual screenshots.
 
 ---
 
@@ -93,15 +93,15 @@ For a **single screenshot**, the **screenshot-level** log is that asset’s base
 
 ## What each level shows
 
-**Project history** — Project created/deleted; settings updated; builds merged to baseline.
+**Project history**: Project created/deleted; settings updated; builds merged to baseline.
 
 <img loading="lazy" className='doc_img' src={require('../assets/images/smart-visual-testing/audit-history/project_level_history.png').default} alt="Project-level audit history" />
 
-**Build history** — Build created/completed/failed; re-runs (re-execute vs re-run comparison); bulk approve/reject; build deleted.
+**Build history**: Build created/completed/failed; re-runs (re-execute vs re-run comparison); bulk approve/reject; build deleted.
 
 <img loading="lazy" className='doc_img' src={require('../assets/images/smart-visual-testing/audit-history/build_level_history.png').default} alt="Build-level audit history" />
 
-**Screenshot history** — Approvals and rejections (single and bulk); live comparisons; ignore zones/annotations; screenshot added/deleted.
+**Screenshot history**: Approvals and rejections (single and bulk); live comparisons; ignore zones/annotations; screenshot added/deleted.
 
 <img loading="lazy" className='doc_img' src={require('../assets/images/smart-visual-testing/audit-history/screenshot_level_history.png').default} alt="Screenshot-level audit history" />
 
@@ -125,25 +125,25 @@ Every event shows **who**, **when**, and **what**:
 
 Use filters to narrow by **who** (user or system), **what** (event type), **branch**, or **screenshot name**.
 
-**By user or system** — Filter by specific users for accountability, or by **System** to see only automated events (e.g. auto-approvals).
+**By user or system**: Filter by specific users for accountability, or by **System** to see only automated events (e.g. auto-approvals).
 
 <img loading="lazy" className='doc_img' src={require('../assets/images/smart-visual-testing/audit-history/filters_users.png').default} alt="Filter by team members" />
 
 <img loading="lazy" className='doc_img' src={require('../assets/images/smart-visual-testing/audit-history/filters_system_logs.png').default} alt="Filter by System actions" />
 
-**By event type** — e.g. Approve, Reject, Merged to Baseline, Build Re-executed.
+**By event type**: e.g. Approve, Reject, Merged to Baseline, Build Re-executed.
 
 <img loading="lazy" className='doc_img' src={require('../assets/images/smart-visual-testing/audit-history/filters_events.png').default} alt="Filter by event type" />
 
-**By branch** — Restrict to a Git branch.
+**By branch**: Restrict to a Git branch.
 
 <img loading="lazy" className='doc_img' src={require('../assets/images/smart-visual-testing/audit-history/filters_branches.png').default} alt="Filter by branch" />
 
-**By screenshot name** — Search for a specific snapshot.
+**By screenshot name**: Search for a specific snapshot.
 
 <img loading="lazy" className='doc_img' src={require('../assets/images/smart-visual-testing/audit-history/filters_screenshots.png').default} alt="Filter by screenshot name" />
 
-**Bulk actions** — One event per bulk approve/reject; hover or click to see a visual preview of the screenshots included.
+**Bulk actions**: One event per bulk approve/reject; hover or click to see a visual preview of the screenshots included.
 
 <img loading="lazy" className='doc_img' src={require('../assets/images/smart-visual-testing/audit-history/ss_preview_build_level.png').default} alt="Preview of screenshots in a bulk action" />
 
@@ -191,5 +191,5 @@ Use the **Event type** filter in the UI to restrict to these categories.
 
 ## Related documentation
 
-- [Approval & Baseline Management](/support/docs/smartui-approval-workflow-guide/) — How approve, reject, move, and merge affect baselines.
-- [Multiselect & Bulk Operations](/support/docs/smartui-multiselect-bulkops/) — How bulk actions work and how they appear in audit logs.
+- [Approval & Baseline Management](/support/docs/smartui-approval-workflow-guide/): How approve, reject, move, and merge affect baselines.
+- [Multiselect & Bulk Operations](/support/docs/smartui-multiselect-bulkops/): How bulk actions work and how they appear in audit logs.

--- a/docs/smartui-automation-dashboard.md
+++ b/docs/smartui-automation-dashboard.md
@@ -99,7 +99,7 @@ Toggle between a **Grid view** (screenshot thumbnails, ideal for a quick visual 
 
 ### 3. Group by test
 
-Organize screenshots by automation suite or test name so related screenshots stay together — far easier to navigate than a flat list when a run produces dozens of screenshots.
+Organize screenshots by automation suite or test name so related screenshots stay together, far easier to navigate than a flat list when a run produces dozens of screenshots.
 
 ### 4. Deep link into SmartUI
 
@@ -120,7 +120,7 @@ The **View in SmartUI** link on a build takes users straight to the full SmartUI
 ## Availability and access
 
 - The feature appears as a tab in the test view for any test that has associated SmartUI screenshots; tests without SmartUI data won't show SmartUI content.
-- It is rolled out progressively. If the user does not see the SmartUI tab and expects to, their account may not yet be enabled — contact the account team or support.
+- It is rolled out progressively. If the user does not see the SmartUI tab and expects to, their account may not yet be enabled; contact the account team or support.
 - Requires an active SmartUI project linked to the automation run.
 
 ---
@@ -129,7 +129,7 @@ The **View in SmartUI** link on a build takes users straight to the full SmartUI
 
 - **Real Device sessions:** Screenshots are matched to the user's test even when a session identifier isn't present, so results display reliably for Real Device runs.
 - **Mixed runs:** App Automation and Web-Automation-with-Real-Device tests each route to their correct dashboard when the user follows a deep link.
-- For the cleanest grouping, use consistent, descriptive test names in the automation suite — these are what the **Group by test** view uses to cluster screenshots.
+- For the cleanest grouping, use consistent, descriptive test names in the automation suite; these are what the **Group by test** view uses to cluster screenshots.
 
 ---
 

--- a/docs/smartui-custom-css.md
+++ b/docs/smartui-custom-css.md
@@ -51,7 +51,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 ---
 
-Custom CSS injection is a specialized feature in SmartUI that allows you to apply test-only styles during snapshot capture without modifying your application code. This feature enables you to stabilize visual tests by normalizing dynamic content, enforcing consistent styling across environments, and masking sensitive information—all while keeping your visual testing logic centralized and maintainable.
+Custom CSS injection is a specialized feature in SmartUI that allows you to apply test-only styles during snapshot capture without modifying your application code. This feature enables you to stabilize visual tests by normalizing dynamic content, enforcing consistent styling across environments, and masking sensitive information, all while keeping your visual testing logic centralized and maintainable.
 
 ### Why Custom CSS Matters
 
@@ -146,7 +146,7 @@ The embedded string method is useful for quick edits and single-use CSS rules. P
 
 - **Method Selection**: Choose the file path method for larger stylesheets and team collaboration. Use embedded strings only for quick, single-use CSS rules.
 
-- **CSS Organization**: Keep your CSS snapshot-specific—target only elements that need stabilization or normalization. Avoid broad selectors that might affect unintended elements.
+- **CSS Organization**: Keep your CSS snapshot-specific: target only elements that need stabilization or normalization. Avoid broad selectors that might affect unintended elements.
 
 - **JSON Escaping**: When using embedded strings, escape quotes properly:
   - Use single quotes within CSS strings: `"body{font-family:'Inter',sans-serif;}"`
@@ -154,8 +154,8 @@ The embedded string method is useful for quick edits and single-use CSS rules. P
 
 - **Selector Verification**: If the CSS Injection Report shows "no elements found" or "invalid selector" errors:
   - Verify the element exists at snapshot time (use browser dev tools)
-  - Check selector specificity—it may need to be more specific or less specific
-  - Consider timing issues—ensure the element is rendered before snapshot capture
+  - Check selector specificity: it may need to be more specific or less specific
+  - Consider timing issues: ensure the element is rendered before snapshot capture
   - Check the CSS Injection Report in logs for detailed feedback
 
 - **CLI Version**: Ensure SmartUI CLI v4.1.40+ is installed. You can verify this by running `npx smartui --version`. Older versions may not support the `customCSS` feature.

--- a/docs/smartui-diff-highlighter.md
+++ b/docs/smartui-diff-highlighter.md
@@ -45,7 +45,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # Diff Highlighter & Navigation
 
-When reviewing SmartUI visual comparisons, small differences can be easy to miss on dense or zoomed-out screens. The **Diff Highlighter** feature helps you **discover every change** quickly using in-view navigation and an optional highlight animation—so you spend less time scanning and more time deciding what to accept or reject.
+When reviewing SmartUI visual comparisons, small differences can be easy to miss on dense or zoomed-out screens. The **Diff Highlighter** feature helps you **discover every change** quickly using in-view navigation and an optional highlight animation, so you spend less time scanning and more time deciding what to accept or reject.
 
 ## What You Get
 
@@ -74,9 +74,9 @@ On the comparison view, open the **actions menu** (e.g. the 3-dot or actions dro
 
 In the actions menu you’ll see:
 
-- **Previous** — moves focus to the **previous** diff (above the current one).
-- **Highlight** — runs the **highlight animation**: popping circles traverse each diff from **top to bottom**, so you can see every change location in sequence.
-- **Next** — moves focus to the **next** diff (below the current one).
+- **Previous**: moves focus to the **previous** diff (above the current one).
+- **Highlight**: runs the **highlight animation**: popping circles traverse each diff from **top to bottom**, so you can see every change location in sequence.
+- **Next**: moves focus to the **next** diff (below the current one).
 
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/diff-highlight/prev_diff.png').default} alt="Previous Diff Button" className="doc_img" />
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/diff-highlight/highlight_diff.png').default} alt="Highlight Diff Button" className="doc_img" />
@@ -89,7 +89,7 @@ Use **Highlight** when you want to quickly see all diffs without clicking throug
 - On clicking the **Previous** or **Next** buttons, the view will zoom into that specific diff and highlight it with a bounded box.
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/diff-highlight/on_clickingnext_prev.png').default} alt="Zoom and highlight in box" className="doc_img"/>
 - You can continue to use overlay toggles, zoom, slider/side-by-side, and **Mark as bug** or approval actions as usual.
-- Diff navigation and highlight do **not** replace existing comparison tools—they only make it easier to find where the changes are.
+- Diff navigation and highlight do **not** replace existing comparison tools, they only make it easier to find where the changes are.
 
 ## Highlight animation
 
@@ -132,9 +132,9 @@ To use diff navigation and highlight, ensure the screenshot is compared with **S
 
 ## Related docs
 
-- [Smart Ignore](/support/docs/smartui-smartignore) — Reduce noise and use diff regions for navigation.
-- [Layout Testing](/support/docs/smartui-layout-testing) — Compare layout structure (diff navigation for this mode coming later).
-- [View comparison and issues](/support/docs/smart-visual-testing#view-comparison-and-issues) — Basics of the comparison view.
+- [Smart Ignore](/support/docs/smartui-smartignore): Reduce noise and use diff regions for navigation.
+- [Layout Testing](/support/docs/smartui-layout-testing): Compare layout structure (diff navigation for this mode coming later).
+- [View comparison and issues](/support/docs/smart-visual-testing#view-comparison-and-issues): Basics of the comparison view.
 
 
 <nav aria-label="breadcrumbs">

--- a/docs/smartui-export-build-data.md
+++ b/docs/smartui-export-build-data.md
@@ -45,7 +45,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # Export SmartUI Build Data
 
-From the <BrandName /> dashboard you can export **build-level** data for a SmartUI run—comparison outcomes, statuses, and related metadata—without using the CLI or API. Use it for stakeholder summaries, ticket attachments, spreadsheets, or downstream automation.
+From the <BrandName /> dashboard you can export **build-level** data for a SmartUI run (comparison outcomes, statuses, and related metadata) without using the CLI or API. Use it for stakeholder summaries, ticket attachments, spreadsheets, or downstream automation.
 
 ## Prerequisites
 

--- a/docs/smartui-group-by-test-cases.md
+++ b/docs/smartui-group-by-test-cases.md
@@ -34,12 +34,12 @@ It also covers how to get **one Automation / SmartUI build** with **multiple cap
 ## Audience & Prerequisites
 
 - **Audience:** QA Engineers and Developers running automated visual tests on <BrandName />.
-- **Prerequisites (recommended — Hooks):** 
+- **Prerequisites (recommended: Hooks):** 
   - **LambdaTest** username and access key: `LT_USERNAME`, `LT_ACCESS_KEY`.
   - SmartUI project wired through **`smartUI.project`** in Java `LT:Options` (same string as **Smart UI Project Name** in the dashboard, e.g. `sample` or `new`).
   - **`smartui.takeScreenshot`** with a **`screenshotName`** per capture when you want multiple named screenshots in one run.
   - For **SmartUI CLI** static or exec workflows, a **`PROJECT_TOKEN`** from that project (often ends with `#<projectSlug>` matching the project name).
-- **Prerequisites (optional — Node SDK + `visual: true`):** The SmartUI project must be **Web** type; **Omni** names with **`smartUIProjectName`** + **`visual: true`** cause hub `failed to validate project` — see [Omni vs Web](#omni-vs-web). Prefer the **Hooks** flow above for Omni / Hooks projects.
+- **Prerequisites (optional: Node SDK + `visual: true`):** The SmartUI project must be **Web** type; **Omni** names with **`smartUIProjectName`** + **`visual: true`** cause hub `failed to validate project`, see [Omni vs Web](#omni-vs-web). Prefer the **Hooks** flow above for Omni / Hooks projects.
 - On the **grid**, grouping metadata usually comes from session **`name`**, suite/project, or runner test titles. For **local** `smartui exec` + Cypress or Playwright, see the <a href={`${BRAND_URL}/support/docs/smartui-sdk-config-options/`}>SmartUI SDK docs</a>.
   
 :::note
@@ -121,14 +121,14 @@ Use this when you want **one Automation / SmartUI build** with **several** captu
 1. **Same `smartUI.project`** (and same **`PROJECT_TOKEN`** when using the CLI) for the whole run.
 2. **Same `build`** in `LT:Options` for every session that should belong to the same Automation build.
 3. **Distinct `screenshotName`** values for each **`smartui.takeScreenshot`** call so each capture is a separate asset in the build.
-4. **Test case folders:** vary the session **`name`** in `LT:Options` per test method or per parallel session when you need multiple **Test Case** groups (same pattern as multi-session Selenium suites). For **one session** with multiple hooks, grouping still uses automation metadata from that session — align **`name`** / suite with your runner (JUnit/TestNG method names, etc.) per your organization’s conventions.
+4. **Test case folders:** vary the session **`name`** in `LT:Options` per test method or per parallel session when you need multiple **Test Case** groups (same pattern as multi-session Selenium suites). For **one session** with multiple hooks, grouping still uses automation metadata from that session; align **`name`** / suite with your runner (JUnit/TestNG method names, etc.) per your organization’s conventions.
 5. You can run sessions **sequentially or in parallel** as long as **`build`** and **`smartUI.project`** stay consistent.
 
 ---
 
 ## Optional: Node SDK + `visual: true` (Web SmartUI projects only)
 
-Use **`@lambdatest/selenium-driver`** **`smartuiSnapshot`** + **`visual: true`** + **`smartUIProjectName`** only when the SmartUI project is **Web** type. **Omni** project names cause **`failed to validate project`** on the hub for this path — use the [Hooks flow](#hooks-java-webhook) instead.
+Use **`@lambdatest/selenium-driver`** **`smartuiSnapshot`** + **`visual: true`** + **`smartUIProjectName`** only when the SmartUI project is **Web** type. **Omni** project names cause **`failed to validate project`** on the hub for this path; use the [Hooks flow](#hooks-java-webhook) instead.
 
 Workspace sample (five sessions, five names, one build):
 
@@ -174,7 +174,7 @@ To view them hierarchically:
 
 You can review visual differences without leaving your test automation execution context.
 
-<img loading="lazy" src={require('../assets/images/smart-visual-testing/groupby_test_automationpage.png').default} alt="SmartUI Screenshots tab inside the Automation test detail page, showing project and build metadata, a thumbnail grid of captured screenshots, and the side video player — the page users land on when navigating from a SmartUI grouped test view" width="960" className="doc_img" />
+<img loading="lazy" src={require('../assets/images/smart-visual-testing/groupby_test_automationpage.png').default} alt="SmartUI Screenshots tab inside the Automation test detail page, showing project and build metadata, a thumbnail grid of captured screenshots, and the side video player, the page users land on when navigating from a SmartUI grouped test view" width="960" className="doc_img" />
 
 1. Navigate to your **Automation** dashboard and select a test run.
 2. In the test detail view, locate the **SmartUI Screenshots** tab alongside the traditional Overview, Logs, and Network tabs.
@@ -202,7 +202,7 @@ If you are in the Automation dashboard and prefer the full-screen SmartUI review
 
 When reviewing a large number of screenshots, you can triage them efficiently using bulk actions at the test case group level.
 
-**Group by Test Case** uses the **same bulk-action workflow** as the standard (flat) build view: select screenshots via the **group checkbox** on a test-case folder (or pick individual thumbnails), then use **Approve All** / **Reject All** on the floating action bar. You are only changing how screenshots are **organized**—not which bulk controls are available.
+**Group by Test Case** uses the **same bulk-action workflow** as the standard (flat) build view: select screenshots via the **group checkbox** on a test-case folder (or pick individual thumbnails), then use **Approve All** / **Reject All** on the floating action bar. You are only changing how screenshots are **organized**, not which bulk controls are available.
 
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/groupby_test_bulkops.png').default} alt="SmartUI build grouped by test case with group checkbox selected and the standard bulk Approve All and Reject All action bar visible" width="960" className="doc_img" />
 

--- a/docs/smartui-hooks-layout-fullpage-smartignore.md
+++ b/docs/smartui-hooks-layout-fullpage-smartignore.md
@@ -17,6 +17,8 @@ canonical: https://www.testmuai.com/support/docs/smartui-hooks-layout-fullpage-s
 ---
 
 import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 <script type="application/ld+json"
       dangerouslySetInnerHTML={{ __html: JSON.stringify({
@@ -44,33 +46,27 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # SmartUI Hooks: Layout, Full-Page Screenshots, and Smart Ignore
 
-Use this page when you run **SmartUI Hooks** on LambdaTest (for example Selenium `executeScript` without the `smartui exec` CLI wrapper) and need **layout** comparison, **full-page** capture, or **Smart Ignore**.
+Use this page when you run **SmartUI Hooks** on LambdaTest (for example, Selenium `executeScript` without the `smartui exec` CLI wrapper) and need **layout** comparison, **full-page** capture, or **Smart Ignore**.
 
-:::info Capability vs hook, read this first
-For **Hooks**, engineering behavior is:
+## How configuration is split
 
-| Goal | Where to configure | Notes |
-|------|-------------------|--------|
-| **Layout** comparison | **`smartui.takeScreenshot` hook options** (per screenshot) | Pass `ignoreType: ["layout"]` (and related layout flags) in the **Map/object** passed to `executeScript("smartui.takeScreenshot", options)`. **Layout is not enabled for Hooks by setting layout fields only in `LT:Options` capabilities**. That path is not supported the way teams often expect. |
-| **Smart Ignore** | **`LT:Options`** | Set **`smartUI.smartIgnore`: `true`** on the session for baseline and comparison runs. |
-| **Project** | **`LT:Options`** | Set **`smartUI.project`** (and `visual`, auth) as usual. |
+SmartUI Hooks split configuration between the session capabilities (`LT:Options`) and the per-screenshot hook:
 
-If you need **layout via capabilities alone** (no hook options), treat that as a feature request and raise it with your account team. This doc reflects **current** Hooks behavior.
-:::
+| Goal | Where to configure | How |
+|------|--------------------|-----|
+| **Layout** comparison | `smartui.takeScreenshot` hook options | Pass `ignoreType: ["layout"]` in the options map for that screenshot. |
+| **Full-page** capture | `smartui.takeScreenshot` hook options | Pass `fullPage: true` in the options map for that screenshot. |
+| **Smart Ignore** | `LT:Options` | Set `smartUI.smartIgnore: true` on the session, for both baseline and comparison runs. |
+| **Project** | `LT:Options` | Set `smartUI.project` (with `visual` and credentials). |
 
-:::info Smart Ignore vs Ignore DOM / Select DOM
-With **Smart Ignore**, use either **Ignore DOM** or **Select DOM** in the dashboard where applicable, not both on the same flow.
-:::
+Layout and full page are enabled per screenshot through the hook options, not through `LT:Options` capabilities. When you use Smart Ignore, choose either **Ignore DOM** or **Select DOM** in the dashboard for a given flow, not both.
 
 ## 1. Session capabilities (`LT:Options`)
 
-### Always (Hooks)
+Every Hooks session needs `username`, `accessKey`, `visual: true`, and `smartUI.project`. For Smart Ignore, also set `smartUI.smartIgnore: true` on both the baseline and comparison sessions.
 
-- `username`, `accessKey`, `visual: true`, **`smartUI.project`**
-
-### Smart Ignore (Hooks)
-
-Set on **`LT:Options`** for the whole session (baseline **and** comparison):
+<Tabs className="docs__val" groupId="language">
+<TabItem value="java" label="Java" default>
 
 ```java
 import java.util.HashMap;
@@ -87,7 +83,8 @@ ltOptions.put("smartUI.smartIgnore", true);
 browserOptions.setCapability("LT:Options", ltOptions);
 ```
 
-**JavaScript / Node**
+</TabItem>
+<TabItem value="nodejs" label="NodeJS">
 
 ```javascript
 'LT:Options': {
@@ -99,7 +96,22 @@ browserOptions.setCapability("LT:Options", ltOptions);
 },
 ```
 
-**C#**
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+lt_options = {
+    "username": os.getenv("LT_USERNAME"),
+    "accessKey": os.getenv("LT_ACCESS_KEY"),
+    "visual": True,
+    "smartUI.project": "Your_Project_Name",
+    "smartUI.smartIgnore": True,
+}
+options.set_capability("LT:Options", lt_options)
+```
+
+</TabItem>
+<TabItem value="csharp" label="C#">
 
 ```csharp
 capabilities.SetCapability("visual", true);
@@ -107,26 +119,15 @@ capabilities.SetCapability("smartUI.project", "Your_Project_Name");
 capabilities.SetCapability("smartUI.smartIgnore", true);
 ```
 
-:::warning Do not use these for Smart Ignore (Hooks + Java)
-These patterns **do not** turn on Smart Ignore reliably:
+</TabItem>
+</Tabs>
 
-- `ltOptions.put("ignoreType", Arrays.asList("smartignore"));` without `smartUI.smartIgnore`
-- `ltOptions.put("smartignore", true);` at the root of `LT:Options`
+## 2. Layout comparison
 
-Use **`smartUI.smartIgnore`: `true`** only.
-:::
+Pass a single options map to `smartui.takeScreenshot` with a `screenshotName` and `ignoreType: ["layout"]`. Add `fullPage: true` to the same map for a full-page layout shot.
 
-### Layout: not via standalone layout capabilities for Hooks
-
-Do **not** expect **`ignoreType: ["layout"]`**, **`smartUI.layout`**, or nested **`smartUI.options`** layout blocks **alone** in `LT:Options` to enable layout comparison for Hooks. Validated behavior is: **pass layout in the hook** (next section).
-
----
-
-## 2. Layout comparison: pass options to `smartui.takeScreenshot`
-
-Pass a **single map** to `executeScript("smartui.takeScreenshot", options)` including **`screenshotName`** and **`ignoreType`**.
-
-### Java (validated pattern)
+<Tabs className="docs__val" groupId="language">
+<TabItem value="java" label="Java" default>
 
 ```java
 import java.util.Arrays;
@@ -135,15 +136,14 @@ import java.util.Map;
 import org.openqa.selenium.JavascriptExecutor;
 
 Map<String, Object> options = new HashMap<>();
-options.put("ignoreType", Arrays.asList("layout"));
 options.put("screenshotName", "my-layout-screenshot-01");
+options.put("ignoreType", Arrays.asList("layout"));
 
 ((JavascriptExecutor) driver).executeScript("smartui.takeScreenshot", options);
 ```
 
-Session **`LT:Options`** for this flow typically needs at least **`smartUI.project`** (and `visual`, credentials), **not** a separate layout capability block for the same effect.
-
-### JavaScript
+</TabItem>
+<TabItem value="nodejs" label="NodeJS">
 
 ```javascript
 await driver.executeScript('smartui.takeScreenshot', {
@@ -152,7 +152,18 @@ await driver.executeScript('smartui.takeScreenshot', {
 });
 ```
 
-### C#
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+driver.execute_script("smartui.takeScreenshot", {
+    "screenshotName": "my-layout-screenshot-01",
+    "ignoreType": ["layout"],
+})
+```
+
+</TabItem>
+<TabItem value="csharp" label="C#">
 
 ```csharp
 var options = new Dictionary<string, object>
@@ -163,53 +174,88 @@ var options = new Dictionary<string, object>
 ((IJavaScriptExecutor)driver).ExecuteScript("smartui.takeScreenshot", options);
 ```
 
-Add **`fullPage: true`** in the same map when you need a full-page capture for that shot.
+</TabItem>
+</Tabs>
 
----
+## 3. Full-page screenshot
 
-## 3. Full-page screenshot (name-only hook)
+Pass `fullPage: true` to `smartui.takeScreenshot` along with a `screenshotName`. For a full-page layout shot in the same call, add `ignoreType: ["layout"]` to the map.
+
+<Tabs className="docs__val" groupId="language">
+<TabItem value="java" label="Java" default>
 
 ```java
-((JavascriptExecutor) driver).executeScript("smartui.takeFullPageScreenshot=Home_Page_Desktop");
+Map<String, Object> options = new HashMap<>();
+options.put("screenshotName", "Home_Page_Desktop");
+options.put("fullPage", true);
+
+((JavascriptExecutor) driver).executeScript("smartui.takeScreenshot", options);
 ```
+
+</TabItem>
+<TabItem value="nodejs" label="NodeJS">
+
+```javascript
+await driver.executeScript('smartui.takeScreenshot', {
+  screenshotName: 'Home_Page_Desktop',
+  fullPage: true,
+});
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+driver.execute_script("smartui.takeScreenshot", {
+    "screenshotName": "Home_Page_Desktop",
+    "fullPage": True,
+})
+```
+
+</TabItem>
+<TabItem value="csharp" label="C#">
 
 ```csharp
-((IJavaScriptExecutor)driver).ExecuteScript("smartui.takeFullPageScreenshot=Home_Page_Desktop");
+var options = new Dictionary<string, object>
+{
+    { "screenshotName", "Home_Page_Desktop" },
+    { "fullPage", true }
+};
+((IJavaScriptExecutor)driver).ExecuteScript("smartui.takeScreenshot", options);
 ```
 
-For **layout + full page** in one call, prefer the **config object** form in §2 with `fullPage: true` and `ignoreType: ["layout"]`.
-
----
+</TabItem>
+</Tabs>
 
 ## 4. Baseline and comparison
 
-1. Same **`smartUI.project`** and screenshot **names**.
-2. **Smart Ignore:** same **`smartUI.smartIgnore`** on baseline and comparison sessions.
-3. **Layout:** same **`ignoreType: ["layout"]`** (and other layout flags) in the **hook** for matching screenshot names on baseline and comparison runs.
-4. Changing strategy or options usually requires a **new baseline**.
+- Use the same `smartUI.project` and screenshot names on both runs.
+- **Smart Ignore:** set the same `smartUI.smartIgnore` on the baseline and comparison sessions.
+- **Layout:** pass the same `ignoreType: ["layout"]` in the hook for matching screenshot names.
+- Changing the strategy or options usually requires a new baseline.
 
----
+## 5. Build attribution
 
-## 5. Strict comparison vs Smart Ignore
+Runs that use a project token may show the project creator as the build author. Use the intended automation `username`, `accessKey`, and `project` where the product allows.
 
-If the project or build is still effectively in **strict (pixel) comparison**, some Smart Ignore–specific UI flows behave differently. Align dashboard **comparison mode** with session capabilities.
+## 6. Common failures and what not to do
 
----
+:::warning Smart Ignore (Hooks + Java)
+These patterns do not turn on Smart Ignore:
 
-## 6. Build attribution (creator name)
+- `ltOptions.put("ignoreType", Arrays.asList("smartignore"));` without `smartUI.smartIgnore`
+- `ltOptions.put("smartignore", true);` at the root of `LT:Options`
 
-Runs using a **project token** may show the **project creator**. Use the intended automation **username** / **access key** / **project** where the product allows.
-
----
-
-## 7. Troubleshooting
+Set `smartUI.smartIgnore: true` instead.
+:::
 
 | Problem | What to do |
-|--------|------------|
-| Layout never activates; only tried `LT:Options` | Move **`ignoreType: ["layout"]`** into **`smartui.takeScreenshot`** options (§2). |
-| Smart Ignore never activates | Set **`smartUI.smartIgnore`: true** in **`LT:Options`**; verify in session metadata. |
-| Tried `smartUI.layout` | Not the supported Hooks switch for layout; use hook **options** instead. |
-| Want to rely on dashboard toggles only | Hooks still need the correct **hook** + **capability** split per this page. |
+|---------|------------|
+| Layout never activates; only set in `LT:Options` | Move `ignoreType: ["layout"]` into the `smartui.takeScreenshot` options (see §2). |
+| Smart Ignore never activates | Set `smartUI.smartIgnore: true` in `LT:Options`, then confirm it in the session metadata. |
+| Tried `smartUI.layout` or nested `smartUI.options` layout blocks | These are not the Hooks switch for layout; use the hook options instead. |
+| Strict (pixel) comparison still applies | Align the dashboard comparison mode with the session capabilities. |
+| Relying on dashboard toggles only | Hooks still need the correct hook option and capability split shown above. |
 
 ## Related Docs
 

--- a/docs/smartui-iframes-and-embedded-content.md
+++ b/docs/smartui-iframes-and-embedded-content.md
@@ -50,9 +50,9 @@ Pages often include **iframes**: embedded apps, chat widgets, consent managers, 
 
 | Question | Short answer |
 |----------|----------------|
-| Are iframes supported? | **Yes** — snapshots reflect the **real browser output**, including iframe regions when they render. |
-| Will third-party iframes always match pixel-for-pixel? | **No** — cross-origin embeds are **timing- and environment-dependent**; that is expected. |
-| Can SmartUI read DOM inside another site’s iframe? | **No** — browsers block that for cross-origin content. |
+| Are iframes supported? | **Yes**: snapshots reflect the **real browser output**, including iframe regions when they render. |
+| Will third-party iframes always match pixel-for-pixel? | **No**: cross-origin embeds are **timing- and environment-dependent**; that is expected. |
+| Can SmartUI read DOM inside another site’s iframe? | **No**: browsers block that for cross-origin content. |
 
 Embeds load asynchronously; third-party players (YouTube, Vimeo) may show different pixels between runs because of consent, ads, or regional UI. Use waits, **`ignoreDOM`** on the container, or layout comparison when the embed is out of scope.
 
@@ -69,7 +69,7 @@ SmartUI does not override the browser’s security model; plan comparisons accor
 
 For **`<video>`** elements and **embedded players** (often in iframes), SmartUI’s **first-frame** behavior and troubleshooting are documented here:
 
-- [Handle Pages with Videos](/support/docs/smartui-handle-videos/) — includes guidance when **embedded videos via iframe** misbehave, **`ignoreDOM`** on the iframe region, and **CORS / accessibility** of iframe content.
+- [Handle Pages with Videos](/support/docs/smartui-handle-videos/): includes guidance when **embedded videos via iframe** misbehave, **`ignoreDOM`** on the iframe region, and **CORS / accessibility** of iframe content.
 
 ## Element screenshots and frame context
 
@@ -80,7 +80,7 @@ When you use **SmartUI Hooks** to capture a **specific element** (for example [`
 
 ## Full-page and viewport captures
 
-**Full-page** and **viewport** screenshots reflect the **composed** page the browser draws. Same-origin iframes generally composite like any other content. Cross-origin embeds still draw a **rectangle**; what appears inside it depends on the embed loading, cookies, and network—so baselines can be **noisier** than static HTML.
+**Full-page** and **viewport** screenshots reflect the **composed** page the browser draws. Same-origin iframes generally composite like any other content. Cross-origin embeds still draw a **rectangle**; what appears inside it depends on the embed loading, cookies, and network, so baselines can be **noisier** than static HTML.
 
 **Mitigations:** explicit waits, stable viewport size, and **`ignoreDOM`** (or annotations) on the iframe **container** when the embed is intentionally out of scope for the test.
 

--- a/docs/smartui-layout-comparison.md
+++ b/docs/smartui-layout-comparison.md
@@ -85,7 +85,7 @@ Layout Comparison can be executed in two different ways depending on your integr
 
 ### 1. Using SmartUI Hooks (native automation)
 
-If you use **SmartUI Hooks** (visual tests through Selenium / Playwright / Cypress on the grid **without** the `smartui exec` wrapper), **layout comparison is applied per screenshot** by passing **`ignoreType: ["layout"]`** (and `screenshotName`, and optionally `fullPage`, and other layout-related keys) in the **object** you send to **`smartui.takeScreenshot`** via `executeScript`—**not** by relying on `ignoreType` or layout flags **only** inside `LT:Options`.
+If you use **SmartUI Hooks** (visual tests through Selenium / Playwright / Cypress on the grid **without** the `smartui exec` wrapper), **layout comparison is applied per screenshot** by passing **`ignoreType: ["layout"]`** (and `screenshotName`, and optionally `fullPage`, and other layout-related keys) in the **object** you send to **`smartui.takeScreenshot`** via `executeScript`, **not** by relying on `ignoreType` or layout flags **only** inside `LT:Options`.
 
 For **`LT:Options`**, you still set **`smartUI.project`** (and `visual`, credentials). **Do not** assume `LT:Options.ignoreType: ['layout']` or similar capability-only snippets alone will enable layout for Hooks; that does not match current supported behavior.
 

--- a/docs/smartui-multiselect-bulkops.md
+++ b/docs/smartui-multiselect-bulkops.md
@@ -174,7 +174,7 @@ Once approved diffs represent the new expected UI, promote them to Baseline:
   <TabItem value='granular-selection' label='Stay Granular'>
 
 <ul>
-<li>Bulk actions are powerful—always double-check each screenshot thumbnail.</li>
+<li>Bulk actions are powerful: always double-check each screenshot thumbnail.</li>
 <li>Use single selection for high-risk diffs (checkout, payments, authentication).</li>
 </ul>
 
@@ -234,7 +234,7 @@ Once approved diffs represent the new expected UI, promote them to Baseline:
 <p><strong>Fixes</strong>:</p>
 <ul>
 <li>Only <strong>Approved</strong> screenshots can be promoted; re-approve if needed.</li>
-<li>Baseline updates can take a minute to propagate—refresh or reopen the build.</li>
+<li>Baseline updates can take a minute to propagate: refresh or reopen the build.</li>
 <li>Ensure the associated branch/build is not locked by automated workflows.</li>
 </ul>
 

--- a/docs/smartui-root-cause-analysis.md
+++ b/docs/smartui-root-cause-analysis.md
@@ -50,7 +50,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 <NewTag value="Beta" color="#000" bgColor="#ffec02" />
 
-Smart Root Cause Analysis (RCA) in SmartUI helps you instantly identify the underlying reasons for visual mismatches. By analyzing the DOM differences between the baseline and the comparison screenshot, RCA pinpoints exactly what changed—whether it's a style update, content change, or layout shift.
+Smart Root Cause Analysis (RCA) in SmartUI helps you instantly identify the underlying reasons for visual mismatches. By analyzing the DOM differences between the baseline and the comparison screenshot, RCA pinpoints exactly what changed: whether it's a style update, content change, or layout shift.
 
 ## Why use Smart RCA?
 - **Speed**: Instantly find why a pixel-level mismatch occurred.
@@ -88,7 +88,7 @@ Before you begin, please ensure the build was generated using a **<BrandName /> 
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/RCA/RCAicon.png').default} alt="RCA Icon in Toolbar" width="200" height="200" className='doc_img'/>
 </p>
 
-When RCA is activated, DOM diff boxes are automatically enabled. There's nothing manual to configure—you're ready to investigate immediately.
+When RCA is activated, DOM diff boxes are automatically enabled. There's nothing manual to configure, you're ready to investigate immediately.
 
 ### Step 2: Investigate DOM Differences Visually
 

--- a/docs/smartui-smart-comments.md
+++ b/docs/smartui-smart-comments.md
@@ -18,7 +18,7 @@ import NewTag from '../src/component/newTag';
 import CodeBlock from '@theme/CodeBlock';
 import {YOUR_LAMBDATEST_USERNAME, YOUR_LAMBDATEST_ACCESS_KEY} from "@site/src/component/keys";
 
-Smart Comments enables real-time collaboration on SmartUI visual test results. Add comments directly on screenshots and builds, mention teammates, and manage threaded discussions—all without leaving the SmartUI dashboard.
+Smart Comments enables real-time collaboration on SmartUI visual test results. Add comments directly on screenshots and builds, mention teammates, and manage threaded discussions, all without leaving the SmartUI dashboard.
 
 **Key Benefits:**
 - **Contextual Discussions**: Comment directly on specific screenshots and builds
@@ -307,7 +307,7 @@ Comments are specific to each screenshot variant (viewport + browser combination
 
 - Mention relevant team members when their input is needed
 - Use @mentions to bring attention to critical visual issues
-- Avoid over-mentioning—only tag people who need to be involved
+- Avoid over-mentioning: only tag people who need to be involved
 - Combine mentions with clear action items in your comments
 
 </TabItem>
@@ -389,7 +389,7 @@ Comments are specific to each screenshot variant (viewport + browser combination
 **Symptoms**: Draft comment disappears after closing modal or navigating.
 
 **Solutions**:
-1. Drafts are session-based—ensure you haven't refreshed the page
+1. Drafts are session-based: ensure you haven't refreshed the page
 2. Drafts persist only during the active browser session
 3. Try posting the draft immediately if you need to preserve it
 4. Check browser console for any JavaScript errors
@@ -511,7 +511,7 @@ Comments are specific to each screenshot variant (viewport + browser combination
 1. Open Accept modal and start typing: "This looks good, but..."
 2. Close the modal without posting
 3. Navigate to screenshot drawer
-4. Open comment textbox—your draft appears
+4. Open comment textbox, your draft appears
 5. Complete the comment and post it
 6. Draft is cleared after posting
 


### PR DESCRIPTION
## Summary

Applies review feedback to the **SmartUI Hooks: Layout, Full-Page Screenshots, and Smart Ignore** doc, plus a coordinated formatting cleanup across SmartUI docs.

### SmartUI Hooks doc
- Convert Java / Node / Python / C# snippets to **tabbed sections**, matching sibling-doc formatting (`className="docs__val" groupId="language"`).
- Replace `smartui.takeFullPageScreenshot` with `smartui.takeScreenshot` + `fullPage: true`, set at **screenshot level** (not in `LT:Options` at session level).
- Remove the blue `:::info` admonitions; fold their content into prose.
- Fix grammar and drop "reliably" from the yellow warning note.

### Across other SmartUI docs
- Remove remaining `smartui.takeFullPageScreenshot` usage (e.g. `selenium-visual-regression`) in favor of `fullPage: true`.
- Replace em dashes with colons/commas for consistency.

## Files
16 docs updated (see diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)