### PR TITLE
docs: remove em dashes across all docs pages

### DIFF
--- a/docs/accessibility-ai-issue-detection-agent.md
+++ b/docs/accessibility-ai-issue-detection-agent.md
@@ -27,7 +27,7 @@ AI issue analysis should support prioritization and understanding. It should not
 
 1. Open **[Issue Summary](/support/docs/accessibility-testing-dashboard-issue-summary/)** or **[All Issues](/support/docs/accessibility-testing-dashboard-all-issues/)** after a scan completes.
 2. Select an issue or cluster where the UI exposes **AI-assisted** analysis (wording may appear as summary, explanation, or suggested next step).
-3. Read the AI output as **hypothesis support**—verify against the DOM, design intent, and WCAG rule text in the **[rule repositories](/support/docs/accessibility-web-rule-repository/)** where applicable.
+3. Read the AI output as **hypothesis support**, verify against the DOM, design intent, and WCAG rule text in the **[rule repositories](/support/docs/accessibility-web-rule-repository/)** where applicable.
 4. If the suggestion is wrong, capture that feedback through your usual QA process so the team does not over-trust automation.
 5. Pair AI hints with the **[Issue Remediation Guide](/support/docs/accessibility-issue-remediation-guide/)** for engineering-ready fix order.
 

--- a/docs/accessibility-android-what-we-cover.md
+++ b/docs/accessibility-android-what-we-cover.md
@@ -54,11 +54,11 @@ Reserve time for **TalkBack**, **Switch Access**, **font scaling**, and **real d
 
 | Area | Manual verification focus |
 |------|---------------------------|
-| **1.2.x Time-based media** | In-app media — captions, descriptions — validate with representative assets. |
-| **1.3.2–1.3.3 · 1.4.x beyond contrast** | Sequence, sensory-only instructions, resize/reflow/hover content — interactive and visual review. |
-| **2.x keyboard / focus / timing (full)** | Full flows with TalkBack; session and motion behavior — validate beyond rule snapshots. |
-| **3.x language, errors, help** | Error suggestions, legal safeguards — product and compliance review. |
-| **AAA criteria** | Optional stretch goals — plan when AAA is explicitly in scope. |
+| **1.2.x Time-based media** | In-app media (captions, descriptions), validate with representative assets. |
+| **1.3.2–1.3.3 · 1.4.x beyond contrast** | Sequence, sensory-only instructions, resize/reflow/hover content: interactive and visual review. |
+| **2.x keyboard / focus / timing (full)** | Full flows with TalkBack; session and motion behavior, validate beyond rule snapshots. |
+| **3.x language, errors, help** | Error suggestions, legal safeguards: product and compliance review. |
+| **AAA criteria** | Optional stretch goals, plan when AAA is explicitly in scope. |
 
 ## Related docs
 

--- a/docs/accessibility-app-scanner-scan-configurations.md
+++ b/docs/accessibility-app-scanner-scan-configurations.md
@@ -2,7 +2,7 @@
 id: accessibility-app-scanner-scan-configurations
 title: Scan Configurations for Mobile App Accessibility (Manual)
 sidebar_label: Scan Configurations
-description: Configure which accessibility rules run on a manual mobile app scan—pick a WCAG level, toggle rule groups, enable individual rules, and reuse last-used settings.
+description: "Configure which accessibility rules run on a manual mobile app scan: pick a WCAG level, toggle rule groups, enable individual rules, and reuse last-used settings."
 keywords:
   - mobile accessibility scan configuration
   - wcag conformance level
@@ -66,13 +66,13 @@ Use Scan Configurations when users want to scope a manual scan to only the relev
 5. **Fine-tune individual rules.** Within each category, switch specific rules on or off. Anything left on is **Enabled**; anything switched off is **Disabled**.
 6. **Run the scan.** Only the selected rules are evaluated on the device, and the report contains results for exactly those rules.
 
-{/* IMAGE PLACEHOLDER — App Scanner home screen with the Scan Settings summary (original screenshot, compressed to under 100 KB). Save the file at the path below, then uncomment.
-<img loading="lazy" src={require('../assets/images/accessibility-testing/features/scan-settings-home.png').default} alt="App Accessibility Scanner home screen showing the Scan Settings summary — WCAG 2.1 AA, Best Practices On, Beta Rules On, AI Detection Off, Rules 15/15 — and the gear icon that opens scan configuration" className="doc_img"/>
+{/* IMAGE PLACEHOLDER: App Scanner home screen with the Scan Settings summary (original screenshot, compressed to under 100 KB). Save the file at the path below, then uncomment.
+<img loading="lazy" src={require('../assets/images/accessibility-testing/features/scan-settings-home.png').default} alt="App Accessibility Scanner home screen showing the Scan Settings summary (WCAG 2.1 AA, Best Practices On, Beta Rules On, AI Detection Off, Rules 15/15) and the gear icon that opens scan configuration" className="doc_img"/>
 */}
 
 ## Configuration Options Details
 
-{/* IMAGE PLACEHOLDER — scan configuration panel (original screenshot). Save the file at the path below, then uncomment.
+{/* IMAGE PLACEHOLDER: scan configuration panel (original screenshot). Save the file at the path below, then uncomment.
 <img loading="lazy" src={require('../assets/images/accessibility-testing/features/scan-settings-panel.png').default} alt="Scan configuration panel showing WCAG version and level, rule group toggles (Best Practice, Beta, AI-powered), and individual rules grouped by category" className="doc_img"/>
 */}
 
@@ -80,8 +80,8 @@ Use Scan Configurations when users want to scope a manual scan to only the relev
 
 Users select a single WCAG target such as `wcag2a`, `wcag21aa`, or `wcag22aaa`. The selection is **cumulative** higher versions and levels include the lower ones:
 
-- A higher **version** includes the lower ones — choosing **2.1** also brings in all **2.0** rules; choosing **2.2** brings in **2.0 + 2.1**.
-- A higher **level** includes the lower ones — choosing **AA** also brings in all **A** rules; choosing **AAA** brings in **A + AA + AAA**.
+- A higher **version** includes the lower ones: choosing **2.1** also brings in all **2.0** rules; choosing **2.2** brings in **2.0 + 2.1**.
+- A higher **level** includes the lower ones: choosing **AA** also brings in all **A** rules; choosing **AAA** brings in **A + AA + AAA**.
 
 > **Example:** Selecting **WCAG 2.1 AA** runs every rule whose success criterion is in WCAG **2.0 or 2.1** at level **A or AA**. WCAG 2.2 rules and AAA-only rules are **not** included until the version or level is raised.
 
@@ -97,7 +97,7 @@ Some rules carry a special tag in addition to their WCAG criterion. Each tag has
 | **AI-powered** | Rules evaluated by AI Detention Agent (for example, *Image in Text* detection). | OFF |
 
 :::tip
-A rule tagged "Best Practice" will **not** run if the Best Practice toggle is off—even if its WCAG criterion is in range. The same applies to Beta and AI-powered rules. If an expected rule does not run, check its group toggle.
+A rule tagged "Best Practice" will **not** run if the Best Practice toggle is off, even if its WCAG criterion is in range. The same applies to Beta and AI-powered rules. If an expected rule does not run, check its group toggle.
 :::
 
 ### Individual rules and categories
@@ -122,7 +122,7 @@ Within any category, individual rules can be switched on or off. **An explicit s
 Each user's scan configuration is persisted on their last saved scan.
 
 - Every time a user runs a scan, the configuration is saved as that user's **last-used settings**, scoped to **the user account and the platform** (Android and iOS are remembered separately).
-- The next time the user opens the scan configuration panel, it is **pre-filled with the configuration from the most recent scan** on that platform—so the setup does not have to be repeated.
+- The next time the user opens the scan configuration panel, it is **pre-filled with the configuration from the most recent scan** on that platform, so the setup does not have to be repeated.
 - Changing settings and running a new scan **updates** the user's last-used settings to the newest run.
 - This is **per user and per platform**: each user's Android and iOS setups are tracked independently, and teammates' setups do not affect one another.
 
@@ -142,7 +142,7 @@ For users who have never run a configured mobile scan before (no saved settings 
 
 ## What to expect in results
 
-- **Scoped results.** The report contains violations only for the enabled rules. Rules turned off—directly, or through WCAG or group settings—do not appear and do not affect the accessibility score for that scan.
+- **Scoped results.** The report contains violations only for the enabled rules. Rules turned off (directly, or through WCAG or group settings) do not appear and do not affect the accessibility score for that scan.
 - **Faster scans.** Because disallowed rules are skipped **before** they run on the device, narrowing the configuration generally makes scans quicker.
 - **Configuration recorded with the test.** The WCAG version, group toggles, and the enabled or disabled rule lists are stored alongside the scan, so the team can always see how a given result was produced. The exact rules applied to a scan are also visible in the report (see [Scan Configurations via Capabilities (Automation)](/support/docs/accessibility-automation-scan-configurations/#what-to-expect-in-results)).
 
@@ -152,13 +152,13 @@ For users who have never run a configured mobile scan before (no saved settings 
 A check runs only if its WCAG criterion is in range **and** every tag it carries is enabled. If the Best Practice toggle is off, Best Practice rules are skipped regardless of WCAG level. Turn the relevant group toggle on.
 
 **Does every scan need to be reconfigured?**
-No. The last-used configuration is pre-filled automatically (per platform). Users adjust only what they need and run—the scan must be saved for the configuration to persist.
+No. The last-used configuration is pre-filled automatically (per platform). Users adjust only what they need and run. The scan must be saved for the configuration to persist.
 
 **Do configuration changes affect teammates?**
 No. Settings are saved per user and per platform.
 
 **Why are AI-powered rules off by default?**
-They are opt-in by design—AI rules invoke AI evaluation and surface items for manual verification rather than automatic pass/fail. Users enable them when that depth is required.
+They are opt-in by design: AI rules invoke AI evaluation and surface items for manual verification rather than automatic pass/fail. Users enable them when that depth is required.
 
 
 ## Related docs

--- a/docs/accessibility-app-scanner.md
+++ b/docs/accessibility-app-scanner.md
@@ -2,7 +2,7 @@
 id: accessibility-app-scanner
 title: Accessibility App Scanner (Overview)
 sidebar_label: Accessibility App Scanner
-description: Manual mobile app accessibility testing on real devices—upload, session, scan screens, review issues, and export reports.
+description: "Manual mobile app accessibility testing on real devices: upload, session, scan screens, review issues, and export reports."
 slug: accessibility-app-scanner/
 url: https://www.testmuai.com/support/docs/accessibility-app-scanner/
 site_name: TestMu AI
@@ -15,7 +15,7 @@ Accessibility App Scanner is the **manual** mobile app workflow for reviewing ac
 
 ## When to use this
 
-Use App Scanner when you want to **inspect** Android or iOS app screens interactively and validate findings as you move through the app—ideal for exploratory passes, design reviews, or reproducing issues filed by users.
+Use App Scanner when you want to **inspect** Android or iOS app screens interactively and validate findings as you move through the app, ideal for exploratory passes, design reviews, or reproducing issues filed by users.
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ Use App Scanner when you want to **inspect** Android or iOS app screens interact
 2. **Pick a real device** pool that matches your target users (OS + locale).
 3. **Launch the session** and wait until the app is installed and foregrounded.
 4. **Navigate critical journeys** (onboarding, login, checkout, settings). After each major screen stabilizes, trigger the **scan** action the UI provides.
-5. **Review issues** in the side panel or overlay—open each item to see rule text, element context, and suggested remediation where available.
+5. **Review issues** in the side panel or overlay, open each item to see rule text, element context, and suggested remediation where available.
 6. **Save or end** the session so results appear under Accessibility **Reports** for dashboard analysis ([Navigating the Dashboard](/support/docs/accessibility-testing-navigating-dashboard/)).
 7. Optional: run a **[Screen Reader](/support/docs/screen-reader-on-accessibility/)** pass on the same build for manual confirmation.
 

--- a/docs/accessibility-appium-testng.md
+++ b/docs/accessibility-appium-testng.md
@@ -2,7 +2,7 @@
 id: accessibility-appium-testng
 title: Appium TestNG
 sidebar_label: Appium TestNG
-description: Appium TestNG with Accessibility—session capabilities, lambda-accessibility-scan checkpoints, and dashboard review.
+description: "Appium TestNG with Accessibility: session capabilities, lambda-accessibility-scan checkpoints, and dashboard review."
 slug: accessibility-appium-testng/
 url: https://www.testmuai.com/support/docs/accessibility-appium-testng/
 site_name: TestMu AI

--- a/docs/accessibility-appium-webdriverio.md
+++ b/docs/accessibility-appium-webdriverio.md
@@ -2,7 +2,7 @@
 id: accessibility-appium-webdriverio
 title: Appium WebdriverIO
 sidebar_label: Appium WebdriverIO
-description: Appium WebdriverIO with Accessibility—WDIO config, async hooks, lambda-accessibility-scan, and reports.
+description: "Appium WebdriverIO with Accessibility: WDIO config, async hooks, lambda-accessibility-scan, and reports."
 slug: accessibility-appium-webdriverio/
 url: https://www.testmuai.com/support/docs/accessibility-appium-webdriverio/
 site_name: TestMu AI

--- a/docs/accessibility-automation-scan-configurations.md
+++ b/docs/accessibility-automation-scan-configurations.md
@@ -2,7 +2,7 @@
 id: accessibility-automation-scan-configurations
 title: Scan Configurations via Capabilities (Automation)
 sidebar_label: Scan Configurations (Capabilities)
-description: Configure mobile app accessibility scans in automation through Appium capabilities—master toggle, WCAG version, and Best Practice, Beta, and AI rule groups.
+description: "Configure mobile app accessibility scans in automation through Appium capabilities: master toggle, WCAG version, and Best Practice, Beta, and AI rule groups."
 keywords:
   - mobile accessibility automation
   - accessibility capabilities
@@ -58,7 +58,7 @@ Per-rule enable/disable picking is a **Manual-only** feature and is not used in 
 
 ## When to use this
 
-Use these capabilities when users **already run Appium** against <BrandName /> real devices and want each accessibility scan scoped to a specific WCAG target and set of rule groups—without opening a UI. See [Native App Automation Appium (Overview)](/support/docs/accessibility-native-app-automation-test/) for the surrounding test setup and the `lambda-accessibility-scan` hook.
+Use these capabilities when users **already run Appium** against <BrandName /> real devices and want each accessibility scan scoped to a specific WCAG target and set of rule groups, without opening a UI. See [Native App Automation Appium (Overview)](/support/docs/accessibility-native-app-automation-test/) for the surrounding test setup and the `lambda-accessibility-scan` hook.
 
 ## Prerequisites
 
@@ -70,7 +70,7 @@ Use these capabilities when users **already run Appium** against <BrandName /> r
 
 | Capability | Type | Allowed values | Default (RD App Automation) |
 |---|---|---|---|
-| `accessibility` | boolean | `true` / `false` | — (master toggle; must be `true` to enable a11y scanning) |
+| `accessibility` | boolean | `true` / `false` | - (master toggle, must be `true` to enable a11y scanning) |
 | `accessibility.wcagVersion` | string | `wcag2a`, `wcag2aa`, `wcag2aaa`, `wcag21a`, `wcag21aa`, `wcag21aaa`, `wcag22a`, `wcag22aa`, `wcag22aaa` | `wcag21aa` |
 | `accessibility.bestPractice` | boolean | `true` / `false` | `true` |
 | `accessibility.betaRules` | boolean | `true` / `false` | `true` |
@@ -159,11 +159,11 @@ Only the rules in the effective set are evaluated, and the report for that build
 
 - **Scoped results.** Each scan reports violations only for the rules in the test's effective set. Rules outside the WCAG range or behind an off group toggle do not appear and do not affect the accessibility score for that scan.
 - **Configuration recorded with the test.** The WCAG version and group toggles are stored alongside the scan, so the team can always see how a given result was produced.
-- **Applied rules are visible in the report.** The report header shows the applied configuration as tags (for example, **WCAG 2.1 AA**, **Best Practices**, **Beta Rules**), and the **Applied Settings** panel lists every rule that was evaluated—grouped by category and searchable—so the exact selected rules can be confirmed for any scan.
+- **Applied rules are visible in the report.** The report header shows the applied configuration as tags (for example, **WCAG 2.1 AA**, **Best Practices**, **Beta Rules**), and the **Applied Settings** panel lists every rule that was evaluated, grouped by category and searchable, so the exact selected rules can be confirmed for any scan.
 
 The report shows the applied WCAG target and group tags, and the **Applied Settings** panel lists the selected rules by category:
 
-{/* IMAGE PLACEHOLDER — report Applied Settings panel showing the rules evaluated for the scan. Save the screenshot at the path below, then uncomment.
+{/* IMAGE PLACEHOLDER: report Applied Settings panel showing the rules evaluated for the scan. Save the screenshot at the path below, then uncomment.
 <img loading="lazy" src={require('../assets/images/accessibility-testing/features/scan-configurations/applied-settings-report.png').default} alt="Accessibility report header with WCAG 2.1 AA, Best Practices and Beta Rules tags, and the Applied Settings panel listing evaluated rules grouped by category such as Accessibility Labels" className="doc_img"/>
 */}
 

--- a/docs/accessibility-automation.md
+++ b/docs/accessibility-automation.md
@@ -22,7 +22,7 @@ Use this workflow when your team already runs automated web tests and wants repe
 - supported framework integrations
 - automation settings such as WCAG version, best practices, and needs review
 - reporting through the Accessibility dashboard
-- optional CI/CD and HyperExecute orchestration (see **[HyperExecute integration — Selenium accessibility](/support/docs/selenium-hyperexecute-accessibility-tests/)** when running on HyperExecute with Selenium)
+- optional CI/CD and HyperExecute orchestration (see **[HyperExecute integration: Selenium accessibility](/support/docs/selenium-hyperexecute-accessibility-tests/)** when running on HyperExecute with Selenium)
 
 ## Product boundary
 
@@ -35,6 +35,6 @@ For Playwright Accessibility Automation, use Chrome. `pw-chromium` is currently 
 ## Related docs
 
 - [Selenium](/support/docs/accessibility-automation-test/)
-- [HyperExecute integration — Selenium accessibility](/support/docs/selenium-hyperexecute-accessibility-tests/)
+- [HyperExecute integration: Selenium accessibility](/support/docs/selenium-hyperexecute-accessibility-tests/)
 - [Configure Accessibility Automation](/support/docs/accessibility-automation-settings/)
 - [CI/CD Integration Guide](/support/docs/accessibility-cicd-integration-guide/)

--- a/docs/accessibility-choosing-the-right-tool.md
+++ b/docs/accessibility-choosing-the-right-tool.md
@@ -2,7 +2,7 @@
 id: accessibility-choosing-the-right-tool
 title: Choosing the Right Accessibility Tool
 sidebar_label: Choosing the Right Accessibility Tool
-description: Pick DevTools, Automation, Test Scheduling, Web Scanner, mobile paths, reports, checklists, or MCP based on your workflow—with links to each doc.
+description: Pick DevTools, Automation, Test Scheduling, Web Scanner, mobile paths, reports, checklists, or MCP based on your workflow, with links to each doc.
 keywords:
   - TestMu AI
   - Accessibility
@@ -20,7 +20,7 @@ canonical: https://www.testmuai.com/support/docs/accessibility-choosing-the-righ
 
 TestMu AI **Accessibility Testing** spans browser DevTools, web automation, scheduled and Web Scanner scans, native mobile (manual and Appium), reports, checklists, and optional AI/MCP workflows. Use this page as a **router**: match your situation to a starting doc, then follow the linked guides for setup and onboarding.
 
-If you are new to the product, read **[Getting Started with Accessibility Testing](/support/docs/accessibility-testing/)** first—it lists every major path in one place.
+If you are new to the product, read **[Getting Started with Accessibility Testing](/support/docs/accessibility-testing/)** first. It lists every major path in one place.
 
 ---
 
@@ -48,7 +48,7 @@ If you are new to the product, read **[Getting Started with Accessibility Testin
 - you want **manual** or browser-assisted scanning on a live page
 - you need quick investigation without writing test code
 - you want scan types such as [quick scan](/support/docs/accessibility-testing-run-quick-scan/), [full page](/support/docs/accessibility-testing-full-page-scanner/), [partial page](/support/docs/accessibility-testing-partial-page-scanner/), [multi-page](/support/docs/accessibility-testing-multi-page-scanner/), [workflow](/support/docs/accessibility-testing-workflow-scanner/), or [keyboard](/support/docs/accessibility-keyboard-scan/) scan
-- you need to tune DevTools behavior—see [DevTools Settings](/support/docs/accessibility-devtools-settings/) and [Update DevTools](/support/docs/accessibility-update-devtools-extension/)
+- you need to tune DevTools behavior, see [DevTools Settings](/support/docs/accessibility-devtools-settings/) and [Update DevTools](/support/docs/accessibility-update-devtools-extension/)
 
 **Start:** [Accessibility DevTools (Overview)](/support/docs/accessibility-devtools/) → [Install Toolkit](/support/docs/accessibility-testing-install-devtools/) if you have not installed the extension yet.
 
@@ -71,7 +71,7 @@ If you are new to the product, read **[Getting Started with Accessibility Testin
 - [NUnit (C#)](/support/docs/accessibility-nunit-csharp-test/)
 - [Robot Framework](/support/docs/accessibility-robot-framework-test/)
 - [Cucumber (Java)](/support/docs/accessibility-cucumber-java-test/)
-- [HyperExecute integration — Selenium accessibility](/support/docs/selenium-hyperexecute-accessibility-tests/)
+- [HyperExecute integration: Selenium accessibility](/support/docs/selenium-hyperexecute-accessibility-tests/)
 
 **Configuration and pipeline:**
 
@@ -84,7 +84,7 @@ If you are new to the product, read **[Getting Started with Accessibility Testin
 
 - you want **recurring** site scans without opening DevTools each time
 - you need **sitemap**, **CSV**, or **crawler**-driven URL discovery
-- you want the **Accessibility-native** scheduling surface—not the Web Scanner app
+- you want the **Accessibility-native** scheduling surface, not the Web Scanner app
 
 **Start:** [Test Scheduling - Sitemap (Overview)](/support/docs/accessibility-test-scheduling/).
 

--- a/docs/accessibility-cicd-integration-guide.md
+++ b/docs/accessibility-cicd-integration-guide.md
@@ -2,7 +2,7 @@
 id: accessibility-cicd-integration-guide
 title: CI/CD Integration Guide
 sidebar_label: CI/CD Integration Guide
-description: Connect Accessibility Automation to CI/CD—secrets, matrix jobs, gating, and where to review reports after each build.
+description: "Connect Accessibility Automation to CI/CD: secrets, matrix jobs, gating, and where to review reports after each build."
 keywords:
   - TestMu AI
   - Accessibility
@@ -17,7 +17,7 @@ canonical: https://www.testmuai.com/support/docs/accessibility-cicd-integration-
 
 # CI/CD Integration Guide
 
-Use this guide when you want **Accessibility Automation** (Selenium capabilities + hooks or auto-scan) to run on **every PR, nightly, or release branch**—not only from a laptop.
+Use this guide when you want **Accessibility Automation** (Selenium capabilities + hooks or auto-scan) to run on **every PR, nightly, or release branch**, not only from a laptop.
 
 ## Typical CI/CD use cases
 
@@ -34,11 +34,11 @@ Use this guide when you want **Accessibility Automation** (Selenium capabilities
 
 ## Onboarding checklist
 
-1. **Store secrets** as `LT_USERNAME` and `LT_ACCESS_KEY` (or your platform’s secret manager) and inject them into the job—never commit keys to the repo ([credentials guide](/support/docs/using-environment-variables-for-authentication-credentials/)).
+1. **Store secrets** as `LT_USERNAME` and `LT_ACCESS_KEY` (or your platform’s secret manager) and inject them into the job, never commit keys to the repo ([credentials guide](/support/docs/using-environment-variables-for-authentication-credentials/)).
 2. **Reuse the same command** you already use locally (`mvn test`, `dotnet test`, `npm test`, etc.) so CI exercises the identical driver bootstrap that sets `accessibility: true`.
 3. **Start with a smoke slice** (one suite or `@Tag`) so pipeline time stays predictable; expand coverage after reports look correct.
 4. **Open the Automation dashboard** after the first green CI run and confirm the **Accessibility** tab populates; bookmark the filtered view for your team.
-5. **Optional gating:** treat critical/serious new issues like other quality gates—document who can override flakes.
+5. **Optional gating:** treat critical/serious new issues like other quality gates, document who can override flakes.
 
 ## Example: GitHub Actions (pattern)
 
@@ -72,10 +72,10 @@ Adapt `run` to your build tool; the important part is that the invoked tests set
 ## Where to review results
 
 - **Automation** build → **Accessibility** tab for the session ([Selenium flow](/support/docs/accessibility-automation-test/)).
-- For **HyperExecute**, see [HyperExecute integration — Selenium accessibility automation](/support/docs/selenium-hyperexecute-accessibility-tests/).
+- For **HyperExecute**, see [HyperExecute integration: Selenium accessibility automation](/support/docs/selenium-hyperexecute-accessibility-tests/).
 
 ## Related docs
 
 - [Accessibility Automation (Overview)](/support/docs/accessibility-automation/)
 - [Configure Accessibility Automation](/support/docs/accessibility-automation-settings/)
-- [HyperExecute integration — Selenium accessibility automation](/support/docs/selenium-hyperexecute-accessibility-tests/)
+- [HyperExecute integration: Selenium accessibility automation](/support/docs/selenium-hyperexecute-accessibility-tests/)

--- a/docs/accessibility-compliance-guide.md
+++ b/docs/accessibility-compliance-guide.md
@@ -28,10 +28,10 @@ Accessibility Testing supports compliance workflows, but automated results alone
 
 ## Onboarding stakeholders (what to say in week one)
 
-1. **WCAG** is the technical baseline—map automated findings to success criteria using **[Web](/support/docs/accessibility-web-what-we-cover/)**, **[iOS](/support/docs/accessibility-ios-what-we-cover/)**, and **[Android](/support/docs/accessibility-android-what-we-cover/)** checklists plus rule repositories.
+1. **WCAG** is the technical baseline, map automated findings to success criteria using **[Web](/support/docs/accessibility-web-what-we-cover/)**, **[iOS](/support/docs/accessibility-ios-what-we-cover/)**, and **[Android](/support/docs/accessibility-android-what-we-cover/)** checklists plus rule repositories.
 2. **ADA / EAA / 508 conversations** still require **manual evidence** (keyboard-only paths, screen readers, policy docs). Use Accessibility outputs as **inputs**, not the final legal position.
 3. Establish a **definition of done**: e.g., “no open critical/serious automated issues on core journeys + documented manual matrix.”
-4. For procurement or VPAT-style evidence work, pair this guide with **[VPAT and ACR evidence (customer-owned templates)](/support/docs/accessibility-vpat-report-generation/)**—TestMu AI does **not** provide VPAT or ACR reports—and **[Supported WCAG Versions & Browsers](/support/docs/accessibility-supported-wcag-browsers/)**.
+4. For procurement or VPAT-style evidence work, pair this guide with **[VPAT and ACR evidence (customer-owned templates)](/support/docs/accessibility-vpat-report-generation/)** (TestMu AI does **not** provide VPAT or ACR reports) and **[Supported WCAG Versions & Browsers](/support/docs/accessibility-supported-wcag-browsers/)**.
 
 ## Related docs
 

--- a/docs/accessibility-cucumber-java-test.md
+++ b/docs/accessibility-cucumber-java-test.md
@@ -2,7 +2,7 @@
 id: accessibility-cucumber-java-test
 title: Cucumber (Java)
 sidebar_label: Cucumber (Java)
-description: Run Accessibility Automation with Java Cucumber and Selenium—hooks, step defs, shared driver, and Accessibility reports.
+description: "Run Accessibility Automation with Java Cucumber and Selenium: hooks, step defs, shared driver, and Accessibility reports."
 keywords:
   - TestMu AI
   - Accessibility

--- a/docs/accessibility-devtools.md
+++ b/docs/accessibility-devtools.md
@@ -29,7 +29,7 @@ DevTools is not the same as:
 
 - **Accessibility Automation**, which runs through test frameworks
 - **Test Scheduling** (Accessibility), which runs recurring web scans inside the Accessibility product
-- **Web Scanner**, the separate Web Scanner product for URL lists and scans—different navigation tree from Accessibility Test Scheduling
+- **Web Scanner**, the separate Web Scanner product for URL lists and scans, different navigation tree from Accessibility Test Scheduling
 
 ## Typical workflow
 

--- a/docs/accessibility-exporting-sharing-reports.md
+++ b/docs/accessibility-exporting-sharing-reports.md
@@ -29,7 +29,7 @@ Report exports reflect the active issue state for the current report view. In sc
 ## How to export (onboarding)
 
 1. Open the report from **[Navigating the Dashboard](/support/docs/accessibility-testing-navigating-dashboard/)**.
-2. Apply any **filters** or **[hide/restore](/support/docs/accessibility-hide-restore-issues/)** decisions first—exports represent the **current** visible state.
+2. Apply any **filters** or **[hide/restore](/support/docs/accessibility-hide-restore-issues/)** decisions first. Exports represent the **current** visible state.
 3. Use the report’s **export** or **share** action (label varies by surface) and pick the format your stakeholder needs (spreadsheet, PDF, or packaged evidence where offered).
 4. Store exports with **build metadata** (date, commit SHA, scan type) so audit trails stay traceable.
 5. For recurring programs, pair exports with **[Integrations](/support/docs/accessibility-report-integrations/)** so issues also land in Jira or Slack automatically.

--- a/docs/accessibility-fragment-identifier.md
+++ b/docs/accessibility-fragment-identifier.md
@@ -65,10 +65,10 @@ The same three URLs are tracked as **distinct** targets:
 
 ## Benefits
 
-- **Granular issue tracking** — See and triage issues for specific sections or hash states instead of one blended bucket.
-- **Better SPA support** — Hash-based routing and deep links are easier to reason about in the dashboard and reports.
-- **Clearer workflow** — Assign and manage work per fragment when that matches how your app is structured.
-- **Richer reporting** — Reports can reflect section- or state-specific findings where the base URL alone would hide variation.
+- **Granular issue tracking**: See and triage issues for specific sections or hash states instead of one blended bucket.
+- **Better SPA support**: Hash-based routing and deep links are easier to reason about in the dashboard and reports.
+- **Clearer workflow**: Assign and manage work per fragment when that matches how your app is structured.
+- **Richer reporting**: Reports can reflect section- or state-specific findings where the base URL alone would hide variation.
 
 ---
 

--- a/docs/accessibility-ios-rule-accessibility-label-not-punctuated.md
+++ b/docs/accessibility-ios-rule-accessibility-label-not-punctuated.md
@@ -33,7 +33,7 @@ VoiceOver uses punctuation to determine pacing and intonation. A label that ends
 
 - end accessibility labels with a period when they form a complete phrase or sentence
 - use punctuation consistent with the label's tone: period for statements, question mark for questions
-- keep labels concise — a label should describe the element, not be a paragraph
+- keep labels concise: a label should describe the element, not be a paragraph
 - test with VoiceOver to confirm the speech rhythm sounds natural between consecutive elements
 
 ## Related docs

--- a/docs/accessibility-ios-rule-missing-button-element-label.md
+++ b/docs/accessibility-ios-rule-missing-button-element-label.md
@@ -35,7 +35,7 @@ VoiceOver users hear "Button" with no additional context when a button lacks a l
 - set `accessibilityLabel` on every button that does not have visible title text
 - for icon-only buttons, describe the action: "Close", "Open menu", "Share"
 - in SwiftUI, use `.accessibilityLabel("action description")` on `Button` views
-- if the button already has title text, VoiceOver uses it automatically — no additional label needed
+- if the button already has title text, VoiceOver uses it automatically, no additional label needed
 
 ## Related docs
 

--- a/docs/accessibility-ios-rule-missing-image-element-label.md
+++ b/docs/accessibility-ios-rule-missing-image-element-label.md
@@ -21,7 +21,7 @@ The scanner identifies image elements that are visible on screen and carry meani
 
 ## Why it matters
 
-VoiceOver users cannot see images. Without a label, they miss the information the image conveys — whether it is a product photo, an avatar, a status icon, or a chart.
+VoiceOver users cannot see images. Without a label, they miss the information the image conveys, whether it is a product photo, an avatar, a status icon, or a chart.
 
 ## Common failure patterns
 

--- a/docs/accessibility-ios-rule-missing-switch-element-label.md
+++ b/docs/accessibility-ios-rule-missing-switch-element-label.md
@@ -33,7 +33,7 @@ Hearing "Switch, off" tells the user the state but not what the switch controls.
 
 - set `accessibilityLabel` on the `UISwitch` to describe the setting (e.g., "Dark mode", "Push notifications")
 - use `UITableViewCell`'s built-in `textLabel` as the accessibility label for the cell when the switch is the cell's accessory view
-- in SwiftUI, the `Toggle("Label text")` initializer automatically provides a label — ensure it is always populated
+- in SwiftUI, the `Toggle("Label text")` initializer automatically provides a label. Ensure it is always populated
 - test with VoiceOver to confirm the full announcement includes both the setting name and the state
 
 ## Related docs

--- a/docs/accessibility-ios-rule-repository.md
+++ b/docs/accessibility-ios-rule-repository.md
@@ -10,7 +10,7 @@ slug: accessibility-ios-rule-repository/
 
 Use this repository to browse iOS accessibility rules and remediation guidance.
 
-This repository groups iOS accessibility rules—VoiceOver, labeling, touch targets, and related mobile requirements—with pointers into deeper rule pages. Open it when an App Scanner or Native App Automation report cites an iOS finding and you want WCAG-aligned context and remediation next steps.
+This repository groups iOS accessibility rules (VoiceOver, labeling, touch targets, and related mobile requirements) with pointers into deeper rule pages. Open it when an App Scanner or Native App Automation report cites an iOS finding and you want WCAG-aligned context and remediation next steps.
 
 ## When to use this
 

--- a/docs/accessibility-ios-what-we-cover.md
+++ b/docs/accessibility-ios-what-we-cover.md
@@ -51,11 +51,11 @@ Plan extra time for **VoiceOver**, **Switch Control**, **device rotation**, and 
 
 | Area | Manual verification focus |
 |------|---------------------------|
-| **1.2.x Time-based media** | In-app video/audio — captions, descriptions, live captions — validate with real content. |
-| **1.3.2–1.3.5 structure & input purpose** | Meaningful sequence, sensory-only instructions, orientation lock justification, `UITextContentType` / WebView `lang` — design and assistive-tech pass. |
-| **2.x keyboard / focus / timing (full)** | Complete tasks with VoiceOver and hardware keyboard; session timeouts and motion — exercise beyond rule snapshots. |
-| **3.x language, errors, help** | Error suggestion quality, legal safeguards, help consistency — product and compliance review. |
-| **AAA criteria** | Optional stretch goals — schedule only when AAA is explicitly in scope. |
+| **1.2.x Time-based media** | In-app video/audio (captions, descriptions, live captions): validate with real content. |
+| **1.3.2–1.3.5 structure & input purpose** | Meaningful sequence, sensory-only instructions, orientation lock justification, `UITextContentType` / WebView `lang`: design and assistive-tech pass. |
+| **2.x keyboard / focus / timing (full)** | Complete tasks with VoiceOver and hardware keyboard; session timeouts and motion: exercise beyond rule snapshots. |
+| **3.x language, errors, help** | Error suggestion quality, legal safeguards, help consistency: product and compliance review. |
+| **AAA criteria** | Optional stretch goals: schedule only when AAA is explicitly in scope. |
 
 ## Related docs
 

--- a/docs/accessibility-jaws-windows.md
+++ b/docs/accessibility-jaws-windows.md
@@ -2,7 +2,7 @@
 id: accessibility-jaws-windows
 title: JAWS on Windows
 sidebar_label: JAWS on Windows
-description: JAWS on Windows for enterprise manual accessibility validation—sessions, web modes, and triage patterns.
+description: "JAWS on Windows for enterprise manual accessibility validation: sessions, web modes, and triage patterns."
 slug: accessibility-jaws-windows/
 url: https://www.testmuai.com/support/docs/accessibility-jaws-windows/
 site_name: TestMu AI
@@ -22,7 +22,7 @@ Use JAWS when your team needs to validate important desktop screen-reader flows 
 1. Launch **JAWS** before the browser if your IT policy requires it; otherwise JAWS attaches to the active window.
 2. Open **Chrome or Edge** (match your automated scan browsers where possible).
 3. Press **Insert + Space** to enter **Forms mode** when interacting with native controls, and return to virtual cursor for reading-heavy pages (JAWS announces mode changes).
-4. Use **Insert + F6** for headings list, **Insert + F7** for links list—fast ways to audit IA after a scan.
+4. Use **Insert + F6** for headings list, **Insert + F7** for links list, fast ways to audit IA after a scan.
 5. Document findings with **speech history** (Insert + Space, then H) when filing bugs.
 
 ## What to validate

--- a/docs/accessibility-junit5-test.md
+++ b/docs/accessibility-junit5-test.md
@@ -2,7 +2,7 @@
 id: accessibility-junit5-test
 title: JUnit 5
 sidebar_label: JUnit 5
-description: Run Accessibility Automation with Selenium and JUnit 5—capabilities, lifecycle hooks, and dashboard reporting.
+description: "Run Accessibility Automation with Selenium and JUnit 5: capabilities, lifecycle hooks, and dashboard reporting."
 keywords:
   - TestMu AI
   - Accessibility
@@ -17,7 +17,7 @@ canonical: https://www.testmuai.com/support/docs/accessibility-junit5-test/
 
 # JUnit 5
 
-Use this guide when your **Selenium** tests use **JUnit 5 (Jupiter)**. Accessibility is still driven entirely by **grid capabilities** and the **`lambda-accessibility-scan`** hook (or **auto-scan**), identical to the [Selenium Accessibility Automation](/support/docs/accessibility-automation-test/) flow—only the test lifecycle annotations differ.
+Use this guide when your **Selenium** tests use **JUnit 5 (Jupiter)**. Accessibility is still driven entirely by **grid capabilities** and the **`lambda-accessibility-scan`** hook (or **auto-scan**), identical to the [Selenium Accessibility Automation](/support/docs/accessibility-automation-test/) flow. Only the test lifecycle annotations differ.
 
 > **Browsers:** Use **Chrome or Edge** with supported versions for Accessibility Automation.
 

--- a/docs/accessibility-keyboard-scan.md
+++ b/docs/accessibility-keyboard-scan.md
@@ -97,7 +97,7 @@ If you select "**No**":
 
 If you select "**Yes**":
 
-<img loading="lazy" src={require('/assets/images/accessibility-testing/keyboard-scanner/missed-elements-yes.png').default} alt="Yes — missing elements prompt" className="doc_img" width="1360" height="768" />
+<img loading="lazy" src={require('/assets/images/accessibility-testing/keyboard-scanner/missed-elements-yes.png').default} alt="Yes: missing elements prompt" className="doc_img" width="1360" height="768" />
 
 - You'll see the prompt: "Please click on the interactive element(s) that were missed in the tab order"
 - Click on any interactive elements (buttons, links, form fields, etc.) that should be keyboard accessible but weren't in the tab list.

--- a/docs/accessibility-native-app-automation-test.md
+++ b/docs/accessibility-native-app-automation-test.md
@@ -25,7 +25,7 @@ Use this page when your team **already runs Appium** for functional tests and wa
 
 ## Onboarding: first automated mobile accessibility run
 
-1. **Reuse a green Appium suite** without accessibility first—confirm install, locators, and hub connectivity.
+1. **Reuse a green Appium suite** without accessibility first: confirm install, locators, and hub connectivity.
 2. **Add accessibility capability** on the session (exact key names align with your Appium server version; mirror the examples in [Appium TestNG](/support/docs/accessibility-appium-testng/) or [Appium WebdriverIO](/support/docs/accessibility-appium-webdriverio/)).
 3. After each **stable screen** (post-navigation waits), call:
 

--- a/docs/accessibility-nunit-csharp-test.md
+++ b/docs/accessibility-nunit-csharp-test.md
@@ -2,7 +2,7 @@
 id: accessibility-nunit-csharp-test
 title: NUnit (C#)
 sidebar_label: NUnit (C#)
-description: Run Accessibility Automation with Selenium C# and NUnit—RemoteWebDriver capabilities, test lifecycle, and reports.
+description: "Run Accessibility Automation with Selenium C# and NUnit: RemoteWebDriver capabilities, test lifecycle, and reports."
 keywords:
   - TestMu AI
   - Accessibility
@@ -70,7 +70,7 @@ Automation Dashboard → build → **Accessibility** tab (same as [Selenium guid
 
 | Symptom | What to check |
 |--------|----------------|
-| Capability ignored | Selenium 4 requires `AddAdditionalOption` on `ChromeOptions` (or equivalent) for vendor-specific keys—verify spelling. |
+| Capability ignored | Selenium 4 requires `AddAdditionalOption` on `ChromeOptions` (or equivalent) for vendor-specific keys. Verify spelling. |
 | No report | Confirm hook or autoscan as above. |
 
 ## Related docs

--- a/docs/accessibility-nvda-windows.md
+++ b/docs/accessibility-nvda-windows.md
@@ -2,7 +2,7 @@
 id: accessibility-nvda-windows
 title: NVDA on Windows
 sidebar_label: NVDA on Windows
-description: Platform-specific screen reader reference for NVDA on Windows—setup, navigation basics, and what to validate after automated scans.
+description: "Platform-specific screen reader reference for NVDA on Windows: setup, navigation basics, and what to validate after automated scans."
 slug: accessibility-nvda-windows/
 url: https://www.testmuai.com/support/docs/accessibility-nvda-windows/
 site_name: TestMu AI

--- a/docs/accessibility-passed-test-cases.md
+++ b/docs/accessibility-passed-test-cases.md
@@ -29,7 +29,7 @@ Passed checks help teams:
 
 ## How to enable and read Passed Test Cases (onboarding)
 
-1. Open an Accessibility **report settings** or **scan configuration** surface where passed checks are exposed (wording may appear as “Passed tests”, “Include passing checks”, or similar—UI varies by scan type).
+1. Open an Accessibility **report settings** or **scan configuration** surface where passed checks are exposed (wording may appear as “Passed tests”, “Include passing checks”, or similar, UI varies by scan type).
 2. Turn the option **on** before the next run if you want auditors to see green checks alongside violations.
 3. After the run, open **[Issue Summary](/support/docs/accessibility-testing-dashboard-issue-summary/)** and look for passed-rule summaries or toggles that reveal passing rules.
 4. Pair passes with **[Accessibility Web Score](/support/docs/accessibility-web-score/)** trends so leadership sees improvement, not only open defects.

--- a/docs/accessibility-pdf-accessibility-scanning.md
+++ b/docs/accessibility-pdf-accessibility-scanning.md
@@ -27,7 +27,7 @@ PDF accessibility should be treated as its own document-focused workflow. Do not
 
 1. **Confirm scope** with legal or design: which PDFs are in scope (marketing, invoices, user manuals)?
 2. **Upload or target** the PDF through the product flow your account supports for document scanning (menus vary by release).
-3. **Choose WCAG / PDF-UA expectations** aligned with your policy—note that automated checks still require **manual reading order and tag inspection** for high-stakes filings.
+3. **Choose WCAG / PDF-UA expectations** aligned with your policy. Note that automated checks still require **manual reading order and tag inspection** for high-stakes filings.
 4. **Review findings** in the same dashboard patterns as web reports where applicable; export evidence for audits ([exporting](/support/docs/accessibility-exporting-sharing-reports/)).
 5. **Track remediation** in your CMS or document owner tool; re-upload after fixes and re-scan.
 

--- a/docs/accessibility-report-bug.md
+++ b/docs/accessibility-report-bug.md
@@ -33,7 +33,7 @@ Bug Report turns confirmed accessibility findings into engineering work items in
 1. Open **[All Issues](/support/docs/accessibility-testing-dashboard-all-issues/)** and select the finding you want tracked.
 2. Choose **Report bug** (or equivalent) from the row or detail actions.
 3. Confirm the **title** auto-fills from the rule or element; edit so engineers recognize the user impact.
-4. Attach **screenshots or HAR** if the dialog offers uploads—speeds reproduction.
+4. Attach **screenshots or HAR** if the dialog offers uploads (speeds reproduction).
 5. Pick the **integration project** (Jira/Azure/etc.) if connected via **[Integrations](/support/docs/accessibility-report-integrations/)**; otherwise copy the deep link into your tracker manually.
 6. After the engineering fix ships, **re-run** the scan and link the new build to the same ticket for closure.
 

--- a/docs/accessibility-report-integrations.md
+++ b/docs/accessibility-report-integrations.md
@@ -27,7 +27,7 @@ Many integrations are shared platform capabilities. This page exists to explain 
 
 ## Onboarding: wire Jira or Slack for Accessibility
 
-1. Complete the **global** integration setup first—see **[Jira Integration](/support/docs/jira-integration/)** or **[Slack Integration](/support/docs/slack-integration/)** for credentials, OAuth, and workspace allowlists.
+1. Complete the **global** integration setup first. See **[Jira Integration](/support/docs/jira-integration/)** or **[Slack Integration](/support/docs/slack-integration/)** for credentials, OAuth, and workspace allowlists.
 2. In the **Accessibility** report or workspace settings (exact menu depends on UI version), choose the integration you want to **receive** new issues or notifications.
 3. Map **severity or tags** to Jira priorities if the UI offers mapping; otherwise agree a default priority in your triage playbook.
 4. Send a **test ticket** from a non-production report to confirm fields populate correctly.

--- a/docs/accessibility-robot-framework-test.md
+++ b/docs/accessibility-robot-framework-test.md
@@ -2,7 +2,7 @@
 id: accessibility-robot-framework-test
 title: Robot Framework
 sidebar_label: Robot Framework
-description: Run Accessibility Automation when Robot Framework drives Selenium—variables, Open Browser keywords, hooks, and reports.
+description: "Run Accessibility Automation when Robot Framework drives Selenium: variables, Open Browser keywords, hooks, and reports."
 keywords:
   - TestMu AI
   - Accessibility
@@ -37,7 +37,7 @@ Define suite or global variables so every test uses the same grid options:
 ${LT_OPTIONS}    {"accessibility": true, "accessibility.wcagVersion": "wcag21aa"}
 ```
 
-Exact syntax depends on how you merge JSON into capabilities for your `Open Browser` keyword—some teams use a **custom keyword** that builds the options dict in Python and passes it to `Create Dictionary` / `Evaluate`.
+Exact syntax depends on how you merge JSON into capabilities for your `Open Browser` keyword. Some teams use a **custom keyword** that builds the options dict in Python and passes it to `Create Dictionary` / `Evaluate`.
 
 ### 2. Open Browser with Accessibility on
 

--- a/docs/accessibility-sitemap-extraction-url-import.md
+++ b/docs/accessibility-sitemap-extraction-url-import.md
@@ -27,7 +27,7 @@ Use this page when you want to scan many URLs and do not want to add them one by
 
 1. Open **[Test Scheduling](/support/docs/accessibility-test-scheduling/)** and start **[Create Scheduled Scan](/support/docs/accessibility-test-scheduling-scan/)** (or edit an existing schedule).
 2. Choose **manual**, **CSV**, or **sitemap** import depending on where your canonical URL list lives.
-3. For **sitemap**, supply the sitemap URL (often `https://example.com/sitemap.xml`). Wait for extraction to finish, then **review** the list—remove admin-only, duplicate, or non-HTML URLs.
+3. For **sitemap**, supply the sitemap URL (often `https://example.com/sitemap.xml`). Wait for extraction to finish, then **review** the list: remove admin-only, duplicate, or non-HTML URLs.
 4. For **CSV**, align columns with the template your team uses (path, locale, or environment columns if applicable). Validate in a spreadsheet before upload.
 5. For **manual** entry, paste critical journeys first (login, checkout, settings), then broaden coverage.
 6. Save the URL set, then continue with authentication and schedule steps in the scheduling wizard.

--- a/docs/accessibility-talkback-android.md
+++ b/docs/accessibility-talkback-android.md
@@ -2,7 +2,7 @@
 id: accessibility-talkback-android
 title: TalkBack on Android
 sidebar_label: TalkBack on Android
-description: TalkBack on Android devices—enablement, gestures, and what to validate for mobile accessibility.
+description: "TalkBack on Android devices: enablement, gestures, and what to validate for mobile accessibility."
 slug: accessibility-talkback-android/
 url: https://www.testmuai.com/support/docs/accessibility-talkback-android/
 site_name: TestMu AI
@@ -21,7 +21,7 @@ Use TalkBack when validating Android accessibility behavior on mobile devices, e
 
 1. On the device, open **Settings → Accessibility → TalkBack** (path varies by OEM) and toggle **On**.
 2. Complete the **tutorial** gesture set (swipe right then up for default navigation) in a safe test build first.
-3. Enable **Developer options → Show layout bounds** only if your policy allows—helps compare focus rectangles with visuals.
+3. Enable **Developer options → Show layout bounds** only if your policy allows, helps compare focus rectangles with visuals.
 4. Open your app under test; swipe **right** to move to the next focusable element, **double-tap** to activate.
 5. Use **local context menu** (swipe up then right) to jump by headings or controls when available.
 

--- a/docs/accessibility-test-scheduling-login-authentication.md
+++ b/docs/accessibility-test-scheduling-login-authentication.md
@@ -65,7 +65,7 @@ If the site is not reachable from the public internet, combine login with **loca
 
 ### From the scheduler (create or edit)
 
-1. In **Create scan** or **Edit scan**, go to the step where you **add URLs** (manual URLs, CSV, sitemap, or crawler—depending on your setup).
+1. In **Create scan** or **Edit scan**, go to the step where you **add URLs** (manual URLs, CSV, sitemap, or crawler, depending on your setup).
 2. Expand **Advanced options**.
 3. Under login settings, use **Add** next to **Add login configurations** to open the modal.
 
@@ -85,9 +85,9 @@ In the modal:
 1. Choose **New configuration** (or equivalent) to open the editor.
 2. Enter a **configuration name** you will recognize in the list (for example `Staging Microsoft login`).
 3. Select **Authentication type**:
-   - **Basic** — HTTP Basic auth (no HTML form).
-   - **Form** — Username and password on **one** page.
-   - **Multi-page** — Username step, then **Next**, then password (same or different URL).
+   - **Basic**: HTTP Basic auth (no HTML form).
+   - **Form**: Username and password on **one** page.
+   - **Multi-page**: Username step, then **Next**, then password (same or different URL).
 
 4. Fill the fields for that type (see tables below) and **Save**.
 
@@ -101,7 +101,7 @@ Confirm every CSS selector in Chrome (or Edge) DevTools on the real login page: 
 
 ### Basic authentication
 
-Use when the server responds with **HTTP Basic** authentication (browser-style username/password challenge), not when you only have a custom HTML login page—in that case use **Form** or **Multi-page**.
+Use when the server responds with **HTTP Basic** authentication (browser-style username/password challenge), not when you only have a custom HTML login page. In that case use **Form** or **Multi-page**.
 
 | Field | Required | Description |
 |--------|----------|-------------|
@@ -129,9 +129,9 @@ Use when, after opening the **Login Page URL**, the username field, password fie
 
 ### Multi-page authentication
 
-Use for **sequential** flows: enter the username, click **Next** (or equivalent), then enter the password—common with many enterprise identity providers.
+Use for **sequential** flows: enter the username, click **Next** (or equivalent), then enter the password, common with many enterprise identity providers.
 
-#### Step 1 — Login or username page
+#### Step 1: Login or username page
 
 | Field | Required | Description |
 |--------|----------|-------------|
@@ -142,7 +142,7 @@ Use for **sequential** flows: enter the username, click **Next** (or equivalent)
 
 <img loading="lazy" src={require('../assets/images/accessibility-testing/features/login/multi-page-username.png').default} className="doc_img" alt="Multi-page login step one: username page fields" />
 
-#### Step 2 — Password page
+#### Step 2: Password page
 
 | Field | Required | Description |
 |--------|----------|-------------|
@@ -153,7 +153,7 @@ Use for **sequential** flows: enter the username, click **Next** (or equivalent)
 
 <img loading="lazy" src={require('../assets/images/accessibility-testing/features/login/multi-page-password.png').default} className="doc_img" alt="Multi-page login step two: password page fields" />
 
-#### Step 3 — After login
+#### Step 3: After login
 
 | Field | Required | Description |
 |--------|----------|-------------|
@@ -173,9 +173,9 @@ Open **Login configurations** from the dashboard (or the same modal from a scan)
 
 ## Best practices
 
-- **Stable selectors** — Prefer `id`, `name`, `data-testid`, or short attribute-based selectors over long positional paths.
-- **Least privilege** — Use automation or QA accounts, not personal admin accounts.
-- **Post-login URL** — Point at a route that only appears after a successful login so failures are easier to interpret.
+- **Stable selectors**: Prefer `id`, `name`, `data-testid`, or short attribute-based selectors over long positional paths.
+- **Least privilege**: Use automation or QA accounts, not personal admin accounts.
+- **Post-login URL**: Point at a route that only appears after a successful login so failures are easier to interpret.
 
 ## Limitations
 
@@ -194,7 +194,7 @@ Use staging environments with simplified auth, or other supported access paths, 
 | Symptom | What to check |
 |--------|----------------|
 | Scan fails on the first URL | Correct profile selected; **Login Page URL** is the real start of the flow. |
-| Timeout or “element not found” | Selectors, spelling, or UI that loads late—verify in DevTools with throttling if needed. |
+| Timeout or “element not found” | Selectors, spelling, or UI that loads late. Verify in DevTools with throttling if needed. |
 | Multi-page fails after username | **Next Button CSS Selector** targets the visible control; add **Password Page URL** if the path changes. |
 | Works locally, fails on schedule | Cookie banners, geo restrictions, or MFA triggered for automated sessions. |
 

--- a/docs/accessibility-test-scheduling.md
+++ b/docs/accessibility-test-scheduling.md
@@ -29,15 +29,15 @@ This page is for the Accessibility-native scheduling flow. If you use the separa
 
 1. Create the scheduled scan.
 2. Add URLs manually, through CSV, or through sitemap extraction.
-3. Add **saved login configurations** (or tunnel / local access) if required—see [Login & Authentication for Scheduled Scans](/support/docs/accessibility-test-scheduling-login-authentication/).
+3. Add **saved login configurations** (or tunnel / local access) if required. See [Login & Authentication for Scheduled Scans](/support/docs/accessibility-test-scheduling-login-authentication/).
 4. Set the schedule.
 5. Review the resulting reports.
 
 ## Onboarding: schedule your first recurring scan
 
-1. Read **[Steps to Schedule an Accessibility Scan](/support/docs/accessibility-test-scheduling-scan/)** end-to-end once—menus use the same vocabulary as the live product.
+1. Read **[Steps to Schedule an Accessibility Scan](/support/docs/accessibility-test-scheduling-scan/)** end-to-end once. Menus use the same vocabulary as the live product.
 2. Seed URLs using **[Sitemap Extraction & URL Import](/support/docs/accessibility-sitemap-extraction-url-import/)** when you have more than a handful of pages.
-3. If pages sit behind login, open **Add login configurations** in Advanced options or use dashboard **Login configurations**, then attach a profile—see **[Login & Authentication for Scheduled Scans](/support/docs/accessibility-test-scheduling-login-authentication/)** (Basic, Form, Multi-page, or tunnel per your environment) before widening scope.
+3. If pages sit behind login, open **Add login configurations** in Advanced options or use dashboard **Login configurations**, then attach a profile. See **[Login & Authentication for Scheduled Scans](/support/docs/accessibility-test-scheduling-login-authentication/)** (Basic, Form, Multi-page, or tunnel per your environment) before widening scope.
 4. Start with a **weekly** cadence on a **subset** of URLs; promote to daily only after noise is manageable.
 5. After the first run, open **[Navigating the Dashboard](/support/docs/accessibility-testing-navigating-dashboard/)** and confirm aggregates match expectations.
 6. Optional: enable **[Fragment Identifier](/support/docs/accessibility-fragment-identifier/)** in DevTools settings when hash routes should split reporting for SPA teams (web URL grouping only).

--- a/docs/accessibility-testing-dashboard-all-issues.md
+++ b/docs/accessibility-testing-dashboard-all-issues.md
@@ -32,7 +32,7 @@ Use this view when you need issue-level depth rather than summary statistics.
 1. Open a report from the dashboard, then choose **All Issues**.
 2. **Sort or filter** by severity, rule, URL, or state (available controls depend on scan type).
 3. Click an issue to read the **element context**, selector hints, and remediation text where the product provides it.
-4. For noisy or accepted exceptions, use **[Hide and Restore Issues](/support/docs/accessibility-hide-restore-issues/)** so future runs respect your decision—document the reason for auditors.
+4. For noisy or accepted exceptions, use **[Hide and Restore Issues](/support/docs/accessibility-hide-restore-issues/)** so future runs respect your decision. Document the reason for auditors.
 5. For engineering work, use **[Bug Report](/support/docs/accessibility-report-bug/)** or your **[Jira / Slack](/support/docs/accessibility-report-integrations/)** integration so the finding carries screenshots and deep links.
 6. Re-run the same URL or flow after a fix and **compare** issue counts or use **[Passed Test Cases](/support/docs/accessibility-passed-test-cases/)** if enabled for a fuller before/after story.
 

--- a/docs/accessibility-testing-dashboard-issue-summary.md
+++ b/docs/accessibility-testing-dashboard-issue-summary.md
@@ -32,7 +32,7 @@ Use this view when you want to understand report shape and severity before drill
 
 1. From **[Navigating the Dashboard](/support/docs/accessibility-testing-navigating-dashboard/)**, open a completed report.
 2. Select **Issue Summary** (or the equivalent tab/panel name in the UI).
-3. Read **severity totals** first—critical/serious items usually block users or compliance narratives.
+3. Read **severity totals** first. Critical/serious items usually block users or compliance narratives.
 4. Scan **guideline or rule groupings** to see which WCAG themes dominate (contrast, keyboard, forms, ARIA, etc.).
 5. Use **needs-review** and **best-practice** counts to decide how much manual validation you owe before filing engineering tickets.
 6. When a bucket looks actionable, jump to **[All Issues](/support/docs/accessibility-testing-dashboard-all-issues/)** filtered or grouped by that bucket, or open the **[Web Rule Repository](/support/docs/accessibility-web-rule-repository/)** entry for the rule text.

--- a/docs/accessibility-testing-navigating-dashboard.md
+++ b/docs/accessibility-testing-navigating-dashboard.md
@@ -28,7 +28,7 @@ Continue reading to understand the dashboard's purpose and how to navigate betwe
 1. **Sign in** to TestMu AI and open **Accessibility** from the product navigation (exact placement can vary by account layout).
 2. **Locate the report list** for your workspace: completed DevTools sessions, automation builds, scheduled scans, or Web Scanner imports should each appear as rows or cards once processing has finished.
 3. **Pick a report** by name, time, or URL. If nothing appears, confirm the upstream run finished (Automation dashboard for Selenium, or your scan wizard for scheduling/Web Scanner).
-4. **Scan the header** for counts, severity mix, and (if shown) **Accessibility Web Score**—use this as a triage compass before drilling down.
+4. **Scan the header** for counts, severity mix, and (if shown) **Accessibility Web Score**. Use this as a triage compass before drilling down.
 5. Open **[Issue Summary](/support/docs/accessibility-testing-dashboard-issue-summary/)** for grouped insight, then **[All Issues](/support/docs/accessibility-testing-dashboard-all-issues/)** for line-item work.
 6. Use **filters** (date, user, scan type, WCAG-related fields where available) to narrow large histories.
 7. When you are ready to share evidence, use **[Exporting & Sharing Reports](/support/docs/accessibility-exporting-sharing-reports/)** or integrations from **[Integrations](/support/docs/accessibility-report-integrations/)**.

--- a/docs/accessibility-testng-test.md
+++ b/docs/accessibility-testng-test.md
@@ -2,7 +2,7 @@
 id: accessibility-testng-test
 title: TestNG
 sidebar_label: TestNG
-description: Run Accessibility Automation with Selenium and TestNG—capabilities, hooks, TestNG suite layout, and how to review reports in the dashboard.
+description: "Run Accessibility Automation with Selenium and TestNG: capabilities, hooks, TestNG suite layout, and how to review reports in the dashboard."
 keywords:
   - TestMu AI
   - Accessibility

--- a/docs/accessibility-voiceover-macos.md
+++ b/docs/accessibility-voiceover-macos.md
@@ -2,7 +2,7 @@
 id: accessibility-voiceover-macos
 title: VoiceOver on macOS
 sidebar_label: VoiceOver on macOS
-description: VoiceOver on macOS for manual accessibility validation—turn on, rotor, web navigation, and checklist.
+description: "VoiceOver on macOS for manual accessibility validation: turn on, rotor, web navigation, and checklist."
 slug: accessibility-voiceover-macos/
 url: https://www.testmuai.com/support/docs/accessibility-voiceover-macos/
 site_name: TestMu AI
@@ -20,7 +20,7 @@ Use VoiceOver on macOS when your team needs to understand how desktop macOS user
 ## Onboarding: enable VoiceOver and browse the web
 
 1. Open **System Settings → Accessibility → VoiceOver** (names vary slightly by macOS version) and turn VoiceOver **On**, or press **Command + F5**.
-2. Accept the quick-start tutorial the first time—it teaches the **VO** modifier (Control + Option by default).
+2. Accept the quick-start tutorial the first time. It teaches the **VO** modifier (Control + Option by default).
 3. Open **Safari**, load your URL, and use **VO + Right Arrow** to move by rotor setting (start with **DOM** or **auto** mode for web).
 4. Practice the **rotor** (VO + U) to jump by headings, links, or form controls.
 5. Use **Tab** and **Shift+Tab** alongside VoiceOver to confirm focus order matches visual order.

--- a/docs/accessibility-vpat-report-generation.md
+++ b/docs/accessibility-vpat-report-generation.md
@@ -22,12 +22,12 @@ keywords:
 :::danger TestMu AI does not provide VPAT or ACR deliverables
 **TestMu AI does not issue, host, or ship an official VPAT® document or Accessibility Conformance Report (ACR)** as a product output. There is **no** “download VPAT” or “generate VPAT” action in the platform that replaces your organization’s own procurement or accessibility documentation.
 
-What you **do** get from **Accessibility Testing** are **testing artifacts**—issues, severities, URLs or screens, exports, integrations—that **you** may choose to cite while **your team** completes the official **ITI VPAT** (or equivalent) and assigns **Conformance** levels. This page is only a **workflow guide** for that evidence work.
+What you **do** get from **Accessibility Testing** are **testing artifacts** (issues, severities, URLs or screens, exports, integrations) that **you** may choose to cite while **your team** completes the official **ITI VPAT** (or equivalent) and assigns **Conformance** levels. This page is only a **workflow guide** for that evidence work.
 :::
 
 A **Voluntary Product Accessibility Template (VPAT®)** is a structured way to document how a product meets accessibility criteria (commonly WCAG 2.x and/or Section 508 / EN 301 549, depending on the template version you use). Buyers and compliance teams use it in **procurement** and **audit** conversations.
 
-**TestMu AI Accessibility Testing** can speed up **evidence collection**—issue lists, severities, URLs or screens, remediation notes, and exports—but it does **not** auto-generate a finished VPAT or ACR. Filling the official template, assigning **Conformance** levels per criterion, and signing off for your organization remain **human** steps, often with accessibility specialists and legal review.
+**TestMu AI Accessibility Testing** can speed up **evidence collection** (issue lists, severities, URLs or screens, remediation notes, and exports), but it does **not** auto-generate a finished VPAT or ACR. Filling the official template, assigning **Conformance** levels per criterion, and signing off for your organization remain **human** steps, often with accessibility specialists and legal review.
 
 This page walks **end to end** from scoping a release to packaging outputs that **you** can reference when drafting VPAT-style tables **outside** the product. It is **not legal advice**; treat it as a practical bridge between product workflows and VPAT preparation.
 
@@ -48,13 +48,13 @@ Use the product as an **evidence engine** alongside manual testing and policy re
 
 - **Automated and semi-automated findings** tied to pages, components, or builds (web and mobile, depending on your setup).
 - **Coverage signals** (what was scanned, when, and under which WCAG target) to support your “evaluation methods used” narrative.
-- **Triage and remediation context**—issue detail, hide/restore for noise, bug export—so engineering and accessibility leads can align before you freeze wording in the VPAT.
+- **Triage and remediation context**: issue detail, hide/restore for noise, bug export, so engineering and accessibility leads can align before you freeze wording in the VPAT.
 - **Exports and integrations** for stakeholders who work outside the dashboard ([Exporting & Sharing Reports](/support/docs/accessibility-exporting-sharing-reports/), [Integrations (Jira / Slack)](/support/docs/accessibility-report-integrations/)).
 
 What Accessibility Testing **does not** replace:
 
 - **Full manual conformance evaluation** for every success criterion (keyboard-only journeys, zoom/reflow, screen reader behavior, cognitive and multimedia checks where applicable).
-- **Authoritative Conformance** labels (Supports / Partially Supports / Does Not Support / Not Applicable) in the VPAT—those are your judgments, informed by evidence.
+- **Authoritative Conformance** labels (Supports / Partially Supports / Does Not Support / Not Applicable) in the VPAT. Those are your judgments, informed by evidence.
 - **Legal or contractual interpretation** of ADA, EAA, Section 508, or customer-specific accessibility addenda.
 
 For framework language at a high level, see the **[Accessibility Compliance Guide](/support/docs/accessibility-compliance-guide/)**.
@@ -63,41 +63,41 @@ For framework language at a high level, see the **[Accessibility Compliance Guid
 
 Follow these phases in order; later phases assume earlier decisions are documented (scope, WCAG level, build or release ID).
 
-### Phase 1 — Lock scope and standards
+### Phase 1: Lock scope and standards
 
 1. **Define the product boundary** for this VPAT cycle: web app only, mobile apps, admin vs customer surfaces, embedded third-party widgets, etc.
-2. **Pick the VPAT template edition** and the **WCAG conformance target** (e.g. 2.1 AA) your procurement or policy requires. Confirm what your Accessibility projects are configured to use—see **[Supported WCAG Versions & Browsers](/support/docs/accessibility-supported-wcag-browsers/)**.
+2. **Pick the VPAT template edition** and the **WCAG conformance target** (e.g. 2.1 AA) your procurement or policy requires. Confirm what your Accessibility projects are configured to use. See **[Supported WCAG Versions & Browsers](/support/docs/accessibility-supported-wcag-browsers/)**.
 3. **List representative environments**: browsers, OS versions, assistive technologies you will cite in “evaluation methods used.” Align with how you actually test (for example **[Manual Testing (DevTools)](/support/docs/accessibility-devtools/)** and **[Assistive technology (manual)](/support/docs/screen-reader-on-accessibility/)** guides).
 4. **Record a traceability ID** (release version, sprint, or build) and keep the same ID on every export and screenshot filename so auditors can follow the thread.
 
-### Phase 2 — Baseline automated coverage
+### Phase 2: Baseline automated coverage
 
-1. **Run scans** that match your VPAT scope: DevTools sessions for targeted UX, **[Automation](/support/docs/accessibility-automation/)** for regression suites (including the **[HyperExecute integration — Selenium accessibility](/support/docs/selenium-hyperexecute-accessibility-tests/)** guide where you use that integration), **[Test Scheduling](/support/docs/accessibility-test-scheduling/)** or **[Web Scanner](/support/docs/web-scanner-getting-started/)** for broader URL coverage where applicable.
+1. **Run scans** that match your VPAT scope: DevTools sessions for targeted UX, **[Automation](/support/docs/accessibility-automation/)** for regression suites (including the **[HyperExecute integration: Selenium accessibility](/support/docs/selenium-hyperexecute-accessibility-tests/)** guide where you use that integration), **[Test Scheduling](/support/docs/accessibility-test-scheduling/)** or **[Web Scanner](/support/docs/web-scanner-getting-started/)** for broader URL coverage where applicable.
 2. Open completed work in the dashboard using **[Navigating the Dashboard](/support/docs/accessibility-testing-navigating-dashboard/)**; use **[Issue Summary](/support/docs/accessibility-testing-dashboard-issue-summary/)** and **[All Issues](/support/docs/accessibility-testing-dashboard-all-issues/)** for a severity- and criteria-oriented view.
 3. Capture **what was in scope** for each run (URLs, app package, scan type). You will reuse this wording in VPAT “remarks” or evaluation-method sections.
 
-### Phase 3 — Manual verification and gaps
+### Phase 3: Manual verification and gaps
 
 VPAT readers expect evidence beyond automation.
 
 1. Walk **core user journeys** keyboard-only and with assistive technologies relevant to your audience; use your checklist docs as a matrix: **[Web](/support/docs/accessibility-web-what-we-cover/)**, **[iOS](/support/docs/accessibility-ios-what-we-cover/)**, **[Android](/support/docs/accessibility-android-what-we-cover/)** (including **manual test checklist** sections where present).
 2. Log **pass/fail/needs retest** per journey or per WCAG theme, not only per automated issue ID.
-3. For anything **Partially Supports** or **Does Not Support**, collect **screenshots, short repro steps, and dates**—the same artifacts you would attach in a bug or audit response.
+3. For anything **Partially Supports** or **Does Not Support**, collect **screenshots, short repro steps, and dates**. The same artifacts you would attach in a bug or audit response.
 
-### Phase 4 — Triage, remediate, re-scan
+### Phase 4: Triage, remediate, re-scan
 
 1. Use **[Hide and Restore Issues](/support/docs/accessibility-hide-restore-issues/)** only for agreed false positives or noise; document the rationale so your VPAT story matches the report.
 2. Route fixes through engineering; use **[Bug Report](/support/docs/accessibility-report-bug/)** or **[Integrations](/support/docs/accessibility-report-integrations/)** if issues should live in your tracker.
 3. **Re-run** the same scan types after fixes and keep **before/after** exports if procurement asks for remediation history.
 
-### Phase 5 — Package evidence for VPAT tables
+### Phase 5: Package evidence for VPAT tables
 
-1. **Export** the report state you want frozen for this VPAT version ([Exporting & Sharing Reports](/support/docs/accessibility-exporting-sharing-reports/)). Exports reflect **filters and hide/restore** at export time—export intentionally.
+1. **Export** the report state you want frozen for this VPAT version ([Exporting & Sharing Reports](/support/docs/accessibility-exporting-sharing-reports/)). Exports reflect **filters and hide/restore** at export time. Export intentionally.
 2. Build an **evidence index**: map each major VPAT section or WCAG theme to one or more attachments (export file name, dashboard link if permitted internally, ticket IDs).
 3. **Draft table rows** in the official template: for each criterion, add **Conformance**, **Remarks**, and pointers to evidence. Prefer concise remarks that quote scan type, date, and scope (“WCAG 2.1 AA DevTools scan on v2.3.1, 2026-04-10, customer checkout only”).
-4. For **Accessibility Web Score** or similar summaries, use them only as **supporting context**, not as a substitute for criterion-by-criterion statements—see **[Accessibility Web Score](/support/docs/accessibility-web-score/)**.
+4. For **Accessibility Web Score** or similar summaries, use them only as **supporting context**, not as a substitute for criterion-by-criterion statements. See **[Accessibility Web Score](/support/docs/accessibility-web-score/)**.
 
-### Phase 6 — Internal review and publication
+### Phase 6: Internal review and publication
 
 1. Have an **accessibility SME** verify that table wording matches evidence and that no criterion is marked **Supports** without documented manual or automated coverage.
 2. Route through **legal or procurement** per your company policy before sharing externally.
@@ -109,7 +109,7 @@ You will not find a one-to-one button from “issue type” to “VPAT row.” I
 
 - **Rule or issue categories** in the dashboard often **align to WCAG success criteria** or platform checks; use your **[rule repository](/support/docs/accessibility-web-rule-repository/)** (web) or platform equivalents to justify which criterion each finding relates to.
 - **“Supports”** usually requires both absence of blocking defects **and** documented manual checks for that criterion’s intent.
-- **“Partially Supports”** is common when automation passes but assistive technology or keyboard behavior still has gaps—or when only part of the product was evaluated.
+- **“Partially Supports”** is common when automation passes but assistive technology or keyboard behavior still has gaps, or when only part of the product was evaluated.
 - **“Not Applicable”** needs a short justification (e.g. “product has no video; criterion x.x.x not applicable”).
 
 If stakeholders conflate **score** or **issue count** with **legal compliance**, point them to the compliance guide and this page together.
@@ -128,10 +128,10 @@ Before you call the VPAT draft “ready for review,” confirm you have:
 
 ## Common pitfalls
 
-- **Treating a single export as the VPAT** — Buyers expect the ITI-style tables and your org’s responses, not only a scan PDF.
-- **Overselling automation** — Many WCAG criteria need manual judgment; say what was actually tested.
-- **Ignoring scope drift** — A VPAT tied to “v3.0” must not silently reuse v2.9 exports without a documented delta.
-- **Hiding issues without documentation** — Align hide/restore decisions with what you are willing to defend in remarks.
+- **Treating a single export as the VPAT**: Buyers expect the ITI-style tables and your org’s responses, not only a scan PDF.
+- **Overselling automation**: Many WCAG criteria need manual judgment. Say what was actually tested.
+- **Ignoring scope drift**: A VPAT tied to “v3.0” must not silently reuse v2.9 exports without a documented delta.
+- **Hiding issues without documentation**: Align hide/restore decisions with what you are willing to defend in remarks.
 
 ## Related docs
 

--- a/docs/accessibility-web-rule-1-4-12-text-spacing.md
+++ b/docs/accessibility-web-rule-1-4-12-text-spacing.md
@@ -8,7 +8,7 @@ slug: accessibility-web-rule-1-4-12-text-spacing/
 
 # Text Spacing (1.4.12)
 
-Content must remain readable and functional when users override text spacing properties — line height, paragraph spacing, letter spacing, and word spacing — up to specified thresholds.
+Content must remain readable and functional when users override text spacing properties (line height, paragraph spacing, letter spacing, and word spacing) up to specified thresholds.
 
 
 :::info WCAG Reference

--- a/docs/accessibility-web-rule-2-1-1-keyboard.md
+++ b/docs/accessibility-web-rule-2-1-1-keyboard.md
@@ -17,11 +17,11 @@ All interactive functionality must be operable through a keyboard interface with
 
 ## What this rule checks
 
-The scanner verifies that interactive elements (links, buttons, form controls, and custom widgets) are reachable and operable using keyboard alone — Tab, Shift+Tab, Enter, Space, and arrow keys as appropriate.
+The scanner verifies that interactive elements (links, buttons, form controls, and custom widgets) are reachable and operable using keyboard alone: Tab, Shift+Tab, Enter, Space, and arrow keys as appropriate.
 
 ## Why it matters
 
-Users who cannot use a mouse — including people who rely on switch devices, voice control, or screen readers — depend entirely on keyboard access. If a control cannot be reached or activated by keyboard, those users are blocked.
+Users who cannot use a mouse, including people who rely on switch devices, voice control, or screen readers, depend entirely on keyboard access. If a control cannot be reached or activated by keyboard, those users are blocked.
 
 ## Common failure patterns
 

--- a/docs/accessibility-web-rule-2-4-2-page-titled.md
+++ b/docs/accessibility-web-rule-2-4-2-page-titled.md
@@ -32,7 +32,7 @@ The page title is the first thing a screen reader announces when a page loads. I
 
 ## Remediation guidance
 
-- write titles in the format "Page Purpose — Site Name" (e.g., "Order History — Acme Store")
+- write titles in the format "Page Purpose - Site Name" (e.g., "Order History - Acme Store")
 - update `document.title` on route changes in single-page applications
 - include key differentiators when pages are similar (e.g., "Edit Profile" vs. "View Profile")
 - keep titles concise but specific enough to identify the page without seeing it

--- a/docs/accessibility-web-rule-4-1-3-status-messages.md
+++ b/docs/accessibility-web-rule-4-1-3-status-messages.md
@@ -37,7 +37,7 @@ Sighted users see toast notifications, search result counts, and progress indica
 - use `role="status"` for non-urgent updates (result counts, save confirmations)
 - use `role="alert"` for urgent messages (errors, warnings)
 - ensure the live region exists in the DOM before the content is injected (add content to an existing container rather than injecting the container)
-- avoid overusing alerts — frequent announcements interrupt the user's workflow
+- avoid overusing alerts, since frequent announcements interrupt the user's workflow
 
 ## Related docs
 

--- a/docs/accessibility-web-score.md
+++ b/docs/accessibility-web-score.md
@@ -2,7 +2,7 @@
 id: accessibility-web-score
 title: Accessibility Web Score
 sidebar_label: Accessibility Web Score
-description: How the Accessibility Web Score works—severity weights, issue density, formula, bands, and how to use it without mistaking it for legal compliance.
+description: "How the Accessibility Web Score works: severity weights, issue density, formula, bands, and how to use it without mistaking it for legal compliance."
 keywords:
   - TestMu AI
   - Accessibility
@@ -17,7 +17,7 @@ canonical: https://www.testmuai.com/support/docs/accessibility-web-score/
 
 # Accessibility Web Score
 
-The **Accessibility Web Score** is a unified metric that represents the accessibility health of your website or application workflow. Instead of only reading long reports, the score gives you a **clear, actionable number** for where the product stands relative to the issues found in that scan. Use it to **track progress over time**, **compare releases**, and **show improvement trends** to stakeholders—**together** with issue detail and any manual testing your program requires.
+The **Accessibility Web Score** is a unified metric that represents the accessibility health of your website or application workflow. Instead of only reading long reports, the score gives you a **clear, actionable number** for where the product stands relative to the issues found in that scan. Use it to **track progress over time**, **compare releases**, and **show improvement trends** to stakeholders, **together** with issue detail and any manual testing your program requires.
 
 :::caution Not legal or WCAG certification
 The score is **not** the same as WCAG conformance sign-off, VPAT completion, or legal accessibility certification. Always interpret it with **[Issue Summary](/support/docs/accessibility-testing-dashboard-issue-summary/)**, **[All Issues](/support/docs/accessibility-testing-dashboard-all-issues/)**, and your own manual coverage ([compliance guide](/support/docs/accessibility-compliance-guide/)).
@@ -32,7 +32,7 @@ The Accessibility Web Score helps:
 - **Accessibility teams** monitoring problem areas and regression risk  
 - **Developers** who want quick feedback on whether a change **improved or hurt** accessibility before merge  
 
-If you ship digital products for real users, the score is a useful **signal**—not the only bar for “done.”
+If you ship digital products for real users, the score is a useful **signal**, not the only bar for “done.”
 
 ## Where to find it
 
@@ -106,17 +106,17 @@ The **same formula idea** applies whether you are viewing a **single page** or a
 
 ## What impacts your score
 
-- **Severity distribution** — More weight on critical/serious issues lowers the score faster than many minor-only findings.  
-- **Issue density** — More issues **per element** lowers the score; a complex page with more elements affects **y** relative to a tiny page.  
-- **Total element count** — Larger DOMs change the density denominator; the formula is built so density stays meaningful across page sizes.  
+- **Severity distribution**: More weight on critical/serious issues lowers the score faster than many minor-only findings.  
+- **Issue density**: More issues **per element** lowers the score; a complex page with more elements affects **y** relative to a tiny page.  
+- **Total element count**: Larger DOMs change the density denominator; the formula is built so density stays meaningful across page sizes.  
 
 ## Improving your score
 
 Focus on **high-impact** changes:
 
-1. **Fix critical issues first** — They carry the most weight and usually block real users.  
-2. **Reduce density** — Systematic patterns (wrong component library defaults, shared header issues) hurt more than one-off edge cases.  
-3. **Re-scan after meaningful fixes** — Compare score **and** issue lists run-over-run; use **[Exporting & Sharing Reports](/support/docs/accessibility-exporting-sharing-reports/)** for audit trails.  
+1. **Fix critical issues first**: They carry the most weight and usually block real users.  
+2. **Reduce density**: Systematic patterns (wrong component library defaults, shared header issues) hurt more than one-off edge cases.  
+3. **Re-scan after meaningful fixes**: Compare score **and** issue lists run-over-run; use **[Exporting & Sharing Reports](/support/docs/accessibility-exporting-sharing-reports/)** for audit trails.  
 
 For fix order and rule context, use the **[Accessibility Issue Remediation Guide](/support/docs/accessibility-issue-remediation-guide/)** and platform checklists: [Web](/support/docs/accessibility-web-what-we-cover/) · [iOS](/support/docs/accessibility-ios-what-we-cover/) · [Android](/support/docs/accessibility-android-what-we-cover/).
 
@@ -124,7 +124,7 @@ For fix order and rule context, use the **[Accessibility Issue Remediation Guide
 
 1. Open the report from **[Navigating the Dashboard](/support/docs/accessibility-testing-navigating-dashboard/)** and note the score **vs** the previous comparable build.  
 2. Open **[Issue Summary](/support/docs/accessibility-testing-dashboard-issue-summary/)** to see **which severities and rules** moved.  
-3. Only then decide if the score alone is enough for a stakeholder update—or if you need **[Passed Test Cases](/support/docs/accessibility-passed-test-cases/)** and manual notes.  
+3. Only then decide if the score alone is enough for a stakeholder update, or if you need **[Passed Test Cases](/support/docs/accessibility-passed-test-cases/)** and manual notes.  
 
 ## Remember
 

--- a/docs/accessibility-web-what-we-cover.md
+++ b/docs/accessibility-web-what-we-cover.md
@@ -75,15 +75,15 @@ Use this checklist for **quality beyond automated rules**: keyboard journeys, me
 
 | Area | Manual verification focus |
 |------|---------------------------|
-| **1.2.x Time-based media** | Captions, audio description, transcripts, sign language — exercise with real media workflows and tooling. |
-| **1.3.2 Meaningful sequence · 1.3.3 Sensory characteristics · 1.3.5 Identify input purpose** | Reading order, instructions, autofill semantics — design and assisted-tech review. |
-| **1.4.4 Resize text · 1.4.5 Images of text · 1.4.13 Content on hover or focus** | Zoom, images-of-text, hover layers — interactive and visual testing. |
+| **1.2.x Time-based media** | Captions, audio description, transcripts, sign language. Exercise with real media workflows and tooling. |
+| **1.3.2 Meaningful sequence · 1.3.3 Sensory characteristics · 1.3.5 Identify input purpose** | Reading order, instructions, autofill semantics. Design and assisted-tech review. |
+| **1.4.4 Resize text · 1.4.5 Images of text · 1.4.13 Content on hover or focus** | Zoom, images-of-text, hover layers. Interactive and visual testing. |
 | **Full keyboard operability & real focus behavior** | Automated rules support you; still walk critical paths with keyboard only and assistive technologies. |
-| **2.4.5–2.4.6, 2.4.8–2.4.10** | Multiple ways, headings/labels (extended), location — document expectations and verify in session. |
-| **2.2.3–2.2.6 · 2.3.2–2.3.3** | Extended timing and motion — validate against your UX and policy. |
-| **3.1.x Language of parts, unusual words, reading level** | Localization and plain language — content and engineering review. |
-| **3.3.3–3.3.6 Error suggestion / prevention** | Error helpfulness and legal safeguards — review with design and compliance. |
-| **AAA success criteria** | Optional stretch goals — plan explicitly if AAA is in scope; default automation targets A/AA-style coverage. |
+| **2.4.5–2.4.6, 2.4.8–2.4.10** | Multiple ways, headings/labels (extended), location. Document expectations and verify in session. |
+| **2.2.3–2.2.6 · 2.3.2–2.3.3** | Extended timing and motion. Validate against your UX and policy. |
+| **3.1.x Language of parts, unusual words, reading level** | Localization and plain language. Content and engineering review. |
+| **3.3.3–3.3.6 Error suggestion / prevention** | Error helpfulness and legal safeguards. Review with design and compliance. |
+| **AAA success criteria** | Optional stretch goals. Plan explicitly if AAA is in scope; default automation targets A/AA-style coverage. |
 
 ## Related docs
 

--- a/docs/adb-commands-support.md
+++ b/docs/adb-commands-support.md
@@ -169,7 +169,7 @@ result = driver.execute_script("lambda-adb",params)
 
 - **adb shell mkdir** <RealDeviceTag value="Real Device" />
 
-  The `adb shell mkdir` command is used to create new directories on an Android device’s filesystem. It is especially useful when preparing the device environment before automated test runs—ensuring that the required folder structure exists for storing screenshots, logs, or other test-related files. The following is a Python sample using the adb command:
+  The `adb shell mkdir` command is used to create new directories on an Android device’s filesystem. It is especially useful when preparing the device environment before automated test runs, ensuring that the required folder structure exists for storing screenshots, logs, or other test-related files. The following is a Python sample using the adb command:
 
   ```python
   params = {"command": "shell", "text": "mkdir /sdcard/TestResults"}
@@ -197,7 +197,7 @@ result = driver.execute_script("lambda-adb",params)
 
 - **adb shell am** <RealDeviceTag value="Real Device" />
 
-  The `adb shell am command` uses the Activity Manager to control app components on a real device. It’s useful for launching activities, restarting apps, or sending broadcast intents—commonly done during tests to simulate user actions or reset app state. The following is a Python sample using the adb command:
+  The `adb shell am command` uses the Activity Manager to control app components on a real device. It’s useful for launching activities, restarting apps, or sending broadcast intents, commonly done during tests to simulate user actions or reset app state. The following is a Python sample using the adb command:
 
   ```python
   params = {"command": "shell", "text": "am start -n com.example/.MainActivity"}
@@ -250,11 +250,11 @@ result = driver.execute_script("lambda-adb",params)
   
   #### These are the `ls` commands that can are enabled:
 
-  - `ls /sdcard/Download` — Lists all files and directories inside the Downloads folder. Typically used to check if test downloads or app-generated files exist, and to validate proper file creation or cleanup.
+  - `ls /sdcard/Download`: Lists all files and directories inside the Downloads folder. Typically used to check if test downloads or app-generated files exist, and to validate proper file creation or cleanup.
 
-  - `ls /sdcard/Pictures` — Lists all files in the Pictures directory, which usually stores photos and screenshots. Useful for confirming screenshots are saved correctly or for accessing images created during tests.
+  - `ls /sdcard/Pictures`: Lists all files in the Pictures directory, which usually stores photos and screenshots. Useful for confirming screenshots are saved correctly or for accessing images created during tests.
 
-  - `ls /sdcard/Movies` — Lists media files in the Movies folder. Commonly used to validate recorded or downloaded videos and manage video artifacts from test executions.
+  - `ls /sdcard/Movies`: Lists media files in the Movies folder. Commonly used to validate recorded or downloaded videos and manage video artifacts from test executions.
 
   ```python
   # List files in the Downloads folder
@@ -273,11 +273,11 @@ result = driver.execute_script("lambda-adb",params)
   The `adb shell cat` command in Android's shell outputs a file’s contents to the console, allowing quick access to text or binary data on the device. Short for “concatenate,” it’s a common Linux command used to read files. In automation, cat helps inspect logs, reports, images, or videos without manual device access. Text files show readable content, while binary files output raw data that may need special handling. 
   
   #### These are the cat commands that can are enabled:
-    - `cat /sdcard/Download/<filename>` — Outputs the contents of a file in the Downloads folder. Typically used to read logs, reports, or downloaded test artifacts.
+    - `cat /sdcard/Download/<filename>`: Outputs the contents of a file in the Downloads folder. Typically used to read logs, reports, or downloaded test artifacts.
 
-    - `cat /sdcard/Pictures/<filename>` — Outputs the raw binary data of an image file in the Pictures folder, useful for verifying screenshots or photos.
+    - `cat /sdcard/Pictures/<filename>`: Outputs the raw binary data of an image file in the Pictures folder, useful for verifying screenshots or photos.
 
-    - `cat /sdcard/Movies/<filename>` — Outputs raw binary content of video files in the Movies folder, helpful for validating recorded or downloaded videos.
+    - `cat /sdcard/Movies/<filename>`: Outputs raw binary content of video files in the Movies folder, helpful for validating recorded or downloaded videos.
 
   ```python
   params = {"command": "shell", "text": "cat /proc/version"}

--- a/docs/agent-features-and-metrics.md
+++ b/docs/agent-features-and-metrics.md
@@ -3,7 +3,7 @@ id: agent-features-and-metrics
 title: Agent Features & Metrics - Customer Reference Guide
 hide_title: false
 sidebar_label: Features & Metrics
-description: A comprehensive overview of all customer-visible features and metrics for each agent type supported on the platform — Chat, Voice, Phone Caller Inbound, Phone Caller Outbound, and Image Analyzer.
+description: "A comprehensive overview of all customer-visible features and metrics for each agent type supported on the platform: Chat, Voice, Phone Caller Inbound, Phone Caller Outbound, and Image Analyzer."
 keywords:
  - agent features
  - agent metrics
@@ -71,12 +71,12 @@ The platform supports **5 agent types**, each designed for a specific testing sc
 
 #### 📄 Workflow-Based Test Generation
 
-Connect your knowledge sources and let the platform auto-generate test scenarios — no manual scripting needed.
+Connect your knowledge sources and let the platform auto-generate test scenarios, no manual scripting needed.
 
-- **Document Upload** — Upload knowledge base documents (PDF, text files) that your chatbot is expected to understand
-- **Source Integrations** — Connect Confluence, JIRA, or GitHub as knowledge sources
-- **AI Test Generation** — Automatically generates test scenarios from uploaded documents
-- **Real-time Progress** — Live streaming of test generation progress
+- **Document Upload**: Upload knowledge base documents (PDF, text files) that your chatbot is expected to understand
+- **Source Integrations**: Connect Confluence, JIRA, or GitHub as knowledge sources
+- **AI Test Generation**: Automatically generates test scenarios from uploaded documents
+- **Real-time Progress**: Live streaming of test generation progress
 
 <br />
 
@@ -84,13 +84,13 @@ Connect your knowledge sources and let the platform auto-generate test scenarios
 
 Build and manage the exact conversations you want to test, manually or via AI.
 
-- **Manual Scenario Creation** — Create test scenarios with title, description, and expected behavior
-- **AI-Generated Scenarios** — Auto-generate scenarios from uploaded knowledge sources
-- **Validation Criteria** — Define custom pass/fail criteria per scenario (e.g., "Agent must mention return policy", "Agent should not hallucinate product prices")
-- **Special Instructions** — Add specific instructions to guide scenario execution
-- **Persona Assignment** — Assign user personas to scenarios (e.g., "frustrated customer", "first-time user")
-- **Test Profile Association** — Link test data profiles to scenarios for data-driven testing
-- **Scenario Deletion** — Remove scenarios that are no longer needed
+- **Manual Scenario Creation**: Create test scenarios with title, description, and expected behavior
+- **AI-Generated Scenarios**: Auto-generate scenarios from uploaded knowledge sources
+- **Validation Criteria**: Define custom pass/fail criteria per scenario (e.g., "Agent must mention return policy", "Agent should not hallucinate product prices")
+- **Special Instructions**: Add specific instructions to guide scenario execution
+- **Persona Assignment**: Assign user personas to scenarios (e.g., "frustrated customer", "first-time user")
+- **Test Profile Association**: Link test data profiles to scenarios for data-driven testing
+- **Scenario Deletion**: Remove scenarios that are no longer needed
 
 <br />
 
@@ -98,25 +98,25 @@ Build and manage the exact conversations you want to test, manually or via AI.
 
 Group related scenarios together and track results over time.
 
-- **Suite Creation** — Group multiple scenarios into test suites
-- **Test Profile Selection** — Assign a test data profile to the entire suite
-- **Run History** — View all past runs with status, score, and timestamps
-- **Status Filtering** — Filter results by Passed, Failed, In Progress
+- **Suite Creation**: Group multiple scenarios into test suites
+- **Test Profile Selection**: Assign a test data profile to the entire suite
+- **Run History**: View all past runs with status, score, and timestamps
+- **Status Filtering**: Filter results by Passed, Failed, In Progress
 
 <br />
 
 #### 🔌 Endpoint Profiles
 
-Configure how the platform connects to your agent's API — supporting everything from simple REST calls to multi-phase auth flows.
+Configure how the platform connects to your agent's API, supporting everything from simple REST calls to multi-phase auth flows.
 
-- **Postman Collection Import** — Upload Postman collections (with optional environment files) to configure your agent's API. Supports nested folders, collection variables, and environment variable substitution
-- **Manual Configuration** — Define endpoints via JSON with URL, method, headers, and body
-- **Multi-Phase Execution** — Configure suite_setup (login/auth), scenario_setup (session creation), and chat (conversation) phases
-- **Variable Management** — Define static values, auto-generated values (UUID, mobile number, timestamp, email), and extracted values from API responses
-- **Retry & Caching** — Configure retry-on-failure and cache suite setup results to speed up execution
-- **Test Endpoint** — Dry-run your endpoint profile to verify connectivity before running full evaluations
-- **Import/Export** — Export profiles as JSON and import across projects
-- **Default Profile** — Mark one profile as the default for quick evaluation runs
+- **Postman Collection Import**: Upload Postman collections (with optional environment files) to configure your agent's API. Supports nested folders, collection variables, and environment variable substitution
+- **Manual Configuration**: Define endpoints via JSON with URL, method, headers, and body
+- **Multi-Phase Execution**: Configure suite_setup (login/auth), scenario_setup (session creation), and chat (conversation) phases
+- **Variable Management**: Define static values, auto-generated values (UUID, mobile number, timestamp, email), and extracted values from API responses
+- **Retry & Caching**: Configure retry-on-failure and cache suite setup results to speed up execution
+- **Test Endpoint**: Dry-run your endpoint profile to verify connectivity before running full evaluations
+- **Import/Export**: Export profiles as JSON and import across projects
+- **Default Profile**: Mark one profile as the default for quick evaluation runs
 
 <br />
 
@@ -124,10 +124,10 @@ Configure how the platform connects to your agent's API — supporting everythin
 
 Create reusable data sets to power data-driven testing across multiple scenarios.
 
-- **Custom Key-Value Data** — Create reusable test data profiles with typed fields (string, number, boolean, email, URL, JSON)
-- **Default Profile** — Mark one profile as the default
-- **Import/Export** — Share test profiles across projects via JSON export/import
-- **Data Injection** — Test data is injected at runtime for data-driven scenario execution
+- **Custom Key-Value Data**: Create reusable test data profiles with typed fields (string, number, boolean, email, URL, JSON)
+- **Default Profile**: Mark one profile as the default
+- **Import/Export**: Share test profiles across projects via JSON export/import
+- **Data Injection**: Test data is injected at runtime for data-driven scenario execution
 
 <br />
 
@@ -135,10 +135,10 @@ Create reusable data sets to power data-driven testing across multiple scenarios
 
 Interactively test your agent configuration before running a full evaluation suite.
 
-- **Interactive Chat** — Send messages to your configured agent endpoint in real-time
-- **Multi-Turn Conversations** — Maintain conversation context across multiple messages
-- **Connection Testing** — Test connectivity via cURL command verification
-- **Schema Analysis** — Automatic detection of request/response schema from your endpoint
+- **Interactive Chat**: Send messages to your configured agent endpoint in real-time
+- **Multi-Turn Conversations**: Maintain conversation context across multiple messages
+- **Connection Testing**: Test connectivity via cURL command verification
+- **Schema Analysis**: Automatic detection of request/response schema from your endpoint
 
 <br />
 
@@ -146,21 +146,21 @@ Interactively test your agent configuration before running a full evaluation sui
 
 Run evaluations at scale with real-time feedback on your agent's quality.
 
-- **Metric Selection** — Choose which quality metrics to evaluate (or run all)
-- **Endpoint Profile Selection** — Pick which endpoint profile to evaluate against
-- **HyperExecute Integration** — Run evaluations at scale using LambdaTest's HyperExecute infrastructure with optional tunnel configuration for testing agents behind firewalls or private networks
-- **Real-Time Streaming** — Live progress updates during evaluation via Server-Sent Events
+- **Metric Selection**: Choose which quality metrics to evaluate (or run all)
+- **Endpoint Profile Selection**: Pick which endpoint profile to evaluate against
+- **HyperExecute Integration**: Run evaluations at scale using LambdaTest's HyperExecute infrastructure with optional tunnel configuration for testing agents behind firewalls or private networks
+- **Real-Time Streaming**: Live progress updates during evaluation via Server-Sent Events
 
 <br />
 
 #### 🎚️ Metric Threshold Configuration
 
-Define exactly what "passing" means for your project — then enforce it automatically.
+Define exactly what "passing" means for your project, then enforce it automatically.
 
-- **Per-Metric Thresholds** — Set minimum acceptable score (0.0–1.0) for each metric
-- **Higher/Lower is Better** — Configure directionality for each metric
-- **Named Configurations** — Create named threshold configs (e.g., "Strict", "Default")
-- **Active/Inactive Toggle** — Enable or disable threshold configurations
+- **Per-Metric Thresholds**: Set minimum acceptable score (0.0–1.0) for each metric
+- **Higher/Lower is Better**: Configure directionality for each metric
+- **Named Configurations**: Create named threshold configs (e.g., "Strict", "Default")
+- **Active/Inactive Toggle**: Enable or disable threshold configurations
 
 <br />
 
@@ -176,17 +176,17 @@ Get a clear, defensible production-readiness verdict before you ship.
 | 🔴 **RED** | Not ready |
 :::
 
-- **Overall Score** — Weighted composite score (0–100)
-- **Confidence Level** — Based on number of evaluations run
+- **Overall Score**: Weighted composite score (0–100)
+- **Confidence Level**: Based on number of evaluations run
   - HIGH: 100+ evaluations
   - MEDIUM: 50–99 evaluations
   - LOW: 20–49 evaluations
   - VERY_LOW: Fewer than 20 evaluations
-- **Dimension Scores** — Functional Completeness, Quality Standards, Risk Profile, Operational Readiness (each weighted 25%)
-- **Scenario Coverage** — Matrix showing well-tested vs. untested scenarios
-- **Risk Assessment** — AI-powered failure pattern analysis with prioritized action items
-- **Validation Criteria Summary** — Aggregated compliance rate across all criteria
-- **AI Insights** — Actionable recommendations for improvement
+- **Dimension Scores**: Functional Completeness, Quality Standards, Risk Profile, Operational Readiness (each weighted 25%)
+- **Scenario Coverage**: Matrix showing well-tested vs. untested scenarios
+- **Risk Assessment**: AI-powered failure pattern analysis with prioritized action items
+- **Validation Criteria Summary**: Aggregated compliance rate across all criteria
+- **AI Insights**: Actionable recommendations for improvement
 
 <br />
 
@@ -194,10 +194,10 @@ Get a clear, defensible production-readiness verdict before you ship.
 
 Automate ongoing regression coverage without manual intervention.
 
-- **Cron-Based Scheduling** — Schedule evaluations with preset frequencies (Hourly, Daily, Weekdays, Weekly, Monthly) or custom cron expressions
-- **Timezone Support** — Full IANA timezone selection
-- **Pause/Resume** — Temporarily pause and resume scheduled runs
-- **Run History** — Track all scheduled execution results
+- **Cron-Based Scheduling**: Schedule evaluations with preset frequencies (Hourly, Daily, Weekdays, Weekly, Monthly) or custom cron expressions
+- **Timezone Support**: Full IANA timezone selection
+- **Pause/Resume**: Temporarily pause and resume scheduled runs
+- **Run History**: Track all scheduled execution results
 
 </TabItem>
 <TabItem value="metrics" label="Metrics">
@@ -316,10 +316,10 @@ Same **9 quality metrics** as the Chat agent:
 
 Register and manage the phone numbers your voice agent answers on.
 
-- **Add Phone Numbers** — Register your agent's phone numbers with country code selection (20+ countries supported)
-- **Default Phone Number** — Set a default number for quick test execution
-- **Phone Number Display** — Masked display for security with country flag identification
-- **Edit & Delete** — Update phone number details or remove numbers no longer in use
+- **Add Phone Numbers**: Register your agent's phone numbers with country code selection (20+ countries supported)
+- **Default Phone Number**: Set a default number for quick test execution
+- **Phone Number Display**: Masked display for security with country flag identification
+- **Edit & Delete**: Update phone number details or remove numbers no longer in use
 
 <br />
 
@@ -327,11 +327,11 @@ Register and manage the phone numbers your voice agent answers on.
 
 Generate realistic inbound call scenarios at scale with AI or build them manually.
 
-- **AI Scenario Generation** — Generate up to 20 inbound test scenarios with configurable personas, languages, and special instructions
-- **Manual Scenario Creation** — Create scenarios with name, description, expected output
-- **Scenario Deletion** — Remove scenarios no longer needed
-- **Persona Selection** — Choose from available personas or create custom ones to simulate different caller types
-- **Language Support** — Generate scenarios in multiple languages (English, Spanish, etc.)
+- **AI Scenario Generation**: Generate up to 20 inbound test scenarios with configurable personas, languages, and special instructions
+- **Manual Scenario Creation**: Create scenarios with name, description, expected output
+- **Scenario Deletion**: Remove scenarios no longer needed
+- **Persona Selection**: Choose from available personas or create custom ones to simulate different caller types
+- **Language Support**: Generate scenarios in multiple languages (English, Spanish, etc.)
 
 <br />
 
@@ -339,12 +339,12 @@ Generate realistic inbound call scenarios at scale with AI or build them manuall
 
 Control every detail of how the simulated caller sounds and behaves.
 
-- **Voice Selection** — Choose from a library of voices with audio preview (multiple voice providers and accents available)
-- **Voice Preview** — Listen to voice samples with animated waveform visualization before selecting
-- **Background Sound** — Enable simulated background noise (15 presets: cafe, street, factory, rain, crowd, market, train, radio interference, etc.)
-- **Response Timing** — Configure wait time after speech ends (0.5–5.0 seconds) to handle agents that speak in multiple sentences
-- **Max Call Duration** — Set maximum call length (60–1800 seconds) to prevent runaway calls
-- **First Speaker** — Choose who speaks first — the simulated user or the agent
+- **Voice Selection**: Choose from a library of voices with audio preview (multiple voice providers and accents available)
+- **Voice Preview**: Listen to voice samples with animated waveform visualization before selecting
+- **Background Sound**: Enable simulated background noise (15 presets: cafe, street, factory, rain, crowd, market, train, radio interference, etc.)
+- **Response Timing**: Configure wait time after speech ends (0.5–5.0 seconds) to handle agents that speak in multiple sentences
+- **Max Call Duration**: Set maximum call length (60–1800 seconds) to prevent runaway calls
+- **First Speaker**: Choose who speaks first, the simulated user or the agent
 
 <br />
 
@@ -352,9 +352,9 @@ Control every detail of how the simulated caller sounds and behaves.
 
 Create reusable caller personas to standardize how test calls are placed across suites.
 
-- **Agent Profile Creation** — Configure agent personas with name, phone number, voice, and background noise
-- **Profile Library** — Organization-level reusable agent profiles
-- **Active/Inactive Toggle** — Enable or disable profiles
+- **Agent Profile Creation**: Configure agent personas with name, phone number, voice, and background noise
+- **Profile Library**: Organization-level reusable agent profiles
+- **Active/Inactive Toggle**: Enable or disable profiles
 
 <br />
 
@@ -362,10 +362,10 @@ Create reusable caller personas to standardize how test calls are placed across 
 
 Batch your inbound scenarios into suites and run them all with a single action.
 
-- **Suite Creation** — Group multiple scenarios with per-scenario voice and phone configuration
-- **Test Profile Association** — Link test data for data-driven voice testing
-- **Agent Profile Assignment** — Associate agent profiles with suites
-- **Run Suites** — Execute all scenarios in a suite with a single action
+- **Suite Creation**: Group multiple scenarios with per-scenario voice and phone configuration
+- **Test Profile Association**: Link test data for data-driven voice testing
+- **Agent Profile Assignment**: Associate agent profiles with suites
+- **Run Suites**: Execute all scenarios in a suite with a single action
 
 <br />
 
@@ -373,10 +373,10 @@ Batch your inbound scenarios into suites and run them all with a single action.
 
 Trigger, track, and manage live test calls in real-time.
 
-- **Initiate Test Calls** — Trigger simulated inbound calls to your voice agent
-- **Real-Time Monitoring** — Track call status as calls progress
-- **Call Duration Tracking** — Live duration counter during active calls
-- **Call Termination** — End calls in progress if needed
+- **Initiate Test Calls**: Trigger simulated inbound calls to your voice agent
+- **Real-Time Monitoring**: Track call status as calls progress
+- **Call Duration Tracking**: Live duration counter during active calls
+- **Call Termination**: End calls in progress if needed
 
 </TabItem>
 <TabItem value="post-eval" label="Post-evaluation (Recording Analysis)">
@@ -385,15 +385,15 @@ Trigger, track, and manage live test calls in real-time.
 
 #### 📂 Voice Analytics
 
-Upload and analyze real production recordings — no new calls needed.
+Upload and analyze real production recordings, no new calls needed.
 
-- **Recording Upload** — Upload production call recordings (MP3, WAV) from real customer interactions
-- **Transcript Upload** — Upload transcripts alongside recordings for STT comparison
-- **Batch Upload & Analysis** — Upload and analyze multiple recordings in parallel
-- **Selective Metric Analysis** — Choose specific metric categories or individual metrics to analyze
-- **Bookmarking** — Bookmark important recordings for review
-- **Tagging** — Organize recordings with custom tags
-- **Search & Filter** — Find recordings by name, status, date, or tags
+- **Recording Upload**: Upload production call recordings (MP3, WAV) from real customer interactions
+- **Transcript Upload**: Upload transcripts alongside recordings for STT comparison
+- **Batch Upload & Analysis**: Upload and analyze multiple recordings in parallel
+- **Selective Metric Analysis**: Choose specific metric categories or individual metrics to analyze
+- **Bookmarking**: Bookmark important recordings for review
+- **Tagging**: Organize recordings with custom tags
+- **Search & Filter**: Find recordings by name, status, date, or tags
 
 <br />
 
@@ -401,10 +401,10 @@ Upload and analyze real production recordings — no new calls needed.
 
 Listen to any call and follow along with a full, speaker-identified transcript.
 
-- **Audio Player** — Play/pause controls with duration tracking
-- **Full Transcript** — Speaker-identified transcript (agent vs. user)
-- **DTMF Detection** — Phone keypad inputs (0–9, *, #) captured and displayed in transcript
-- **Download** — Download recording audio and transcript files
+- **Audio Player**: Play/pause controls with duration tracking
+- **Full Transcript**: Speaker-identified transcript (agent vs. user)
+- **DTMF Detection**: Phone keypad inputs (0–9, *, #) captured and displayed in transcript
+- **Download**: Download recording audio and transcript files
 
 </TabItem>
 <TabItem value="shared" label="Shared (Both Modes)">
@@ -419,25 +419,25 @@ Listen to any call and follow along with a full, speaker-identified transcript.
 | 🟢 **GREEN** | ≥ 80 | Ready for Production |
 | 🟡 **YELLOW** | 65–79 | Ready with Caveats |
 | 🔴 **RED** | < 65 | Not Ready |
-| ⚪ **NO_DATA** | — | Insufficient data to assess |
+| ⚪ **NO_DATA** | - | Insufficient data to assess |
 :::
 
-- **Overall Score & Confidence** — Weighted score with confidence based on call volume (HIGH: 100+, MEDIUM: 50–99, LOW: 20–49, VERY_LOW: < 20)
-- **Dimension Scores** — Functional Completeness, Quality Standards, Risk Profile, Operational Readiness
-- **Scenario Coverage** — Well-tested vs. untested vs. high-risk scenarios
-- **Failure Pattern Analysis** — AI-powered root cause analysis
-- **Validation Criteria Compliance** — Aggregated pass/fail rates
-- **Prioritized Action Items** — Improvement recommendations with expected impact
+- **Overall Score & Confidence**: Weighted score with confidence based on call volume (HIGH: 100+, MEDIUM: 50–99, LOW: 20–49, VERY_LOW: < 20)
+- **Dimension Scores**: Functional Completeness, Quality Standards, Risk Profile, Operational Readiness
+- **Scenario Coverage**: Well-tested vs. untested vs. high-risk scenarios
+- **Failure Pattern Analysis**: AI-powered root cause analysis
+- **Validation Criteria Compliance**: Aggregated pass/fail rates
+- **Prioritized Action Items**: Improvement recommendations with expected impact
 
 <br />
 
 #### 🎚️ Metric Configuration
 
-Select exactly which metrics to run — skip what's not relevant to reduce time and cost.
+Select exactly which metrics to run. Skip what's not relevant to reduce time and cost.
 
-- **Configurable Metrics** — Select which metric categories to evaluate per project, or choose individual metrics for granular control
-- **Category Toggles** — Enable/disable entire metric categories
-- **Reduce Complexity** — Skip non-critical metrics to reduce analysis time and cost
+- **Configurable Metrics**: Select which metric categories to evaluate per project, or choose individual metrics for granular control
+- **Category Toggles**: Enable/disable entire metric categories
+- **Reduce Complexity**: Skip non-critical metrics to reduce analysis time and cost
 
 <br />
 
@@ -445,10 +445,10 @@ Select exactly which metrics to run — skip what's not relevant to reduce time 
 
 Keep coverage running continuously without manual effort.
 
-- **Cron-Based Scheduling** — Schedule test executions with preset frequencies (Hourly, Daily, Weekdays, Weekly, Monthly) or custom cron expressions
-- **Timezone Support** — Full IANA timezone selection
-- **Pause/Resume** — Temporarily pause and resume scheduled runs
-- **Run History** — Track all scheduled execution results
+- **Cron-Based Scheduling**: Schedule test executions with preset frequencies (Hourly, Daily, Weekdays, Weekly, Monthly) or custom cron expressions
+- **Timezone Support**: Full IANA timezone selection
+- **Pause/Resume**: Temporarily pause and resume scheduled runs
+- **Run History**: Track all scheduled execution results
 
 </TabItem>
 <TabItem value="metrics" label="Metrics">
@@ -566,8 +566,8 @@ The system automatically detects and flags the following issues in every call re
 |--------|-------------|--------|--------|
 | Average Latency | ≤ 1000ms | ≤ 2500ms | > 2500ms |
 | Words Per Minute | ≥ 160 (Fast) | 131–160 (Good) | < 110 (Slow) |
-| Voice Quality Index | ≥ 2.5 / 5 | — | < 2.5 / 5 |
-| Average Pitch | 85–300 Hz (Normal) | — | < 85 or > 300 Hz |
+| Voice Quality Index | ≥ 2.5 / 5 | - | < 2.5 / 5 |
+| Average Pitch | 85–300 Hz (Normal) | - | < 85 or > 300 Hz |
 
 </TabItem>
 </Tabs>
@@ -587,24 +587,24 @@ Phone Caller Outbound supports the **same two evaluation modes** as Inbound (Pre
 
 #### Outbound-Specific Pre-evaluation Features
 
-- **Scenario Generation** — Generate up to **7** outbound test scenarios (vs. 20 for inbound)
-- **Caller Profile Selection** — Select an outbound caller profile when generating scenarios
-- **Outbound Number Pool** — Reserve phone numbers from the outbound pool for test calls
-- **Passive Mode** — Listen to outbound calls without interfering (for QA monitoring)
-- **First Speaker Default** — Agent speaks first (vs. simulator for inbound)
+- **Scenario Generation**: Generate up to **7** outbound test scenarios (vs. 20 for inbound)
+- **Caller Profile Selection**: Select an outbound caller profile when generating scenarios
+- **Outbound Number Pool**: Reserve phone numbers from the outbound pool for test calls
+- **Passive Mode**: Listen to outbound calls without interfering (for QA monitoring)
+- **First Speaker Default**: Agent speaks first (vs. simulator for inbound)
 
 <br />
 
 #### Outbound Pool Management
 
-- **View Pool Status** — See available outbound numbers
-- **Reservations** — View and manage per-suite number reservations
-- **Clear Reservations** — Release reserved numbers when done
+- **View Pool Status**: See available outbound numbers
+- **Reservations**: View and manage per-suite number reservations
+- **Clear Reservations**: Release reserved numbers when done
 
 <br />
 
 :::tip
-All other features — phone number management, voice configuration, test suites, call execution, post-evaluation (voice analytics, recording upload, batch analysis), go-live assessment, metrics, and scheduling — are **identical to Phone Caller Inbound**.
+All other features (phone number management, voice configuration, test suites, call execution, post-evaluation, go-live assessment, metrics, and scheduling) are **identical to Phone Caller Inbound**.
 :::
 
 </TabItem>
@@ -612,7 +612,7 @@ All other features — phone number management, voice configuration, test suites
 
 <br />
 
-Same as Phone Caller Inbound — all **8 categories** and **30+ metrics**.
+Same as Phone Caller Inbound, all **8 categories** and **30+ metrics**.
 
 </TabItem>
 </Tabs>
@@ -628,18 +628,18 @@ Same as Phone Caller Inbound — all **8 categories** and **30+ metrics**.
 
 #### 🖼️ Image Analysis
 
-Upload single images or batch-process up to 50 at once — via file upload or URL.
+Upload single images or batch-process up to 50 at once, via file upload or URL.
 
-- **Single Image Analysis** — Upload an image (or provide a URL) along with the original prompt used to generate it
-- **Batch Analysis** — Analyze up to 50 images at once with a shared prompt
-- **Drag & Drop Upload** — Drag and drop images directly into the upload area
-- **Supported Formats** — JPG, JPEG, PNG, GIF, WEBP, BMP (max 20 MB per image)
+- **Single Image Analysis**: Upload an image (or provide a URL) along with the original prompt used to generate it
+- **Batch Analysis**: Analyze up to 50 images at once with a shared prompt
+- **Drag & Drop Upload**: Drag and drop images directly into the upload area
+- **Supported Formats**: JPG, JPEG, PNG, GIF, WEBP, BMP (max 20 MB per image)
 
 <br />
 
 #### 🎯 Custom Evaluation Criteria
 
-Define what "good" means for your images — choose from three criteria types:
+Define what "good" means for your images. Choose from three criteria types:
 
 <Tabs>
 <TabItem value="brand" label="Brand Guidelines">
@@ -680,18 +680,18 @@ All criteria support Active/Inactive toggling, create/edit/delete operations, an
 
 #### 📋 Analysis History
 
-- **Search** — Find past analyses by image name or prompt text
-- **Status Tracking** — View analysis status (Pending, Completed, Failed)
-- **Detailed View** — Click any analysis to view full results
-- **Bookmarking** — Bookmark important analyses for quick access
+- **Search**: Find past analyses by image name or prompt text
+- **Status Tracking**: View analysis status (Pending, Completed, Failed)
+- **Detailed View**: Click any analysis to view full results
+- **Bookmarking**: Bookmark important analyses for quick access
 
 <br />
 
 #### 📊 Analytics Dashboard
 
-- **Overall Statistics** — Average score, highest score, lowest score, total analyses count
-- **Quality Trends** — Daily score breakdown over the last 30 days with bar chart visualization
-- **Prompt Performance** — Top 20 prompts ranked by average quality score, showing min/max scores, usage count, and comparison vs. overall average
+- **Overall Statistics**: Average score, highest score, lowest score, total analyses count
+- **Quality Trends**: Daily score breakdown over the last 30 days with bar chart visualization
+- **Prompt Performance**: Top 20 prompts ranked by average quality score, showing min/max scores, usage count, and comparison vs. overall average
 
 </TabItem>
 <TabItem value="metrics" label="Metrics">
@@ -736,9 +736,9 @@ For each active criterion, results show:
 
 ### 🗂️ Project Management
 
-- **Create Agents** — Name, description, and agent type selection
-- **Agent Listing** — View all agents with type-specific icons and filtering
-- **Agent Dashboard** — Overview of workflows, suites, and recent activity
+- **Create Agents**: Name, description, and agent type selection
+- **Agent Listing**: View all agents with type-specific icons and filtering
+- **Agent Dashboard**: Overview of workflows, suites, and recent activity
 
 <br />
 

--- a/docs/alttester-unity-game-automation.md
+++ b/docs/alttester-unity-game-automation.md
@@ -278,7 +278,7 @@ The suite runs on **Pixel 8 (Android 14)** by default. To target a different dev
 "platformVersion": "14",
 "platformName": "android",
 
-# iOS — uncomment and adjust
+# iOS: uncomment and adjust
 # "deviceName": "iPhone 14",
 # "platformVersion": "16",
 # "platformName": "ios",

--- a/docs/analytics-dashboards-custom-widgets.md
+++ b/docs/analytics-dashboards-custom-widgets.md
@@ -302,7 +302,7 @@ Get a per-device breakdown showing test count and total duration on each dedicat
 
 Create one widget for **App Automation** and one for **Real Device** testing.
 
-#### Testing by Type — Table
+#### Testing by Type: Table
 
 Get a product-level summary (e.g., "App Automation Real Device", "Manual App Testing Real Device") for dedicated devices.
 
@@ -315,7 +315,7 @@ Get a product-level summary (e.g., "App Automation Real Device", "Manual App Tes
 
 Create one widget for **App Automation** and one for **Real Device** testing.
 
-#### Testing by Type — Bar Chart
+#### Testing by Type: Bar Chart
 
 Same data as the table above, rendered as a bar chart for visual comparison.
 

--- a/docs/analytics-insights-app-profiling.md
+++ b/docs/analytics-insights-app-profiling.md
@@ -83,16 +83,16 @@ Each per-metric trend widget and Label Page Load Time supports **Compare** mode.
 
 Compare dimensions:
 
-- **OS** — Android vs iOS
-- **Device** — for example Galaxy S23 vs Pixel 8 vs iPhone 15 Pro
-- **App Build Version** — for build-over-build comparisons
-- **Label** — for page-transition-level breakdowns
+- **OS**: Android vs iOS
+- **Device**: for example Galaxy S23 vs Pixel 8 vs iPhone 15 Pro
+- **App Build Version**: for build-over-build comparisons
+- **Label**: for page-transition-level breakdowns
 
-Compare is scoped to the widget — enabling it on one chart does not affect others. Performance Overview, Performance Trends and Device Performance Matrix do not expose Compare: the first two are summary widgets (use filters to change the data scope instead), and the matrix already breaks data down per device.
+Compare is scoped to the widget. Enabling it on one chart does not affect others. Performance Overview, Performance Trends and Device Performance Matrix do not expose Compare: the first two are summary widgets (use filters to change the data scope instead), and the matrix already breaks data down per device.
 
 ## SLA thresholds
 
-SLA thresholds are configured at the **organisation level** by an admin. Once set, the same threshold is applied everywhere a metric is rendered — Performance Overview cards, Performance Trends overlays, Device Performance Matrix cells, Label Page Load Time, and the per-metric trend widgets.
+SLA thresholds are configured at the **organisation level** by an admin. Once set, the same threshold is applied everywhere a metric is rendered: Performance Overview cards, Performance Trends overlays, Device Performance Matrix cells, Label Page Load Time, and the per-metric trend widgets.
 
 Default thresholds:
 
@@ -123,17 +123,17 @@ Admins can override the defaults at the organisation level. Regular users see th
 
 A strip of KPI cards summarising the headline metrics over the selected window.
 
-- **Avg CPU (%)** — application CPU usage averaged across sessions in scope.
-- **Avg Memory (MB)** — application memory usage averaged across sessions in scope.
-- **Avg FPS** — frames per second averaged across sessions in scope.
-- **Avg Cold Startup (ms)** — cold-start duration averaged across sessions in scope.
-- **Avg Crashes per Crashed Session** — `avg(crash_count)` over sessions that reported at least one crash. This is the mean crash count among already-crashed sessions, not a crash rate.
+- **Avg CPU (%)**: application CPU usage averaged across sessions in scope.
+- **Avg Memory (MB)**: application memory usage averaged across sessions in scope.
+- **Avg FPS**: frames per second averaged across sessions in scope.
+- **Avg Cold Startup (ms)**: cold-start duration averaged across sessions in scope.
+- **Avg Crashes per Crashed Session**: `avg(crash_count)` over sessions that reported at least one crash. This is the mean crash count among already-crashed sessions, not a crash rate.
 
 > Cards are hidden automatically when the underlying metric are not recorded for the test session.
 
 ### 2. Performance Trends
 
-A single time-series chart that overlays selected metrics on dual Y-axes. The **KPIs** selector in the widget header controls which series are visible — CPU, FPS, Memory, Temperature, Battery, Network Upload and Network Download are available; CPU and Memory are on by default. Each visible KPI gets a Min / Max / Avg row in the stats panel below the chart.
+A single time-series chart that overlays selected metrics on dual Y-axes. The **KPIs** selector in the widget header controls which series are visible: CPU, FPS, Memory, Temperature, Battery, Network Upload and Network Download are available; CPU and Memory are on by default. Each visible KPI gets a Min / Max / Avg row in the stats panel below the chart.
 
 ### 3. Device Performance Matrix
 
@@ -149,13 +149,13 @@ A table comparing performance metrics across the devices that ran in the filtere
 | **FPS** | Frame rate, colour-coded against the configured SLA threshold |
 | **Sessions** | Session count for that device in the filtered scope |
 
-Click any column header to sort. The dashboard-level **Device** filter intentionally does not narrow this widget — the matrix is itself the device breakdown.
+Click any column header to sort. The dashboard-level **Device** filter intentionally does not narrow this widget. The matrix is itself the device breakdown.
 
 ### 4. Label Page Load Time
 
 Duration per page transition label, captured from the `label` events recorded inside the test. Each visible label is plotted as a horizontal bar showing its average duration; the widget shows the top labels by session count by default, and a label selector inside the widget lets you add or remove labels from the chart.
 
-SLA thresholds render as vertical green/amber/red bands behind the bars, with the configured threshold drawn as a dashed reference line — bars that extend into the red band are out of SLA. The stats panel below the chart reports Min / Max / Avg duration across the visible labels.
+SLA thresholds render as vertical green/amber/red bands behind the bars, with the configured threshold drawn as a dashed reference line. Bars that extend into the red band are out of SLA. The stats panel below the chart reports Min / Max / Avg duration across the visible labels.
 
 ### 5. CPU Utilization Trend
 

--- a/docs/analytics-insights-private-real-devices.md
+++ b/docs/analytics-insights-private-real-devices.md
@@ -97,11 +97,11 @@ We provide a range of filters to help you customize your insights dashboard. You
 
 ## Custom Widgets for Private Devices
 
-The widgets above provide standard, pre-built dashboards for private real device insights. If you need more tailored views — such as per-device test counts, duration breakdowns by product, or bar chart comparisons — you can build **custom widgets** using the Custom Widget builder.
+The widgets above provide standard, pre-built dashboards for private real device insights. If you need more tailored views (such as per-device test counts, duration breakdowns by product, or bar chart comparisons), you can build **custom widgets** using the Custom Widget builder.
 
 All custom widgets for private devices use the filter `is_dedicated = Equals = true` to scope data to your dedicated devices only.
 
-For step-by-step instructions and recommended widget configurations, see [Custom Widgets — Private/Dedicated Device Widgets](/support/docs/dashboards-custom-widgets/#privatededicated-device-widgets).
+For step-by-step instructions and recommended widget configurations, see [Custom Widgets: Private/Dedicated Device Widgets](/support/docs/dashboards-custom-widgets/#privatededicated-device-widgets).
 
 ## Support
 

--- a/docs/analytics-modules-accessibility-widgets.md
+++ b/docs/analytics-modules-accessibility-widgets.md
@@ -58,7 +58,7 @@ The Accessibility Widgets module is currently in  <NewTag value="BETA" bgColor="
 3. Pick a **date range** that includes at least one completed Accessibility scan; empty widgets usually mean no data in range.
 4. Start with **Accessibility Test Overview** for totals, then **Types of Scans** to confirm manual vs automated mix, then **Top 10 URLs Issue Criticality** for remediation focus.
 5. Click through any **drill-down** links the widgets expose to jump into the underlying Accessibility report when available.
-6. For executive readouts, **export** or screenshot the widgets and pair them with narrative from **[Accessibility Compliance Guide](/support/docs/accessibility-compliance-guide/)**—widgets summarize engineering signals, not legal conclusions.
+6. For executive readouts, **export** or screenshot the widgets and pair them with narrative from **[Accessibility Compliance Guide](/support/docs/accessibility-compliance-guide/)**. Widgets summarize engineering signals, not legal conclusions.
 
 ## Accessibility Test Overview
 

--- a/docs/analytics-modules-flaky-tests.md
+++ b/docs/analytics-modules-flaky-tests.md
@@ -46,7 +46,7 @@ The best way to analyze your flaky tests is to use Test Intelligence. Test Intel
 </div>
 
 :::note Get Flaky Alerts on Slack
-Don't want to keep checking the dashboard? If you have the [Slack Integration](/docs/slack-integration/) enabled, turn on the **Flaky Test Messages** preference to receive a Slack alert the **first time** <BrandName /> detects a test as flaky — including the test name, build, and flake rate. Alerts are opt-in and off by default.
+Don't want to keep checking the dashboard? If you have the [Slack Integration](/docs/slack-integration/) enabled, turn on the **Flaky Test Messages** preference to receive a Slack alert the **first time** <BrandName /> detects a test as flaky, including the test name, build, and flake rate. Alerts are opt-in and off by default.
 :::
 
 ## Flakiness Trends

--- a/docs/analytics-modules-test-manager-widgets.md
+++ b/docs/analytics-modules-test-manager-widgets.md
@@ -62,12 +62,12 @@ Every widget supports configurable filters. Click the **three-dot menu** on any 
 :::
 
 :::tip Drill Down into Data
-All widgets support drill-down. Click on any data point in a chart — such as a segment in a pie chart, a bar in a bar chart, or a status value — to view the underlying list of associated records (e.g., test cases, test runs, or issues) that make up that data point.
+All widgets support drill-down. Click on any data point in a chart (such as a segment in a pie chart, a bar in a bar chart, or a status value) to view the underlying list of associated records (e.g., test cases, test runs, or issues) that make up that data point.
 :::
 
 ## Test Cases Summary
 
-The Test Cases Summary widget displays the total count of test cases and the split between **Automated** and **Manual** test cases. The classification is determined by the **Automation Status** field on each test case — if set to *Automated*, it is counted under Automated; all others fall into the Manual category.
+The Test Cases Summary widget displays the total count of test cases and the split between **Automated** and **Manual** test cases. The classification is determined by the **Automation Status** field on each test case. If set to *Automated*, it is counted under Automated; all others fall into the Manual category.
 
 ### How it works?
 
@@ -155,9 +155,9 @@ The Execution Progress widget displays overall test execution progress as a perc
 * The gauge shows the completion percentage, computed as **(Total test run instances − Not Started instances) / Total test run instances**.
 * Any test instance in a status other than *Not Started* (such as Passed, Failed, Skipped, Blocked, or custom statuses) is counted under **Executed**.
 * A side panel next to the gauge displays three counters:
-    * **Total** — the total number of test run instances in scope.
-    * **Executed** — instances that have moved out of the *Not Started* status.
-    * **Remaining** — instances still in the *Not Started* status.
+    * **Total**: the total number of test run instances in scope.
+    * **Executed**: instances that have moved out of the *Not Started* status.
+    * **Remaining**: instances still in the *Not Started* status.
 * Apply filters from the three-dot menu to scope the widget to a specific test run, phase, or stage.
 
 ### Value Proposition
@@ -172,17 +172,17 @@ The Test Execution Burndown widget tracks how remaining test executions trend do
 
 * The **X-axis** represents dates across the selected execution window, and the **Y-axis** represents the number of remaining test run instances (instances still in *Not Started* status).
 * Three trend lines are plotted:
-    * **Actual** (solid blue) — remaining *Not Started* instances per day, reflecting real execution progress up to today.
-    * **Expected** (dashed grey) — an ideal linear burndown from the total instance count on Day 0 down to zero on the final day.
-    * **Projected** (dashed blue) — a forward-looking extrapolation from today to the end date, based on your current velocity, so you can see where execution will land if the current pace holds.
+    * **Actual** (solid blue): remaining *Not Started* instances per day, reflecting real execution progress up to today.
+    * **Expected** (dashed grey): an ideal linear burndown from the total instance count on Day 0 down to zero on the final day.
+    * **Projected** (dashed blue): a forward-looking extrapolation from today to the end date, based on your current velocity, so you can see where execution will land if the current pace holds.
 * A **Today** marker highlights the current date on the chart, making it easy to see where the Actual line hands off to the Projected line relative to the Expected ideal.
 * Hovering over any point on the chart opens a tooltip showing, for that day:
-    * **Remaining** — remaining instances on that date.
-    * **Ideal** — the expected remaining count for that date.
-    * **Gap** — how far ahead or behind the ideal line you are.
-    * **Executed today** — the number of instances executed on that day.
-    * **7-day avg** — the trailing 7-day execution velocity.
-* The **footer strip** below the chart summarises execution health at a glance — **Total**, **Executed**, **Remaining**, **Complete** (percentage), **Status** (ahead or behind by N instances), **Velocity** (instances/day), projected **Finish** date, and the **Pace needed** (instances/day required to hit the target).
+    * **Remaining**: remaining instances on that date.
+    * **Ideal**: the expected remaining count for that date.
+    * **Gap**: how far ahead or behind the ideal line you are.
+    * **Executed today**: the number of instances executed on that day.
+    * **7-day avg**: the trailing 7-day execution velocity.
+* The **footer strip** below the chart summarises execution health at a glance: **Total**, **Executed**, **Remaining**, **Complete** (percentage), **Status** (ahead or behind by N instances), **Velocity** (instances/day), projected **Finish** date, and the **Pace needed** (instances/day required to hit the target).
 * Use the **date range picker** in the widget header to change the execution window. Use the **filter icon** (next to the *Test Manager* badge) or the three-dot menu to filter by test run, phase, or stage.
 
 ### Drill down into remaining instances
@@ -190,13 +190,13 @@ The Test Execution Burndown widget tracks how remaining test executions trend do
 Clicking any point on the Actual line opens a drill-down modal titled **Test Execution Burndown**, which lists every test run instance that was still *Remaining* as of that date. From the modal you can:
 
 * See the exact count of remaining instances for the selected date (e.g. *Remaining as of Mar 14: 1000*).
-* Adjust the date range and apply additional filters — **Project**, **Test Run Instance Name**, and **Milestone Name**.
+* Adjust the date range and apply additional filters: **Project**, **Test Run Instance Name**, and **Milestone Name**.
 * Browse the paginated list of instances with their current status, project, and last-updated timestamp.
 * **Export** the list for sharing or offline analysis.
 
 ### Value Proposition
 
-By comparing the actual burndown against the expected line and watching the footer metrics, you can quickly see whether execution is ahead, on track, or slipping — enabling early course correction, better capacity planning, and more reliable release predictions. The drill-down makes it easy to go from a high-level slip directly to the specific instances that are holding the run back.
+By comparing the actual burndown against the expected line and watching the footer metrics, you can quickly see whether execution is ahead, on track, or slipping, enabling early course correction, better capacity planning, and more reliable release predictions. The drill-down makes it easy to go from a high-level slip directly to the specific instances that are holding the run back.
 
 ## Defects by Severity
 
@@ -204,7 +204,7 @@ The Defects by Severity widget displays a bar chart of Jira defects linked to yo
 
 ### How it works?
 
-* Each bar represents a severity level — **Critical**, **High**, **Medium**, and **Low** — with its value showing the count of linked Jira defects at that severity.
+* Each bar represents a severity level (**Critical**, **High**, **Medium**, and **Low**) with its value showing the count of linked Jira defects at that severity.
 * Defects are sourced from Jira issues linked to test cases or raised during test runs in Test Manager.
 * Click any bar to drill down into the underlying list of issues for that severity.
 * Apply filters from the three-dot menu to scope the widget to a specific test run, phase, or stage.
@@ -220,7 +220,7 @@ The Tester Assignment widget displays a horizontal stacked bar chart with one ba
 ### How it works?
 
 * Each bar represents a tester, and its length reflects the total number of test run instances assigned to them.
-* Each bar is broken down into stacked segments by test instance status — **Not Started**, **Passed**, **Failed**, **Skipped**, as well as any **custom statuses** created for your manual test runs.
+* Each bar is broken down into stacked segments by test instance status: **Not Started**, **Passed**, **Failed**, **Skipped**, as well as any **custom statuses** created for your manual test runs.
 * Click any segment to drill down into the underlying list of test run instances for that tester and status.
 * Apply filters from the three-dot menu to scope the widget to a specific test run, phase, or stage.
 

--- a/docs/analytics-project-report.md
+++ b/docs/analytics-project-report.md
@@ -23,7 +23,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 # Project - Reports and C-Suite Insights 
 
 <Admonition title="Executive Summary">
-The Project Analytics Dashboard is not just a tool for QA teams—it's a strategic asset for C-Suite executives. With real-time, high-level insights, it empowers leadership to make data-driven decisions, monitor release readiness, and communicate quality metrics to stakeholders and boards with confidence.
+The Project Analytics Dashboard is not just a tool for QA teams, it's a strategic asset for C-Suite executives. With real-time, high-level insights, it empowers leadership to make data-driven decisions, monitor release readiness, and communicate quality metrics to stakeholders and boards with confidence.
 </Admonition>
 
 ## Introduction
@@ -67,7 +67,7 @@ The Project Analytics Dashboard is a comprehensive platform designed to provide 
 ## Feature Overview & Widgets
 
 <Admonition title="C-Suite Value">
-The dashboard’s visualizations and health indicators are designed for rapid executive consumption—enabling quick identification of risk, ROI, and release readiness without deep technical dives.
+The dashboard’s visualizations and health indicators are designed for rapid executive consumption, enabling quick identification of risk, ROI, and release readiness without deep technical dives.
 </Admonition>
 
 ### 1. Testing Velocity

--- a/docs/analytics-report-scheduling.md
+++ b/docs/analytics-report-scheduling.md
@@ -72,9 +72,9 @@ In the **Dashboard Settings** panel, expand the **Email Notifications** section 
 ### Step 3: Set the Delivery Schedule
 
 1. Under **Frequency**, select your preferred schedule from the dropdown:
-   - **Daily** — Receive reports every day at your chosen time.
-   - **Weekly** — Receive reports once a week.
-   - **Monthly** — Receive reports once a month.
+   - **Daily**: Receive reports every day at your chosen time.
+   - **Weekly**: Receive reports once a week.
+   - **Monthly**: Receive reports once a month.
 
 2. Under **Time**, select the hour from the dropdown (e.g., `9:00`).
 
@@ -84,8 +84,8 @@ In the **Dashboard Settings** panel, expand the **Email Notifications** section 
 
 Select the date range for the data included in each report:
 
-- **Default** — Uses the platform's default date range.
-- **Custom** — Specify a custom number of days. For example, setting this to `7` includes data from the last 7 days in each report.
+- **Default**: Uses the platform's default date range.
+- **Custom**: Specify a custom number of days. For example, setting this to `7` includes data from the last 7 days in each report.
 
 ### Step 5: Add Recipients
 

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -179,6 +179,6 @@ Any build in App Distribution can be launched on a <BrandName /> real device in 
 
 **Step 2:** Click the **Run** icon on the build row. The device selection modal opens with the build pre-loaded.
 
-**Step 3:** Select an Android or iOS real device and start your session — the build is installed automatically and ready to test.
+**Step 3:** Select an Android or iOS real device and start your session. The build is installed automatically and ready to test.
 
 ---

--- a/docs/appium-date-and-time.md
+++ b/docs/appium-date-and-time.md
@@ -106,7 +106,7 @@ To modify the date and time settings programmatically, use the `lambda_executor`
 | Android   | 10 and above        | Fully Supported    |
 
 :::warning Unsupported Android Devices
-Custom date and time configuration is not supported on certain Android device models — primarily from **Motorola, Xiaomi, Oppo, and other Chinese OEMs**. On these devices, the Appium hook will return the following error:
+Custom date and time configuration is not supported on certain Android device models, primarily from **Motorola, Xiaomi, Oppo, and other Chinese OEMs**. On these devices, the Appium hook will return the following error:
 
 `Custom date and time hook is not supported on this device. Please try on another device_id.`
 

--- a/docs/apple-pay-auto.md
+++ b/docs/apple-pay-auto.md
@@ -24,7 +24,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 <RealDeviceTag value="Real Device" /> 
 **Apple Pay** is Apple’s secure digital wallet and payment system that enables purchases, one-click checkouts, and adds an extra layer of protection for financial transactions. In real-world apps and websites, Apple Pay is widely used for simplifying checkout experiences, reducing friction, and improving user trust.
 
-For **testing payment flows**, validating Apple Pay becomes critical. Automation of Apple Pay ensures you can reliably test end-to-end purchase scenarios, confirm that payment sheets open correctly, details are pre-filled, and transactions are processed securely—without relying on production cards.
+For **testing payment flows**, validating Apple Pay becomes critical. Automation of Apple Pay ensures you can reliably test end-to-end purchase scenarios, confirm that payment sheets open correctly, details are pre-filled, and transactions are processed securely, without relying on production cards.
 
 With <BrandName />, you can automate Apple Pay flows on **real iOS devices**. From provisioning Wallet with sandboxed test cards, to injecting payment details, confirming payments, and entering the passcode, <BrandName /> provides a seamless way to run and validate Apple Pay scenarios as part of your automation suite.
 

--- a/docs/application-setup-via-gui.md
+++ b/docs/application-setup-via-gui.md
@@ -86,5 +86,5 @@ Wait for the file to upload and process. A success message will indicate when yo
 
 :::info
 - The **App Automation Dashboard** supports both **Real** and **Virtual Devices**.  
-- To perform testing on Virtual Devices, simply select the **Virtual Device** option during upload — the rest of the flow remains identical.
+- To perform testing on Virtual Devices, simply select the **Virtual Device** option during upload. The rest of the flow remains identical.
 :::

--- a/docs/audio-injection-manual-browser.md
+++ b/docs/audio-injection-manual-browser.md
@@ -51,7 +51,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # Audio Injection Manual Testing on Real Device Browsers
 
-**Audio Injection** lets you simulate microphone input on real Android and iOS device browsers during a manual **Real Time** browser session. Use it to test speech-to-text web apps, voice search on the mobile web, browser-based voice assistants, web-based KYC voice verification, and any other microphone-dependent web feature — without speaking into a physical mic.
+**Audio Injection** lets you simulate microphone input on real Android and iOS device browsers during a manual **Real Time** browser session. Use it to test speech-to-text web apps, voice search on the mobile web, browser-based voice assistants, web-based KYC voice verification, and any other microphone-dependent web feature, without speaking into a physical mic.
 
 With <BrandName /> Real Time browser testing, you can either inject a **pre-uploaded audio file** or stream **Live Input** directly from your system microphone into the device browser.
 
@@ -118,14 +118,14 @@ Once enabled, the device list is filtered to show **only the devices that suppor
 
 You will see two options:
 
-- **Select Files** — inject a pre-recorded audio file
-- **Inject Live Input** — stream audio from your system microphone in real time
+- **Select Files**: inject a pre-recorded audio file
+- **Inject Live Input**: stream audio from your system microphone in real time
 
 ---
 
 ### Step 4a: Inject an Audio File
 
-Use this mode when you want a deterministic, repeatable input — for example, the same voice query run across many device-browser combinations.
+Use this mode when you want a deterministic, repeatable input, for example, the same voice query run across many device-browser combinations.
 
 1. In the **Audio** tab, select **Select Files**.
 2. Click **Upload** and choose an `.mp3` or `.wav` file (up to **200 MB**, one file at a time).
@@ -133,7 +133,7 @@ Use this mode when you want a deterministic, repeatable input — for example, t
 4. In the browser, navigate to the page that captures microphone input (e.g., tap a voice search icon or **Start Recording**).
 5. Grant the page mic permission when prompted.
 6. Select the uploaded file and click **Inject**.
-7. Once a file is injected, the controls are limited to **Play** and **Pause** — clicking **Play** streams the audio into the device's microphone pipeline as live mic input, and the browser captures it as if the user were speaking.
+7. Once a file is injected, the controls are limited to **Play** and **Pause**. Clicking **Play** streams the audio into the device's microphone pipeline as live mic input, and the browser captures it as if the user were speaking.
 8. To switch audio, select a different file and click **Inject** on it. Only **one file can be injected at a time**, and the new file replaces the previously injected one.
 
 :::tip
@@ -144,17 +144,17 @@ Inject and start playback **after** the page has opened the mic. Some recognizer
 
 ### Step 4b: Use Live Input
 
-Use this mode when you want to drive the device microphone interactively — for example, having an unscripted conversation with a web voice assistant or testing custom prompts on the fly.
+Use this mode when you want to drive the device microphone interactively, for example, having an unscripted conversation with a web voice assistant or testing custom prompts on the fly.
 
 1. In the **Audio** tab, select **Inject Live Input**.
 2. Grant microphone access to your browser when prompted.
 3. In the device browser, open the page that captures microphone input.
-4. Click **Start** — your system microphone is now streamed directly into the device's mic.
+4. Click **Start**. Your system microphone is now streamed directly into the device's mic.
 5. Speak into your mic. The web page receives your voice in real time.
 6. Click **Stop** to end the live stream.
 
 :::note
-Live Input streams from the same browser tab running the Real Time session. Avoid muting your system mic or switching tabs mid-session — the stream will be interrupted.
+Live Input streams from the same browser tab running the Real Time session. Avoid muting your system mic or switching tabs mid-session. The stream will be interrupted.
 :::
 
 ---
@@ -162,7 +162,7 @@ Live Input streams from the same browser tab running the Real Time session. Avoi
 ## Execution Rules
 
 - The web page must be granted microphone permission. Audio Injection does **not** bypass permission prompts.
-- Only one audio source is active at a time — switching from **Files** to **Live Input** (or vice versa) replaces the previous source.
+- Only one audio source is active at a time. Switching from **Files** to **Live Input** (or vice versa) replaces the previous source.
 - For files, only one file can be injected and played at a time.
 - The last injected audio is the active source until you stop it or inject another.
 
@@ -179,8 +179,8 @@ Live Input streams from the same browser tab running the Real Time session. Avoi
 
 ## Related Resources
 
-- [Audio Injection Manual Testing (App)](/docs/audio-injection-manual/) — Same feature on App Live
-- [Audio Injection on Real Devices (Automation)](/docs/audio-injection/) — Inject audio via Appium / Selenium tests
+- [Audio Injection Manual Testing (App)](/docs/audio-injection-manual/): Same feature on App Live
+- [Audio Injection on Real Devices (Automation)](/docs/audio-injection/): Inject audio via Appium / Selenium tests
 - [Browser Testing on Real Devices](/docs/browser-testing-on-real-devices/)
 
 ---

--- a/docs/audio-injection-manual.md
+++ b/docs/audio-injection-manual.md
@@ -50,7 +50,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # Audio Injection Manual Testing on Real Devices
 
-**Audio Injection** lets you simulate microphone input on real Android and iOS devices during a manual **App Live** session. Use it to test speech-to-text, voice commands, voice assistants, in-app recording, KYC voice verification, and any other microphone-dependent feature — without speaking into a physical mic.
+**Audio Injection** lets you simulate microphone input on real Android and iOS devices during a manual **App Live** session. Use it to test speech-to-text, voice commands, voice assistants, in-app recording, KYC voice verification, and any other microphone-dependent feature, without speaking into a physical mic.
 
 With <BrandName /> App Live, you can either inject a **pre-uploaded audio file** or stream **Live Input** directly from your system microphone into the device under test.
 
@@ -121,8 +121,8 @@ Once enabled, the device list is filtered to show **only the devices that suppor
 
 You will see two options:
 
-- **Select Files** — inject a pre-recorded audio file
-- **Inject Live Input** — stream audio from your system microphone in real time
+- **Select Files**: inject a pre-recorded audio file
+- **Inject Live Input**: stream audio from your system microphone in real time
 
 ![Open Media Injection and switch to the Audio tab](../assets/images/real-device-app-testing/audio-injection-2.png)
 
@@ -130,14 +130,14 @@ You will see two options:
 
 ### Step 4a: Inject an Audio File
 
-Use this mode when you want a deterministic, repeatable input — for example, the same voice command run across many devices.
+Use this mode when you want a deterministic, repeatable input, for example, the same voice command run across many devices.
 
 1. In the **Audio** tab, select **Select Files**.
 2. Click **Upload** and choose an `.mp3` or `.wav` file (up to **200 MB**, one file at a time).
 3. Once uploaded, the file appears in your audio library (latest 5 uploaded)
 4. In the app under test, navigate to the screen that captures microphone input (e.g., tap **Record** or **Start Voice Search**).
 5. Select the uploaded file and click **Inject**.
-6. Once a file is injected, the controls are limited to **Play** and **Pause** — clicking **Play** streams the audio into the device's microphone pipeline as live mic input, and the app captures it as if a user were speaking.
+6. Once a file is injected, the controls are limited to **Play** and **Pause**. Clicking **Play** streams the audio into the device's microphone pipeline as live mic input, and the app captures it as if a user were speaking.
 7. To switch audio, select a different file and click **Inject** on it. Only **one file can be injected at a time**, and the new file replaces the previously injected one.
 
 ![Upload and inject an audio file in the Audio tab](../assets/images/real-device-app-testing/audio-injection-3.png)
@@ -150,19 +150,19 @@ Inject and start playback **after** the app has opened the mic. Some recognizers
 
 ### Step 4b: Use Live Input
 
-Use this mode when you want to drive the device microphone interactively — for example, holding an unscripted conversation with a voice assistant or testing custom prompts on the fly.
+Use this mode when you want to drive the device microphone interactively, for example, holding an unscripted conversation with a voice assistant or testing custom prompts on the fly.
 
 1. In the **Audio** tab, select **Inject Live Input**.
 2. Grant microphone access to your browser when prompted.
 3. In the app under test, open the screen that captures microphone input.
-4. Click **Start** — your system microphone is now streamed directly into the device's mic.
+4. Click **Start**. Your system microphone is now streamed directly into the device's mic.
 5. Speak into your mic. The app receives your voice in real time.
 6. Click **Stop** to end the live stream.
 
 ![Stream live mic input from your system into the device](../assets/images/real-device-app-testing/audio-injection-5.png)
 
 :::note
-Live Input streams from the same browser tab running App Live. Avoid muting your system mic or switching tabs mid-session — the stream will be interrupted.
+Live Input streams from the same browser tab running App Live. Avoid muting your system mic or switching tabs mid-session. The stream will be interrupted.
 :::
 
 ---
@@ -170,7 +170,7 @@ Live Input streams from the same browser tab running App Live. Avoid muting your
 ## Execution Rules
 
 - The app must be granted microphone permission. Audio Injection does **not** bypass permission prompts.
-- Only one audio source is active at a time — switching from **Files** to **Live Input** (or vice versa) replaces the previous source.
+- Only one audio source is active at a time. Switching from **Files** to **Live Input** (or vice versa) replaces the previous source.
 - For files, only one file can be injected and played at a time.
 - The last injected audio is the active source until you stop it or inject another.
 
@@ -187,7 +187,7 @@ Live Input streams from the same browser tab running App Live. Avoid muting your
 
 ## Related Resources
 
-- [Audio Injection on Real Devices (Automation)](/docs/audio-injection/) — Inject audio via Appium / Selenium tests
+- [Audio Injection on Real Devices (Automation)](/docs/audio-injection/): Inject audio via Appium / Selenium tests
 - [Camera Image Injection on Real Devices](/docs/camera-image-injection-on-real-devices/)
 - [Biometric Authentication on Real Devices](/docs/biometric-authentication-on-real-devices/)
 

--- a/docs/audio-injection.md
+++ b/docs/audio-injection.md
@@ -59,7 +59,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 # Audio Injection on Real Devices
 <RealDeviceTag value="Real Device" />
 
-Test audio-driven and microphone-dependent features on real Android and iOS devices through Appium / Selenium automation. Inject pre-recorded audio files directly into the device microphone — no physical mic input required.
+Test audio-driven and microphone-dependent features on real Android and iOS devices through Appium / Selenium automation. Inject pre-recorded audio files directly into the device microphone, no physical mic input required.
 
 > To enable it for your organization, please contact us via <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24×7 chat support**</span> or you can also drop a mail to **support@testmuai.com**.<br />
 
@@ -112,7 +112,7 @@ curl -u "LT_USERNAME:LT_ACCESS_KEY"   -X POST "https://api.lambdatest.com/mfs/v1
 }
 ```
 
-Save the returned `media_url` — you will use it in subsequent steps.
+Save the returned `media_url`. You will use it in subsequent steps.
 
 ---
 
@@ -127,7 +127,7 @@ Set the `enableAudioInjection` capability when creating your driver session.
 ```java
 DesiredCapabilities caps = new DesiredCapabilities();
 caps.setCapability("enableAudioInjection", true);
-caps.setCapability("media", "lt://MEDIA1234567890abcdef"); // optional — pre-set audio
+caps.setCapability("media", "lt://MEDIA1234567890abcdef"); // optional: pre-set audio
 ```
 
 </TabItem>
@@ -185,7 +185,7 @@ driver.executeScript("lambda-audio-injection=lt://MEDIA1234567890abcdef");
 // 2. Trigger the app's mic input (e.g., tap Record / Start Voice Search)
 driver.findElement(AppiumBy.id("recordButton")).click();
 
-// 3. Start audio playback — the app receives the file as live mic input
+// 3. Start audio playback, the app receives the file as live mic input
 driver.executeScript("lambda-audio-start");
 
 // ... wait for the app to finish capturing ...
@@ -229,7 +229,7 @@ await driver.executeScript("lambda-audio-stop");
 - Audio must be **injected before** triggering the microphone in the app. The last injected audio is the active input.
 - The session must be created with `enableAudioInjection: true`. Hooks called without the capability return **HTTP 403 Forbidden**.
 - Calling `lambda-audio-start` before any file has been injected returns **HTTP 400** with `AUDIO_INJECTION_MEDIA_FILE_NOT_PROVIDED_ERROR`.
-- Multiple injections in the same session — the last injected audio is used on the next `lambda-audio-start`.
+- Multiple injections in the same session: the last injected audio is used on the next `lambda-audio-start`.
 - The app must be granted microphone permission. Audio Injection does **not** bypass permission prompts.
 
 ---
@@ -247,11 +247,11 @@ await driver.executeScript("lambda-audio-stop");
 
 **Q. Can I use Audio Injection with my own automation framework?**
 
-Yes — Audio Injection is a server-side feature controlled entirely by capabilities and `executeScript` hooks. It works with any Appium- or Selenium-compatible framework.
+Yes. Audio Injection is a server-side feature controlled entirely by capabilities and `executeScript` hooks. It works with any Appium- or Selenium-compatible framework.
 
 **Q. Does Audio Injection work in parallel test runs?**
 
-Yes — each session has its own isolated injection pipeline. Multiple parallel sessions can inject different audio files simultaneously without interference.
+Yes. Each session has its own isolated injection pipeline. Multiple parallel sessions can inject different audio files simultaneously without interference.
 
 **Q. What audio formats give the best results?**
 
@@ -263,19 +263,19 @@ Confirm:
 1. `enableAudioInjection: true` is set on the session.
 2. `lambda-audio-injection=<url>` was called **before** `lambda-audio-start`.
 3. The app has been granted microphone permission.
-4. Some apps (e.g., Google Recorder on Pixel) use privileged hardware audio paths that bypass standard injection — use a different recorder app to verify.
+4. Some apps (e.g., Google Recorder on Pixel) use privileged hardware audio paths that bypass standard injection. Use a different recorder app to verify.
 
 **Q. Can I switch audio files mid-session?**
 
-Yes — call `lambda-audio-injection=<new_url>` followed by `lambda-audio-start`. The new file replaces the previous one immediately.
+Yes. Call `lambda-audio-injection=<new_url>` followed by `lambda-audio-start`. The new file replaces the previous one immediately.
 
 ---
 
 ## Related Features
 
-- [Camera Image Injection](/docs/camera-image-injection/) — Inject images into the device camera
-- [Video Injection](/docs/video-injection/) — Inject videos into the device camera
-- [Biometric Authentication](/docs/biometric-authentication/) — Simulate fingerprint/face authentication
+- [Camera Image Injection](/docs/camera-image-injection/): Inject images into the device camera
+- [Video Injection](/docs/video-injection/): Inject videos into the device camera
+- [Biometric Authentication](/docs/biometric-authentication/): Simulate fingerprint/face authentication
 
 ---
 

--- a/docs/beta-testers-management.md
+++ b/docs/beta-testers-management.md
@@ -47,7 +47,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 **Beta Testers** in <BrandName /> [App Distribution](/support/docs/app-distribution/) are the people you invite to download builds and receive new-build notifications. You can add testers individually, group them into **Beta Teams**, and then assign teams or individual testers to any app's sharing list.
 
-This is a one-time, **organization-level** setup — once a tester is added, you can reuse them across every app in your organization.
+This is a one-time, **organization-level** setup. Once a tester is added, you can reuse them across every app in your organization.
 
 You can manage testers from the sidebar under **Real Device → App Management and Distribution → Beta Testers**.
 
@@ -88,7 +88,7 @@ Until the tester accepts the invite, a **Pending** tag appears next to their ema
 
 ## Create Beta Teams
 
-Teams are groups of testers that make it easier to manage access and notifications at scale. Instead of adding individual testers to each app, you assign a team — and all current (and future) members of that team get access automatically.
+Teams are groups of testers that make it easier to manage access and notifications at scale. Instead of adding individual testers to each app, you assign a team, and all current (and future) members of that team get access automatically.
 
 <!-- <img loading="lazy" src={require('../assets/images/real-device-app-testing/app-distribution/beta-teams-list.png').default} alt="Beta Teams tab listing teams with tester counts and descriptions" className="doc_img"/> -->
 

--- a/docs/chat-agent-api-integration.md
+++ b/docs/chat-agent-api-integration.md
@@ -1,9 +1,9 @@
 ---
 id: chat-agent-api-integration
-title: Chat Agent API — Integration Guide
+title: Chat Agent API - Integration Guide
 hide_title: false
 sidebar_label: Chat Agent API Integration
-description: Learn how the platform communicates with your chatbot via API — request format, connection methods, response schema, and integration requirements.
+description: Learn how the platform communicates with your chatbot via API, request format, connection methods, response schema, and integration requirements.
 keywords:
  - chat agent api
  - agent integration
@@ -44,7 +44,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-This document outlines the API request format, required credentials, and response schema the platform uses to communicate with your chatbot — regardless of provider or framework.
+This document outlines the API request format, required credentials, and response schema the platform uses to communicate with your chatbot, regardless of provider or framework.
 
 ---
 
@@ -70,15 +70,15 @@ The field names above (`assistantId`, `input`) are illustrative. Your chatbot ma
 
 | Component | Value in Example | Description |
 |-----------|-----------------|-------------|
-| **Method** | `POST` | HTTP method — all chat requests use POST. |
-| **Endpoint URL** *(Required)* | `https://api.examplechatbot.com/chat` | Your chatbot's API endpoint — the URL that accepts incoming messages. This varies by provider. |
+| **Method** | `POST` | HTTP method: all chat requests use POST. |
+| **Endpoint URL** *(Required)* | `https://api.examplechatbot.com/chat` | Your chatbot's API endpoint, the URL that accepts incoming messages. This varies by provider. |
 | **Authorization** *(Required)* | `Bearer sk-example-a1b2c3d4e5f6` | Authentication token. The platform uses the token you provide to authenticate each request. Format may vary (Bearer token, API key header, etc.). |
 | **Content-Type** *(Required)* | `application/json` | Indicates a JSON-formatted request body. |
 | **Additional Headers** *(Optional)* | Any extra `-H "…"` entries | If your chatbot requires additional headers (e.g., session ID, API version, workspace ID, custom tracking headers), they are fully supported. **Include as many as needed.** |
-| **Request Body** | JSON payload | Contains the fields your chatbot expects — typically a bot/assistant identifier and the user message. Field names vary by provider. |
+| **Request Body** | JSON payload | Contains the fields your chatbot expects, typically a bot/assistant identifier and the user message. Field names vary by provider. |
 
 :::tip Header Flexibility
-The platform sends the exact URL, token, and headers you configure. If your chatbot requires headers beyond Authorization and Content-Type, simply provide them — the platform forwards all configured headers with every request.
+The platform sends the exact URL, token, and headers you configure. If your chatbot requires headers beyond Authorization and Content-Type, simply provide them. The platform forwards all configured headers with every request.
 :::
 
 ---
@@ -87,7 +87,7 @@ The platform sends the exact URL, token, and headers you configure. If your chat
 
 The platform supports three ways to connect to your chatbot, depending on where it is hosted and how it is accessible. Choose the option that matches your environment.
 
-### Option A — Public API (Direct)
+### Option A: Public API (Direct)
 
 The simplest path. If your chatbot exposes a publicly reachable HTTPS endpoint, the platform connects to it directly using the URL, auth headers, and any additional headers you provide.
 
@@ -101,22 +101,22 @@ The simplest path. If your chatbot exposes a publicly reachable HTTPS endpoint, 
 
 > **Best for:** Production / cloud-hosted bots
 
-### Option B — Secure Proxy (Private Network)
+### Option B: Secure Proxy (Private Network)
 
-If your chatbot is not publicly reachable — e.g., it sits behind a corporate firewall, within a VPC, or on an internal network — the platform provides a lightweight **proxy agent** that you install inside your network. The agent establishes a secure outbound tunnel to our platform, allowing test traffic to reach your chatbot without exposing it to the public internet.
+If your chatbot is not publicly reachable (e.g., it sits behind a corporate firewall, within a VPC, or on an internal network), the platform provides a lightweight **proxy agent** that you install inside your network. The agent establishes a secure outbound tunnel to our platform, allowing test traffic to reach your chatbot without exposing it to the public internet.
 
 **Flow:** `Testing Platform` → `Secure Tunnel` → `Proxy Agent (Your Network)` → `Your Chatbot (Internal)`
 
 | You Provide | Details |
 |-------------|---------|
 | **Internal Endpoint** *(Required)* | The internal URL or hostname of your chatbot (e.g., `https://chatbot.internal:8443/chat`). |
-| **Auth Headers** *(Required)* | Same authentication headers your chatbot expects. The proxy handles *network access*, not authentication — your chatbot still validates credentials on every request. |
+| **Auth Headers** *(Required)* | Same authentication headers your chatbot expects. The proxy handles *network access*, not authentication. Your chatbot still validates credentials on every request. |
 | **Additional Headers** *(Optional)* | Any extra headers your chatbot requires. |
-| **Proxy Agent** | Provided by us. A lightweight service installed on a machine within your network that has access to the chatbot. Only outbound connectivity is needed — no inbound firewall rules required. |
+| **Proxy Agent** | Provided by us. A lightweight service installed on a machine within your network that has access to the chatbot. Only outbound connectivity is needed, no inbound firewall rules required. |
 
 > **Best for:** Enterprise / on-premise deployments
 
-### Option C — Localhost (Dev / Staging)
+### Option C: Localhost (Dev / Staging)
 
 For chatbots running on a local development machine (e.g., `localhost:3000`), the same proxy agent is installed locally. It creates a secure tunnel from our platform to your machine, allowing the platform to reach your locally running chatbot.
 
@@ -126,7 +126,7 @@ For chatbots running on a local development machine (e.g., `localhost:3000`), th
 |-------------|---------|
 | **Local Endpoint** *(Required)* | The localhost URL and port your chatbot runs on (e.g., `http://localhost:3000/chat`). |
 | **Auth Headers** *(If applicable)* | If your local chatbot enforces authentication, provide the same auth headers. If auth is disabled in dev mode, this can be skipped. |
-| **Proxy Agent** | Provided by us. Installed on your local machine — runs as a background process during testing. |
+| **Proxy Agent** | Provided by us. Installed on your local machine, runs as a background process during testing. |
 
 > **Best for:** Development / pre-deployment testing
 
@@ -142,14 +142,14 @@ For chatbots running on a local development machine (e.g., `localhost:3000`), th
 | **Typical use case** | Production, cloud-hosted | Enterprise, on-premise | Development, staging |
 
 :::tip
-Regardless of connection method, the platform sends the exact authentication and custom headers you configure with every request. The proxy agent handles *network reachability* only — it does not bypass or replace your chatbot's authentication.
+Regardless of connection method, the platform sends the exact authentication and custom headers you configure with every request. The proxy agent handles *network reachability* only. It does not bypass or replace your chatbot's authentication.
 :::
 
 ---
 
 ## Response Schema
 
-The response structure varies by provider. Below is a representative example showing common fields. Your chatbot's response may include different or additional fields — the platform adapts to your specific schema.
+The response structure varies by provider. Below is a representative example showing common fields. Your chatbot's response may include different or additional fields. The platform adapts to your specific schema.
 
 ```json title="Example Response"
 {
@@ -192,8 +192,8 @@ To connect your chatbot, provide the following. No code changes or infrastructur
 |------|-----------|-------------|
 | **Chatbot URL** (API endpoint) | Required | The HTTPS endpoint where your chatbot receives messages. Example: `https://your-domain.com/chat` |
 | **Authentication Credentials** | Required | The token or key needed to access your chatbot API. This could be a Bearer token, API key, or any other auth mechanism your API uses. |
-| **Bot / Assistant Identifier** | Required | The identifier for the specific chatbot to be tested — applicable if your platform hosts multiple bots under one API. |
-| **Additional Headers** | Optional | Any extra headers your chatbot requires — such as a session token, API version, workspace ID, or custom tracking header. Provide as many as needed. |
+| **Bot / Assistant Identifier** | Required | The identifier for the specific chatbot to be tested, applicable if your platform hosts multiple bots under one API. |
+| **Additional Headers** | Optional | Any extra headers your chatbot requires, such as a session token, API version, workspace ID, or custom tracking header. Provide as many as needed. |
 | **Request Body Format** | Optional | If your chatbot expects a different body structure (field names, extra fields), let us know and we will match it exactly. |
 
 ---
@@ -205,7 +205,7 @@ Once credentials are configured, the platform handles everything autonomously:
 `Credentials Configured` → `Test Scenarios Generated` → `API Calls Sent to Your Chatbot` → `Responses Captured` → `Quality Scored`
 
 - The platform sends requests using the exact URL, token, and headers you provide.
-- Multi-turn conversations are executed — the platform reads the `output` field from each response and continues the dialogue across multiple exchanges.
+- Multi-turn conversations are executed. The platform reads the `output` field from each response and continues the dialogue across multiple exchanges.
 - Each completed conversation is evaluated across 18+ quality dimensions and results are surfaced in the dashboard.
 
 :::caution Security

--- a/docs/credits-management.md
+++ b/docs/credits-management.md
@@ -129,7 +129,7 @@ The **AI Test Case Generator** converts diverse inputs (text, PDFs, audio, video
 * If fewer scenarios are produced (e.g., **4**), **10 credits are credited back**, so you only pay for what’s actually generated.
 * **Regeneration** also consumes credits at **10 credits per scenario**.
 
->This ensures fair usage—you are charged only for **actual output** produced by the AI.
+>This ensures fair usage. You are charged only for **actual output** produced by the AI.
 
 #### Conversational Layer
 

--- a/docs/cypress-mochaawesome-report.md
+++ b/docs/cypress-mochaawesome-report.md
@@ -69,7 +69,7 @@ In your Cypress configuration file `cypress.config.js`, add the following code t
 :::note
 - The `overwrite` parameter should be set to `true` to ensure the report is replaced with the latest run results.
 - The `html` option should be set to `false` because we will be merging JSON files later, and the mocha-merge utility does not support HTML files.
-- Ensure the `reportDir` path is set to `"cypress/results"` —this path is used to generate logs that will be visible on the dashboard. **Do not change this path.**
+- Ensure the `reportDir` path is set to `"cypress/results"`. This path is used to generate logs that will be visible on the dashboard. **Do not change this path.**
 :::
 
 ### Step 2: Configure the HyperExecute YAML File

--- a/docs/defect-analysis-prediction.md
+++ b/docs/defect-analysis-prediction.md
@@ -50,7 +50,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 # Defect Analysis and Prediction
 * * *
 
-Modern test automation generates thousands of results per day. Without intelligent analysis, teams waste significant time manually triaging failures, chasing flaky tests, and diagnosing root causes. <BrandName />'s AI-powered defect analysis and prediction capabilities automatically classify, analyze, and surface actionable insights from your test execution data — helping you move from reactive debugging to proactive quality improvement.
+Modern test automation generates thousands of results per day. Without intelligent analysis, teams waste significant time manually triaging failures, chasing flaky tests, and diagnosing root causes. <BrandName />'s AI-powered defect analysis and prediction capabilities automatically classify, analyze, and surface actionable insights from your test execution data, helping you move from reactive debugging to proactive quality improvement.
 
 This page provides an overview of the AI/ML-based capabilities available across the <BrandName /> platform for defect analysis and prediction, and how they work together to improve test suite reliability.
 
@@ -58,10 +58,10 @@ This page provides an overview of the AI/ML-based capabilities available across 
 
 <BrandName /> applies machine learning and AI models across your test execution history to:
 
-1. **Detect** — Identify flaky and unreliable tests automatically using execution pattern analysis
-2. **Classify** — Categorize failures by type (environment, script, application, network) using AI models
-3. **Diagnose** — Pinpoint root causes of failures using LLM-powered analysis
-4. **Predict** — Surface early warning signals through smart tags that flag tests trending toward failure
+1. **Detect**: Identify flaky and unreliable tests automatically using execution pattern analysis
+2. **Classify**: Categorize failures by type (environment, script, application, network) using AI models
+3. **Diagnose**: Pinpoint root causes of failures using LLM-powered analysis
+4. **Predict**: Surface early warning signals through smart tags that flag tests trending toward failure
 
 These capabilities work across **Web Automation**, **App Automation**, and **HyperExecute**.
 
@@ -69,7 +69,7 @@ These capabilities work across **Web Automation**, **App Automation**, and **Hyp
 
 ## Flaky Test Detection
 
-Flaky tests — tests that produce inconsistent pass/fail results without any code change — are one of the biggest threats to test suite reliability. They erode team confidence in test results and waste time on false investigations.
+Flaky tests, tests that produce inconsistent pass/fail results without any code change, are one of the biggest threats to test suite reliability. They erode team confidence in test results and waste time on false investigations.
 
 <BrandName /> uses machine learning algorithms to automatically identify flaky tests by analyzing historical execution patterns across your test runs.
 
@@ -88,8 +88,8 @@ Flaky test detection is available in two places:
 
 | Location | What You Get |
 |----------|--------------|
-| [**Test Intelligence — Flaky Tests Detection**](/docs/test-intelligence-flakiness-test-detection/) | Deep-dive into individual flaky tests, flakiness sources, and command-level analysis |
-| [**Insights — Flaky Tests Analytics**](/docs/analytics-modules-test-intelligence-flaky-test-analytics/) | Dashboard widgets showing flakiness trends, distribution, and team-level patterns |
+| [**Test Intelligence: Flaky Tests Detection**](/docs/test-intelligence-flakiness-test-detection/) | Deep-dive into individual flaky tests, flakiness sources, and command-level analysis |
+| [**Insights: Flaky Tests Analytics**](/docs/analytics-modules-test-intelligence-flaky-test-analytics/) | Dashboard widgets showing flakiness trends, distribution, and team-level patterns |
 
 ---
 
@@ -103,13 +103,13 @@ When tests fail, the first question is always: *"Is this a real bug, a test scri
 
 - Automatically categorizes failures by type (application defect, script error, environment issue, etc.)
 - Analyzes parameters like browser, OS, device, and failure patterns to determine category
-- Helps teams prioritize — focus on application defects first, fix script issues separately
+- Helps teams prioritize: focus on application defects first, fix script issues separately
 - Reduces manual triage time significantly
 
 ### How to Use It
 
-- [**Failure Categorization AI**](/docs/analytics-test-failure-classification/) — Available in Insights dashboards for Web Automation, App Automation, and HyperExecute
-- [**Error Categorization Report**](/docs/error-categorization-report/) — Structured failure reports for HyperExecute jobs with multiple error types
+- [**Failure Categorization AI**](/docs/analytics-test-failure-classification/): Available in Insights dashboards for Web Automation, App Automation, and HyperExecute
+- [**Error Categorization Report**](/docs/error-categorization-report/): Structured failure reports for HyperExecute jobs with multiple error types
 
 **Prerequisite:** Add the `remark` capability in your test scripts to provide additional context to the AI model, which improves categorization accuracy.
 
@@ -125,7 +125,7 @@ Once a failure is detected and categorized, the next step is understanding *why*
 
 - Analyzes failed test logs, screenshots, and execution data using advanced AI
 - Distinguishes **primary root causes** from cascading symptoms
-- Provides **actionable fix recommendations** — not just error descriptions, but specific steps to resolve
+- Provides **actionable fix recommendations**, not just error descriptions, but specific steps to resolve
 - Generates **error timelines** showing the chronological sequence of events leading to the failure
 - Available across multiple surfaces for different use cases
 
@@ -133,9 +133,9 @@ Once a failure is detected and categorized, the next step is understanding *why*
 
 | Surface | Use Case | Details |
 |---------|----------|---------|
-| [**Insights — AI RCA**](/docs/analytics-ai-root-cause-analysis/) | Analyze any failed test from dashboards | LLM-powered, credits-based (15-25 credits per analysis) |
-| [**HyperExecute — AI Native RCA**](/docs/ai-powered-test-failure-analysis/) | Automatic RCA for HyperExecute job failures | Integrated into job results, analyzes logs automatically |
-| [**SmartUI — Visual RCA**](/docs/smartui-root-cause-analysis/) | Diagnose visual regression failures | Identifies underlying causes of visual mismatches |
+| [**Insights: AI RCA**](/docs/analytics-ai-root-cause-analysis/) | Analyze any failed test from dashboards | LLM-powered, credits-based (15-25 credits per analysis) |
+| [**HyperExecute: AI Native RCA**](/docs/ai-powered-test-failure-analysis/) | Automatic RCA for HyperExecute job failures | Integrated into job results, analyzes logs automatically |
+| [**SmartUI: Visual RCA**](/docs/smartui-root-cause-analysis/) | Diagnose visual regression failures | Identifies underlying causes of visual mismatches |
 
 ---
 
@@ -147,9 +147,9 @@ Smart Tags provide an early warning system by automatically labeling tests based
 
 | Tag | What It Means | Why It Matters |
 |-----|---------------|----------------|
-| **Flaky** | Inconsistent results across multiple executions | Unreliable signal — needs investigation or quarantine |
-| **Always Failing** | Consistently failing across multiple executions | Likely a real defect or broken test — high priority |
-| **New Failures** | Recently started failing after previously passing | Potential regression — investigate recent changes |
+| **Flaky** | Inconsistent results across multiple executions | Unreliable signal, needs investigation or quarantine |
+| **Always Failing** | Consistently failing across multiple executions | Likely a real defect or broken test, high priority |
+| **New Failures** | Recently started failing after previously passing | Potential regression, investigate recent changes |
 
 ### What It Does
 
@@ -160,13 +160,13 @@ Smart Tags provide an early warning system by automatically labeling tests based
 
 ### How to Use It
 
-- [**Smart Tags — Test Intelligence**](/docs/analytics-smart-tags-test-intelligence/) — Available in Insights dashboards, requires minimum 10 test runs
+- [**Smart Tags: Test Intelligence**](/docs/analytics-smart-tags-test-intelligence/): Available in Insights dashboards, requires minimum 10 test runs
 
 ---
 
 ## Putting It All Together
 
-These capabilities are designed to work as a pipeline — each stage feeds into the next:
+These capabilities are designed to work as a pipeline. Each stage feeds into the next:
 
 ```
 Test Execution
@@ -183,7 +183,7 @@ AI Root Cause Analysis (diagnose root cause + recommended fix)
 ### Recommended Workflow
 
 1. **Set up Insights dashboards** with Flaky Tests and Failure Categorization widgets to monitor your test suite health continuously
-2. **Review Smart Tags** on drilldowns to catch early warning signals — especially "New Failures" which may indicate regressions
+2. **Review Smart Tags** on drilldowns to catch early warning signals, especially "New Failures" which may indicate regressions
 3. **Use Flaky Test Detection** to identify and quarantine unreliable tests, improving the signal-to-noise ratio of your test results
 4. **Apply AI RCA** to diagnosed failures to get actionable fix recommendations without manually reading through logs
 

--- a/docs/device-passcode-appautomation.md
+++ b/docs/device-passcode-appautomation.md
@@ -137,7 +137,7 @@ Use the `enablePasscode` capability to configure passcode-protected devices duri
 </Tabs>
 
 :::note
-- Passcode entry screens are **not visible** in the stream for security reasons — you may see a blank screen briefly during automation.  
+- Passcode entry screens are **not visible** in the stream for security reasons. You may see a blank screen briefly during automation.  
 - Enabling passcode for iOS Devices may increase the setup time of your test by **25–30 seconds** compared to regular sessions.  
 :::
 

--- a/docs/enterprise-ready.md
+++ b/docs/enterprise-ready.md
@@ -76,8 +76,8 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 **Capabilities:**
 - **SAML 2.0** based authentication with any compatible IdP
-- **Just-in-Time (JIT) provisioning** — automatically create user accounts on first login
-- **SCIM provisioning** — automated user lifecycle management (create, update, deactivate)
+- **Just-in-Time (JIT) provisioning**: automatically create user accounts on first login
+- **SCIM provisioning**: automated user lifecycle management (create, update, deactivate)
 - **Supported identity providers**: Okta, Azure AD, PingOne, JumpCloud, and any SAML 2.0 compliant IdP
 
 **Documentation:**
@@ -112,10 +112,10 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 **Capabilities:**
 - **Custom roles** with configurable permissions
-- **Product-level access control** — restrict access to specific products (Web Automation, App Automation, HyperExecute, etc.)
-- **Entity-level permissions** — control access to projects, test cases, test runs, and configurations
-- **Organization-level role assignment** — manage roles centrally for all users
-- **Pre-built roles** — Admin, Manager, User, and Guest with sensible defaults
+- **Product-level access control**: restrict access to specific products (Web Automation, App Automation, HyperExecute, etc.)
+- **Entity-level permissions**: control access to projects, test cases, test runs, and configurations
+- **Organization-level role assignment**: manage roles centrally for all users
+- **Pre-built roles**: Admin, Manager, User, and Guest with sensible defaults
 
 **Documentation:**
 - [Roles and Permissions (RBAC)](/support/docs/rbac-roles-and-permissions/)
@@ -127,9 +127,9 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 <BrandName /> maintains enterprise-grade security across the platform with industry-standard certifications and encryption.
 
 **Certifications & Compliance:**
-- **SOC 2 Type II** certified — security, availability, processing integrity, confidentiality, and privacy (report available under NDA)
-- **ISO 27001** certified — information security management
-- **GDPR** compliant — data privacy and protection
+- **SOC 2 Type II** certified: security, availability, processing integrity, confidentiality, and privacy (report available under NDA)
+- **ISO 27001** certified: information security management
+- **GDPR** compliant: data privacy and protection
 
 **Encryption:**
 - **Data in transit**: TLS 1.2 or higher for all communications
@@ -138,7 +138,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 - **Credentials**: Multi-layer bcrypt hashing, no plaintext storage
 
 **Infrastructure Security:**
-- Clean VM/device per test session — no data leakage between sessions
+- Clean VM/device per test session, no data leakage between sessions
 - Immediate data deletion from VMs/devices after test completion
 - Network isolation and secure service-to-service authentication
 - Private tenant deployment for AI features (Azure OpenAI)
@@ -155,7 +155,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 | Deployment | Description | Best For |
 |-----------|-------------|----------|
-| **SaaS Cloud** | Fully managed cloud platform — no infrastructure to maintain | Most organizations |
+| **SaaS Cloud** | Fully managed cloud platform, no infrastructure to maintain | Most organizations |
 | **Private Cloud** | Dedicated cloud infrastructure with isolated resources | Organizations requiring data isolation |
 | **On-Premise** | Self-hosted deployment within your own infrastructure | Highly regulated industries, air-gapped environments |
 
@@ -176,10 +176,10 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 <BrandName /> provides comprehensive team management capabilities to organize users, control access, and manage testing at scale across your organization.
 
 **Capabilities:**
-- **Organizations** — top-level entity for managing users, billing, and settings
-- **Sub-Organizations** — create separate sub-orgs for departments, teams, or business units with independent analytics and concurrency tracking
-- **Groups** — organize users into groups for easier access management and resource allocation
-- **User Management** — invite, manage, and remove users with role-based permissions
+- **Organizations**: top-level entity for managing users, billing, and settings
+- **Sub-Organizations**: create separate sub-orgs for departments, teams, or business units with independent analytics and concurrency tracking
+- **Groups**: organize users into groups for easier access management and resource allocation
+- **User Management**: invite, manage, and remove users with role-based permissions
 
 **Documentation:**
 - [Team Management](/support/docs/team-management/)
@@ -190,20 +190,20 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 ## Integrations
 
-<BrandName /> integrates with the tools your enterprise already uses — from project management and CI/CD to communication and reporting.
+<BrandName /> integrates with the tools your enterprise already uses, from project management and CI/CD to communication and reporting.
 
 **Project Management:**
-- **Jira** — native app with bidirectional sync, AI test generation from tickets
-- **Azure DevOps** — native app with work item linking and AI generation
+- **Jira**: native app with bidirectional sync, AI test generation from tickets
+- **Azure DevOps**: native app with work item linking and AI generation
 
 **Source Control & CI/CD:**
-- **GitHub App** — PR-based test triggering, auto test generation, RCA, status checks
-- **Jenkins, GitHub Actions, GitLab CI, CircleCI, Azure Pipelines** — full CI/CD integration
-- **HyperExecute CLI** — integrate test execution into any pipeline
+- **GitHub App**: PR-based test triggering, auto test generation, RCA, status checks
+- **Jenkins, GitHub Actions, GitLab CI, CircleCI, Azure Pipelines**: full CI/CD integration
+- **HyperExecute CLI**: integrate test execution into any pipeline
 
 **Communication:**
-- **Slack** — build and dashboard notifications
-- **Microsoft Teams** — build and dashboard notifications
+- **Slack**: build and dashboard notifications
+- **Microsoft Teams**: build and dashboard notifications
 
 **APIs:**
 - RESTful APIs for test management, execution, and artifact retrieval
@@ -220,9 +220,9 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 <BrandName /> provides built-in capabilities to generate, manage, and protect the test data your teams use across automation. Teams can author synthetic datasets for data-driven tests, mask sensitive payloads in network logs and recordings, and parameterize tests so the same flow runs across environments and inputs without rework.
 
 **Capabilities:**
-- **Synthetic data generation** — author datasets in KaneAI Test Manager, populate values manually, autofill with AI based on parameter names, or import from CSV; default datasets are immutable and every dataset carries full version history with revert/restore support
-- **Data masking** — mask sensitive payloads (passwords, tokens, API keys, auth headers, cookies) in HTTP network logs via the `network.mask` Selenium capability; mask credentials, geolocation, and storage state captured in HyperExecute test recordings (Lambda Masking)
-- **Parameterization** — pass dynamic values into test cases at runtime using variables, secrets (encrypted), smart variables (resolved at execution), parameters, and datasets to reuse the same test across environments such as staging, pre-prod, and prod
+- **Synthetic data generation**: author datasets in KaneAI Test Manager, populate values manually, autofill with AI based on parameter names, or import from CSV. Default datasets are immutable and every dataset carries full version history with revert/restore support
+- **Data masking**: mask sensitive payloads (passwords, tokens, API keys, auth headers, cookies) in HTTP network logs via the `network.mask` Selenium capability. Mask credentials, geolocation, and storage state captured in HyperExecute test recordings (Lambda Masking)
+- **Parameterization**: pass dynamic values into test cases at runtime using variables, secrets (encrypted), smart variables (resolved at execution), parameters, and datasets to reuse the same test across environments such as staging, pre-prod, and prod
 
 **Documentation:**
 - [Test Data Generation Overview](/support/docs/test-data-generation/)
@@ -238,14 +238,14 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 <BrandName /> provides enterprise-grade reporting and analytics with AI-powered insights to help QA managers and executives make data-driven decisions.
 
 **Capabilities:**
-- **Pre-built dashboard templates** — get started instantly with common views
-- **Custom dashboards** — build your own with heatmap, bar, line, table, pie, and billboard widgets
-- **AI Test Intelligence** — Smart Tags (Flaky, Always Failing, New Failures), Flaky Test Detection, Failure Categorization AI
-- **AI Root Cause Analysis (AI RCA)** — LLM-powered failure diagnosis with actionable fix recommendations
-- **Build Insights and Comparison** — compare builds side-by-side to track quality trends
-- **Sub-Organization analytics** — drill down into team-level and sub-org performance
-- **Dashboard sharing** — shareable links with configurable expiry and password protection
-- **Data export** — export up to 1,000 records for external analysis
+- **Pre-built dashboard templates**: get started instantly with common views
+- **Custom dashboards**: build your own with heatmap, bar, line, table, pie, and billboard widgets
+- **AI Test Intelligence**: Smart Tags (Flaky, Always Failing, New Failures), Flaky Test Detection, Failure Categorization AI
+- **AI Root Cause Analysis (AI RCA)**: LLM-powered failure diagnosis with actionable fix recommendations
+- **Build Insights and Comparison**: compare builds side-by-side to track quality trends
+- **Sub-Organization analytics**: drill down into team-level and sub-org performance
+- **Dashboard sharing**: shareable links with configurable expiry and password protection
+- **Data export**: export up to 1,000 records for external analysis
 
 **Documentation:**
 - [Insights Overview](/support/docs/analytics-overview/)
@@ -284,9 +284,9 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 **Data Protection:**
 - **Data Processing Agreement (DPA)** available with Standard Contractual Clauses
-- **Customer as Data Controller** — you retain ownership and control of your test data
-- **<BrandName /> as Data Processor** — we process data only as instructed
-- **No PII/PHI storage** by default — system does not collect or require identifiable personal data
+- **Customer as Data Controller**: you retain ownership and control of your test data
+- **<BrandName /> as Data Processor**: we process data only as instructed
+- **No PII/PHI storage** by default: system does not collect or require identifiable personal data
 
 **Data Retention:**
 - Default 60-day retention across all products
@@ -312,11 +312,11 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 <BrandName /> provides tools for controlled test execution management and scheduled rollouts, ensuring enterprises can manage changes systematically.
 
 **Capabilities:**
-- **Scheduled Workflows** — run test suites on a schedule (one-time, recurring, with expiry dates) without CI/CD
-- **Connected Workflows (Test Chains)** — chain workflows across projects for sequential execution — run regression only if smoke passes
-- **Workflow Variables** — parameterize runs to reuse the same configuration across environments (staging, pre-prod, prod)
-- **Feature flags** — enterprise customers can control feature availability at the org level
-- **Version control integration** — GitHub and Bitbucket integration for branch-level test execution
+- **Scheduled Workflows**: run test suites on a schedule (one-time, recurring, with expiry dates) without CI/CD
+- **Connected Workflows (Test Chains)**: chain workflows across projects for sequential execution, run regression only if smoke passes
+- **Workflow Variables**: parameterize runs to reuse the same configuration across environments (staging, pre-prod, prod)
+- **Feature flags**: enterprise customers can control feature availability at the org level
+- **Version control integration**: GitHub and Bitbucket integration for branch-level test execution
 
 **Documentation:**
 - [HyperExecute Workflows](/support/docs/hyperexecute-workflows/)
@@ -355,7 +355,7 @@ If you're evaluating <BrandName /> for your enterprise and need additional detai
 
 - **Enterprise Sales**: Contact your account manager
 - **Security Questionnaire**: Request via [support@testmuai.com](mailto:support@testmuai.com)
-- **SOC 2 Report**: Available under NDA — contact enterprise sales
+- **SOC 2 Report**: Available under NDA. Contact enterprise sales
 - **Architecture Diagram**: Available upon request with NDA in place
 
 <nav aria-label="breadcrumbs">

--- a/docs/error-handling-kaneai.md
+++ b/docs/error-handling-kaneai.md
@@ -146,7 +146,7 @@ Use this guide to quickly identify, understand, and correct authoring issues to 
 
 ### Time Sensitive Assertion
 **Description:** The instruction attempts to validate temporary UI elements such as toasts, spinners, or banners. These elements are short-lived and may lead to unreliable results; use stable post-conditions instead. <br />
-**Common Authoring Error:** Example — assert toast says "Forecast job deleted". <br />
+**Common Authoring Error:** Example: assert toast says "Forecast job deleted". <br />
 **Suggested Ways:** Instead, check something stable (e.g., row is gone, job is absent).
 
 ---
@@ -168,7 +168,7 @@ Use this guide to quickly identify, understand, and correct authoring issues to 
 ---
 
 ### Persistent Loader
-**Description:** If a loading spinner or progress indicator stays visible for too long—specifically, after waiting multiple times or for more than 30 seconds—it usually means the system is stuck and not progressing as expected.<br />
+**Description:** If a loading spinner or progress indicator stays visible for too long (specifically, after waiting multiple times or for more than 30 seconds), it usually means the system is stuck and not progressing as expected.<br />
 **Common Authoring Error:** Waiting forever for the loader to go away without handling timeouts.<br />
 **Suggested Ways:** Implement a timeout to stop waiting after a reasonable period. Use checks that confirm when the page or content has fully loaded instead of relying only on the loader disappearing.
 
@@ -176,7 +176,7 @@ Use this guide to quickly identify, understand, and correct authoring issues to 
 
 ### Dead Click
 
-**Description:** If you keep clicking the same element but nothing happens—no change on the screen, no popup, and no response—this means the click isn’t having any effect.<br />
+**Description:** If you keep clicking the same element but nothing happens (no change on the screen, no popup, and no response), this means the click isn’t having any effect.<br />
 **Common Authoring Error:** Repeatedly clicking on an element that isn’t interactive or is disabled.<br />
 **Suggested Ways:** Make sure the element you want to click can actually be clicked and will trigger some action before clicking it. stop the flow if clicks don’t cause any response.
 
@@ -206,7 +206,7 @@ Use this guide to quickly identify, understand, and correct authoring issues to 
 
 ---
 
-### While Loop — Maximum Iterations Reached
+### While Loop: Maximum Iterations Reached
 
 **Error Code:** `LOOP_MAX_LIMIT_REACHED` <br />
 **Error Message:** *While loop exceeded maximum iterations. This may be due to an issue with the loop condition or the actions within the loop.* <br />
@@ -216,31 +216,31 @@ Use this guide to quickly identify, understand, and correct authoring issues to 
 
 ---
 
-### While Loop — Infinite Loop Detected
+### While Loop: Infinite Loop Detected
 
 **Error Code:** `INFINITE_LOOP_DETECTED` <br />
 **Error Message:** *The while loop appears to be an infinite loop. Please review the loop condition and the actions within the loop to ensure that the loop will terminate properly.* <br />
-**Description:** KaneAI detected a While Loop condition / body combination that cannot terminate — typically a condition that is independent of anything the body changes, or a comparison that is always true (for example, `1 == 1`). <br />
+**Description:** KaneAI detected a While Loop condition / body combination that cannot terminate, typically a condition that is independent of anything the body changes, or a comparison that is always true (for example, `1 == 1`). <br />
 **Common Authoring Error:** A While Loop whose body does not touch any value referenced by the condition, or a condition built from constants only. <br />
-**Suggested Ways:** Ensure the body contains at least one step that changes a value referenced by the condition — increment a counter, click a control that updates UI state, or wait for a status transition. If the condition uses constants, rewrite it so it depends on a variable or UI state that evolves during the loop.
+**Suggested Ways:** Ensure the body contains at least one step that changes a value referenced by the condition: increment a counter, click a control that updates UI state, or wait for a status transition. If the condition uses constants, rewrite it so it depends on a variable or UI state that evolves during the loop.
 
 ---
 
-### While Loop — Both Operands Are Parameters
+### While Loop: Both Operands Are Parameters
 
 **Error Code:** `BOTH_OPERANDS_AS_PARAMETERS` <br />
 **Error Message:** *Both operands in the while loop condition are parameters. Only one operand should be a parameter.* <br />
-**Description:** Both sides of a [While Loop](/support/docs/kaneai-while-loops/) condition are test parameters (for example, `${max_retries} > ${default_retries}`). Parameter values are fixed for the lifetime of a run, so such a condition cannot change between iterations — it would either loop forever or never enter. <br />
+**Description:** Both sides of a [While Loop](/support/docs/kaneai-while-loops/) condition are test parameters (for example, `${max_retries} > ${default_retries}`). Parameter values are fixed for the lifetime of a run, so such a condition cannot change between iterations. It would either loop forever or never enter. <br />
 **Common Authoring Error:** Comparing two dataset parameters directly in the loop condition, such as `${threshold} > ${limit}`. <br />
-**Suggested Ways:** Replace one operand with a runtime‑updated value — a counter variable incremented inside the body, a value read from the UI via a query, or a literal. Valid examples include `{{counter}} < ${max_retries}`, `${status} == "ready"`, and `{{cart_empty}} == false`.
+**Suggested Ways:** Replace one operand with a runtime‑updated value: a counter variable incremented inside the body, a value read from the UI via a query, or a literal. Valid examples include `{{counter}} < ${max_retries}`, `${status} == "ready"`, and `{{cart_empty}} == false`.
 
 ---
 
-### While Loop — Cannot Be Created via Natural Language
+### While Loop: Cannot Be Created via Natural Language
 
 **Error Code:** `WHILE_NOT_SUPPORTED_VIA_NL` <br />
 **Error Message:** *Looping is supported via slash commands only. Type / and select While Loop to add a loop.* <br />
-**Description:** A natural‑language step was used to describe a loop (for example, *"repeat until the cart is empty"*, *"while the spinner is visible, do X"*, or *"keep clicking Next"*). The natural‑language pipeline does not expand these phrases into loops — [While Loops](/support/docs/kaneai-while-loops/) can only be added through the **/** slash command menu. <br />
+**Description:** A natural‑language step was used to describe a loop (for example, *"repeat until the cart is empty"*, *"while the spinner is visible, do X"*, or *"keep clicking Next"*). The natural‑language pipeline does not expand these phrases into loops. [While Loops](/support/docs/kaneai-while-loops/) can only be added through the **/** slash command menu. <br />
 **Common Authoring Error:** Typing looping phrases like *"keep clicking Load more until no more results appear"* as a regular step instead of creating a While Loop block. <br />
 **Suggested Ways:** Remove the looping phrase from the plain‑English step. Open the slash menu (`/`), select **While Loop**, enter the loop condition, and add the per‑iteration action as a body step inside the loop.
 

--- a/docs/espresso-mockwebserver-localhost.md
+++ b/docs/espresso-mockwebserver-localhost.md
@@ -48,7 +48,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 ## Why Special Configuration is Needed
 
-When network capture (`network: true`) is enabled, HTTP requests from the device route through proxy. Localhost requests fail because the proxy runs on the host machine, not the device — so `http://localhost:{port}` resolves to the host's localhost instead of the device's.
+When network capture (`network: true`) is enabled, HTTP requests from the device route through proxy. Localhost requests fail because the proxy runs on the host machine, not the device, so `http://localhost:{port}` resolves to the host's localhost instead of the device's.
 
 Platform provides two solutions: **Localhost Bypass** and **Port Forwarding**.
 
@@ -114,15 +114,15 @@ Port forwarding works at the network level, so **all HTTP libraries are supporte
 - Maximum 5 unique ports. No duplicate ports allowed.
 - Invalid port formats (e.g., strings like `"abc"`) are rejected.
 - Cannot be used together with `localhost`.
-- `network: true` is **not** required for port forwarding — it works independently.
+- `network: true` is **not** required for port forwarding. It works independently.
 :::
 
 
 ## Troubleshooting
 
-- **Connection errors** — Ensure `network: true` is set when using `localhost: true`. For `portForwarding`, `network: true` is optional.
-- **Cannot use localhost and portForwarding together** — These are mutually exclusive. Pick one.
-- **Port validation errors** — Ports must be 1024–65535, max 5 unique ports, no duplicates allowed.
+- **Connection errors**: Ensure `network: true` is set when using `localhost: true`. For `portForwarding`, `network: true` is optional.
+- **Cannot use localhost and portForwarding together**: These are mutually exclusive. Pick one.
+- **Port validation errors**: Ports must be 1024–65535, max 5 unique ports, no duplicates allowed.
 
 <nav aria-label="breadcrumbs">
   <ul className="breadcrumbs">

--- a/docs/generate-test-cases.md
+++ b/docs/generate-test-cases.md
@@ -65,13 +65,13 @@ This feature is designed to save time, improve test coverage, and streamline the
 ## Highlights
 
 ### Conversation Layer
-Refine, correct, expand, and restructure your AI-generated test scenarios and test cases using natural language — no manual editing required. The Conversation Layer brings a **chat-driven workflow** directly into your generation session, letting you iterate in real time without starting over.
+Refine, correct, expand, and restructure your AI-generated test scenarios and test cases using natural language, no manual editing required. The Conversation Layer brings a **chat-driven workflow** directly into your generation session, letting you iterate in real time without starting over.
 
-- **Natural language control** — Describe changes in plain English, and the AI applies them instantly.
-- **Live streaming updates** — Watch scenarios and test cases update in real time as the AI processes your request.
-- **Precise targeting** — Use `@` references to target specific scenarios or test cases for modification.
-- **Context-aware** — The AI retains your full session context including uploaded files, linked issues, and prior instructions.
-- **File-based refinement** — Upload updated specs or requirements mid-session and ask the AI to fill coverage gaps.
+- **Natural language control**: Describe changes in plain English, and the AI applies them instantly.
+- **Live streaming updates**: Watch scenarios and test cases update in real time as the AI processes your request.
+- **Precise targeting**: Use `@` references to target specific scenarios or test cases for modification.
+- **Context-aware**: The AI retains your full session context including uploaded files, linked issues, and prior instructions.
+- **File-based refinement**: Upload updated specs or requirements mid-session and ask the AI to fill coverage gaps.
 
 ### Custom Instructions
 
@@ -141,15 +141,15 @@ The **Memory Layer** is an intelligent context retrieval system that enhances AI
 
 When you initiate a test case generation session, the following process occurs automatically:
 
-1. **Input Analysis** — The AI analyzes your prompt, requirements, and custom instructions.
-2. **Context Retrieval** — The system queries a vector database to retrieve the most relevant existing test cases from your test case repository.
-3. **Context-Aware Generation** — The retrieved content is embedded into the prompt sent to the AI, enabling it to generate test cases that are aware of your existing coverage, non-duplicative, and complementary to your current test suite.
+1. **Input Analysis**: The AI analyzes your prompt, requirements, and custom instructions.
+2. **Context Retrieval**: The system queries a vector database to retrieve the most relevant existing test cases from your test case repository.
+3. **Context-Aware Generation**: The retrieved content is embedded into the prompt sent to the AI, enabling it to generate test cases that are aware of your existing coverage, non-duplicative, and complementary to your current test suite.
 
 ### Benefits
 
-- **Duplicate Prevention** — The AI recognizes test cases that already exist in your repository and avoids regenerating them.
-- **Contextual Relevance** — New test cases are informed by the language, structure, and patterns used in your existing test suite.
-- **Incremental Improvement** — Each generation session builds upon your accumulated testing knowledge.
+- **Duplicate Prevention**: The AI recognizes test cases that already exist in your repository and avoids regenerating them.
+- **Contextual Relevance**: New test cases are informed by the language, structure, and patterns used in your existing test suite.
+- **Incremental Improvement**: Each generation session builds upon your accumulated testing knowledge.
 :::note
 The Memory Layer operates automatically in the background, you can choose to enable or disable Memory enhancement feature before triggering a session.
 :::
@@ -323,11 +323,11 @@ When the Conversation Layer is active, the workspace is divided into two primary
 **Chat Interface (Left Panel)**
 
 The left panel is your chat interface for refining test output:
-- **Message input** — Type your refinement instructions in natural language at the bottom of the panel.
-- **Conversation history** — All messages and AI responses are preserved within the session.
-- **@ Autocomplete** — Type `@` to trigger an autocomplete dropdown for referencing specific scenarios or test cases.
-- **File attachments** — Attach files directly within the conversation using the attachment button.
-- **Confirmation prompts** — The AI asks for confirmation when a change affects more than 5 test cases.
+- **Message input**: Type your refinement instructions in natural language at the bottom of the panel.
+- **Conversation history**: All messages and AI responses are preserved within the session.
+- **@ Autocomplete**: Type `@` to trigger an autocomplete dropdown for referencing specific scenarios or test cases.
+- **File attachments**: Attach files directly within the conversation using the attachment button.
+- **Confirmation prompts**: The AI asks for confirmation when a change affects more than 5 test cases.
 
 <img loading="lazy" src={require('../assets/images/mobile-app-testing/chat_interface_panel.png').default} alt="chat-interface-panel" width="1347" height="616" className="doc_img"/>
 
@@ -335,10 +335,10 @@ The left panel is your chat interface for refining test output:
 **Live Output View (Right Panel)**
 
 The right panel is the primary workspace showing your generated test scenarios and test cases:
-- **Real-time updates** — Affected scenarios and test cases update with a streaming animation as changes are processed.
-- **Scenario cards** — Each scenario is displayed as an expandable card containing its test cases.
-- **Visual indicators** — Scenarios and test cases being modified are visually highlighted during streaming.
-- **Full test case details** — Expand any test case to view its steps, expected results, preconditions, and other fields.
+- **Real-time updates**: Affected scenarios and test cases update with a streaming animation as changes are processed.
+- **Scenario cards**: Each scenario is displayed as an expandable card containing its test cases.
+- **Visual indicators**: Scenarios and test cases being modified are visually highlighted during streaming.
+- **Full test case details**: Expand any test case to view its steps, expected results, preconditions, and other fields.
 
 <img loading="lazy" src={require('../assets/images/mobile-app-testing/live_output_view.png').default} alt="live-output-view" width="1347" height="616" className="doc_img"/>
 
@@ -346,10 +346,10 @@ The right panel is the primary workspace showing your generated test scenarios a
 **Session Context Drawer**
 
 To review the context used for your current generation session, click the **pencil icon** located just above the chat input box at the bottom left. This opens a side drawer displaying:
-- **Attached Files** — All files uploaded during the session.
-- **Organization Instructions** — Organization-level custom instructions applied to the session.
-- **Project Instructions** — Project-level custom instructions applied to the session.
-- **Linked Issues** — Jira or Azure DevOps issues linked to the session.
+- **Attached Files**: All files uploaded during the session.
+- **Organization Instructions**: Organization-level custom instructions applied to the session.
+- **Project Instructions**: Project-level custom instructions applied to the session.
+- **Linked Issues**: Jira or Azure DevOps issues linked to the session.
 
 <img loading="lazy" src={require('../assets/images/mobile-app-testing/session_context_drawer.png').default} alt="session-context-drawer" width="1347" height="616" className="doc_img"/>
 
@@ -363,7 +363,7 @@ Use the context drawer to verify that the AI is working with the correct inputs.
 1. **You send a message** in the chat interface describing what you want to change.
 2. **The AI interprets your intent** and determines which scenarios or test cases to modify.
 3. **Changes stream in real time** to the live output view on the right.
-4. **You review and iterate** — send follow-up messages to fine-tune further.
+4. **You review and iterate**: send follow-up messages to fine-tune further.
 
 #### @ Referencing System
 
@@ -395,9 +395,9 @@ Restructure how your test cases are grouped and organized.
 
 | Action | Example Prompt |
 |--------|----------------|
-| Group by feature or module | Reorganize all test cases by feature — create separate scenarios for User Authentication, Shopping Cart, Checkout, and Order History |
+| Group by feature or module | Reorganize all test cases by feature, create separate scenarios for User Authentication, Shopping Cart, Checkout, and Order History |
 | Split by test type | Split @S1 into three separate scenarios: one for positive flows, one for negative/error cases, and one for boundary conditions |
-| Group by platform or environment | These test cases are mixed. Group them by platform — create one scenario for Web Desktop, one for Mobile Web, and one for Mobile App |
+| Group by platform or environment | These test cases are mixed. Group them by platform, create one scenario for Web Desktop, one for Mobile Web, and one for Mobile App |
 | Create user journey scenarios | Create end-to-end user journey scenarios. Combine login, product search, add to cart, and checkout into a complete "Customer Purchase Journey" scenario |
 
 
@@ -409,7 +409,7 @@ Add new test cases or scenarios to improve coverage.
 |--------|----------------|
 | Add missing test types | Add negative test cases to @S1 covering invalid email formats, passwords shorter than 8 characters, usernames with special characters, and empty field submissions |
 | Add security tests | We need security coverage for @S3. Add test cases for SQL injection, XSS attacks, CSRF validation, and session hijacking across all input fields |
-| Add platform-specific tests | Add mobile-specific test cases to @S2 — include touch gestures, pinch to zoom, orientation changes, and offline mode scenarios |
+| Add platform-specific tests | Add mobile-specific test cases to @S2, include touch gestures, pinch to zoom, orientation changes, and offline mode scenarios |
 | Fill coverage gaps from uploaded files | I've attached the updated requirements document. Review it against our current test cases and create new ones for any features or user stories we haven't covered yet |
 | Add new scenarios | Create a new scenario for the password reset flow with test cases covering successful reset, expired reset links, invalid tokens, rate limiting, and already-used tokens |
 
@@ -474,19 +474,19 @@ Precisely modify specific scenarios or test cases using `@` references.
 
 
 :::tip Pro Tips for Effective Refinement
-- **Use `@` references for precision** — Target specific scenarios (`@S1`) or test cases (`@S2.C3`) to ensure the AI modifies exactly what you intend
-- **Combine multiple actions** — Request several changes in one message: "Remove all Low priority test cases from @S1, add 2 boundary tests for the email field, and rename remaining test cases to include the module name"
-- **Provide updated context mid-session** — Upload revised specifications or link Jira/Azure DevOps tickets at any point to help the AI identify coverage gaps and generate test cases aligned with the latest requirements
-- **Start broad, then refine** — First organize scenarios at a high level, then drill down to individual test cases
+- **Use `@` references for precision**: Target specific scenarios (`@S1`) or test cases (`@S2.C3`) to ensure the AI modifies exactly what you intend
+- **Combine multiple actions**: Request several changes in one message: "Remove all Low priority test cases from @S1, add 2 boundary tests for the email field, and rename remaining test cases to include the module name"
+- **Provide updated context mid-session**: Upload revised specifications or link Jira/Azure DevOps tickets at any point to help the AI identify coverage gaps and generate test cases aligned with the latest requirements
+- **Start broad, then refine**: First organize scenarios at a high level, then drill down to individual test cases
 :::
 
 #### Re-Generation Settings
 
 The Test Case Generator provides several controls that work alongside the Conversation Layer:
 
-- **Max Scenarios** — Control the maximum number of scenarios generated in a session.
-- **Max Test Cases per Scenario** — Set the upper limit for test cases within each individual scenario.
-- **Regenerate Scenarios** — Regenerate all scenarios utilizing existing context and to regenerate fresh Scenarions and Test Cases.
+- **Max Scenarios**: Control the maximum number of scenarios generated in a session.
+- **Max Test Cases per Scenario**: Set the upper limit for test cases within each individual scenario.
+- **Regenerate Scenarios**: Regenerate all scenarios utilizing existing context and to regenerate fresh Scenarions and Test Cases.
 
 <img loading="lazy" src={require('../assets/images/mobile-app-testing/regeneration_settings.png').default} alt="regeneration-settings" width="1347" height="616" className="doc_img"/>
 
@@ -514,9 +514,9 @@ The Conversation Layer consumes AI credits based on the scope of each refinement
 
 The following capabilities are planned for future releases:
 
-- **Undo and versioning** — No rollback mechanism for individual conversation-driven changes.
-- **Step-level referencing** — You cannot reference individual steps within a test case. Instead, reference the test case and describe the change.
-- **Coverage queries** — Asking analytical questions (e.g., "Do we have tests for invalid amounts?") without requesting a change is not supported.
+- **Undo and versioning**: No rollback mechanism for individual conversation-driven changes.
+- **Step-level referencing**: You cannot reference individual steps within a test case. Instead, reference the test case and describe the change.
+- **Coverage queries**: Asking analytical questions (e.g., "Do we have tests for invalid amounts?") without requesting a change is not supported.
 
 ---
 
@@ -548,7 +548,7 @@ The **Create and Automate** option requires KaneAI access. If you do not have Ka
 | Issue | Resolution |
 |-------|------------|
 | Conversation Layer panel not visible | Ensure you have generated at least one set of scenarios. The Conversation Layer activates after the initial generation completes. Refresh the page if needed. |
-| Changes not appearing in Live Output View | Check your internet connection. Large changes may take longer to process. If the issue persists, send a new message — the AI resumes from the current state. |
+| Changes not appearing in Live Output View | Check your internet connection. Large changes may take longer to process. If the issue persists, send a new message. The AI resumes from the current state. |
 | AI modified the wrong scenario or test case | Use explicit  Scenario (`@S1`) or Test Case (`@S1.C1`) references to avoid ambiguity. Rephrase your message with a direct reference and send it again. |
 | File upload fails | Verify the file does not exceed the 50 MB size limit and that you have not exceeded the 10-file session limit. |
 | Credits deducted but no changes appeared | This can occur if the AI could not interpret your request or if there was a connection interruption. Check the conversation history for an error message. |

--- a/docs/getting-started-with-hyperexecute.md
+++ b/docs/getting-started-with-hyperexecute.md
@@ -92,7 +92,7 @@ HyperExecute seamlessly supports all major test automation frameworks as shown b
   </div>
 
 ## Let's Run your First Test
-Ready to experience the power of HyperExecute? Getting started is easy—we’ve simplified the process so you can effortlessly launch your first test with three flexible approaches and experience the speed by yourself:
+Ready to experience the power of HyperExecute? Getting started is easy. We’ve simplified the process so you can effortlessly launch your first test with three flexible approaches and experience the speed by yourself:
 
 :::note RUN SAMPLE TEST
 <Tabs>

--- a/docs/gitlab-integration-with-hyperexecute.md
+++ b/docs/gitlab-integration-with-hyperexecute.md
@@ -46,7 +46,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 # GitLab Integration with HyperExecute
 * * *
 
-GitLab is a web-based Git repository that provides free open and private repositories, issue-following capabilities, and wikis. It is a complete DevOps platform that enables professionals to perform all the tasks in a project—from project planning and source code management to monitoring and security.
+GitLab is a web-based Git repository that provides free open and private repositories, issue-following capabilities, and wikis. It is a complete DevOps platform that enables professionals to perform all the tasks in a project, from project planning and source code management to monitoring and security.
 
 This document will show you how to integrate GitLab Pipeline with HyperExecute to greatly shorten your test cycles.
 

--- a/docs/group-folder-redirect.md
+++ b/docs/group-folder-redirect.md
@@ -41,7 +41,7 @@ This feature ensures your app uses its **private container directory** instead o
 ### 1. Upload Your Application
 - Upload your iOS app to <BrandName /> following standard procedures.  
 - Refer to the [**Upload your Application**](/support/docs/application-setup-via-api/#upload-your-application) documentation for detailed instructions.  
-- Note the **App ID** returned after uploading — you will use this in your automation scripts.
+- Note the **App ID** returned after uploading, you will use this in your automation scripts.
 
 ---
 

--- a/docs/hyperexecute-bidi-testing.md
+++ b/docs/hyperexecute-bidi-testing.md
@@ -49,7 +49,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 ></script>
 **BiDi (Bi-Directional)** refers to the **WebDriver BiDi protocol**, a new standard from the W3C (World Wide Web Consortium). Unlike the traditional WebDriver protocol (which works in a request → response model), **WebDriver BiDi enables two-way communication between your test script and the browser in real time**.
 
-That means instead of only sending commands (like “click this element” or “navigate to this URL”), your test can also **subscribe to events happening inside the browser** as they occur — such as console logs, network requests, page lifecycle events, or JavaScript exceptions. In simple terms:
+That means instead of only sending commands (like “click this element” or “navigate to this URL”), your test can also **subscribe to events happening inside the browser** as they occur, such as console logs, network requests, page lifecycle events, or JavaScript exceptions. In simple terms:
 - **Old WebDriver** = One-way communication (test script sends a command, browser replies).
 - **BiDi WebDriver** = Two-way communication (test script can also “listen” to the browser while interacting with it).
 

--- a/docs/hyperexecute-cli-gui.md
+++ b/docs/hyperexecute-cli-gui.md
@@ -157,7 +157,7 @@ Search within tests is not yet available on the GUI. We are working to make it a
 
 ### Step 4: Specify Run Config
 The **Run Config tab** in HyperExecute GUI offers an intuitive visual interface to configure your test environment and execution settings.
-You’ll find the basic preset configurations displayed just below your project name. If you need to modify or customize these settings, simply navigate to the Run Config tab and adjust your execution environment effortlessly — _no YAML editing required_.
+You’ll find the basic preset configurations displayed just below your project name. If you need to modify or customize these settings, simply navigate to the Run Config tab and adjust your execution environment effortlessly, _no YAML editing required_.
 
 To learn about any configuration in detail, please search for the keyword in the **[HyperExecute YAML Documentation](/support/docs/deep-dive-into-hyperexecute-yaml)**. Please note that the GUI follows version 0.2 YAML parameters instead of discovery and runner commands as in version 0.1 YAML which you can find [here](/support/docs/hyperexecute-yaml-version0.2).
 

--- a/docs/hyperexecute-gattling-testing.md
+++ b/docs/hyperexecute-gattling-testing.md
@@ -106,7 +106,7 @@ Download the HyperExecute CLI and copy it into the root folder of the downloaded
 | macOS | https://downloads.lambdatest.com/hyperexecute/darwin/hyperexecute |
 
 ### Step 3: Configure your hyperexecute.yml file
-The core of HyperExecute configuration lies in the `hyperexecute.yaml` file. Let’s understand how it is constructed — step by step:
+The core of HyperExecute configuration lies in the `hyperexecute.yaml` file. Let’s understand how it is constructed, step by step:
 
 #### 1. Define Test Environment and Execution Strategy
 The first step is to define the environment your tests will run on using the runson parameter. You can also configure intelligent parallelization and test exit conditions.

--- a/docs/hyperexecute-github-app-integration.md
+++ b/docs/hyperexecute-github-app-integration.md
@@ -188,7 +188,7 @@ Each tenant maintains its own:
 - RSA private key for token generation
 - Short-lived installation access tokens
 
-Credentials are **fully isolated** between tenants — tokens and keys from one GitHub instance are never used for another.
+Credentials are **fully isolated** between tenants, tokens and keys from one GitHub instance are never used for another.
 
 ### What You Can Do
 
@@ -210,5 +210,5 @@ For GitHub Enterprise Server or any tenant other than `github.com`:
 3. Complete the registration on the <BrandName /> setup page. The tenant is recorded automatically based on the GitHub App's origin.
 
 :::note
-For the default tenant (`github.com`), the platform's built-in Marketplace GitHub App handles key management automatically — no manual secret creation is needed.
+For the default tenant (`github.com`), the platform's built-in Marketplace GitHub App handles key management automatically, no manual secret creation is needed.
 :::

--- a/docs/hyperexecute-guided-walkthrough.md
+++ b/docs/hyperexecute-guided-walkthrough.md
@@ -67,12 +67,12 @@ The top panel contains multiple items:
 
 The Jobs page provides a filter bar to narrow down the job list based on the following criteria:
 
-- **Status** — Filter jobs by their current status (Running, Completed, Failed, Aborted, etc.)
-- **Label** — Filter by job labels defined in your YAML configuration.
-- **Users** — Filter jobs by the user who triggered them. This is useful when multiple team members share the same organization and you want to view only your jobs.
-- **Type** — Filter by job type (Selenium, Playwright, Cypress, etc.)
-- **Date** — Filter jobs by date range.
-- **View** — Toggle between different view options (e.g., archived jobs).
+- **Status**: Filter jobs by their current status (Running, Completed, Failed, Aborted, etc.)
+- **Label**: Filter by job labels defined in your YAML configuration.
+- **Users**: Filter jobs by the user who triggered them. This is useful when multiple team members share the same organization and you want to view only your jobs.
+- **Type**: Filter by job type (Selenium, Playwright, Cypress, etc.)
+- **Date**: Filter jobs by date range.
+- **View**: Toggle between different view options (e.g., archived jobs).
 
 <img loading="lazy" src={require('../assets/images/hyperexecute/features/job-list/filters-panel.png').default} alt="Job Filters" className="doc_img"/>
 

--- a/docs/hyperexecute-how-to-manage-project-level-secrets.md
+++ b/docs/hyperexecute-how-to-manage-project-level-secrets.md
@@ -3,7 +3,7 @@ id: hyperexecute-how-to-manage-project-level-secrets
 title: Manage Project Level Secrets in HyperExecute
 hide_title: false
 sidebar_label: Project-Level Secrets
-description: Learn how to manage project-level secrets in HyperExecute—scope credentials per project, restrict access, and keep sensitive data secure.
+description: Learn how to manage project-level secrets in HyperExecute, scope credentials per project, restrict access, and keep sensitive data secure.
 keywords:
   - TestMu AI Hyperexecute
   - TestMu AI Hyperexecute help
@@ -97,7 +97,7 @@ env:
 | **Access Control** | Controlled by user account permissions | Controlled by project permissions |
 
 ## Why Use Project-Level Secrets?
-- **Centralized Management :** Keep all secrets related to a test framework or application in one place—the project.
+- **Centralized Management :** Keep all secrets related to a test framework or application in one place: the project.
 - **Team Collaboration :** Multiple team members can access the same secrets via shared project access.
 - **Simplified CI/CD Setup :** Reference your project in the YAML, and secrets are injected automatically without extra configuration.
 - **Security :** Secrets remain encrypted and are never logged or exposed in your code.

--- a/docs/hyperexecute-karate-testing.md
+++ b/docs/hyperexecute-karate-testing.md
@@ -104,7 +104,7 @@ HyperExecute distributes feature files intelligently across defined parallel nod
 Automatically re-run failed scenarios without restarting the entire suite.
 
 #### 3. Real-Time Logs & Reports**
-Debug faster with per-test logs, reports, and console outputs—available instantly in the HyperExecute dashboard.
+Debug faster with per-test logs, reports, and console outputs, available instantly in the HyperExecute dashboard.
 
 #### 4. Flakiness & Stability Insights**
 Track unstable tests using built-in analytics that detect patterns of failure across builds.

--- a/docs/hyperexecute-python-use-cases.md
+++ b/docs/hyperexecute-python-use-cases.md
@@ -93,7 +93,7 @@ If your pipeline fails with:
 
 It means that the `requirements.txt` file might be missing or ignored in .gitignore.
 
-**Solution :** Ensure the file exists in the project root. Remove or comment out any requirements.txt entry from .gitignore. For this issue, ther are no YAML change required — this is a file management fix. However, verify that the command below correctly references the existing file name.
+**Solution :** Ensure the file exists in the project root. Remove or comment out any requirements.txt entry from .gitignore. For this issue, ther are no YAML change required. This is a file management fix. However, verify that the command below correctly references the existing file name.
 
 ```bash
 pip install -r requirements.txt --cache-dir CacheDir

--- a/docs/hyperexecute-release-notes-2024.md
+++ b/docs/hyperexecute-release-notes-2024.md
@@ -324,14 +324,14 @@ HyperExecute now supports Accessibility Testing for both Selenium and Cypress! T
 ### Benefits of Accessibility Testing in HyperExecute
 With this feature, you can seamlessly validate a range of accessibility issues to create more inclusive and user-friendly web applications. Here's how it benefits you:
 
-- **Automated Issue Detection:** Identify common accessibility problems such as missing alt attributes, incorrect ARIA roles, and insufficient color contrast—early in the development process.
+- **Automated Issue Detection:** Identify common accessibility problems such as missing alt attributes, incorrect ARIA roles, and insufficient color contrast, early in the development process.
 - **Detailed Accessibility Reports:** Receive comprehensive reports that pinpoint accessibility issues, with actionable recommendations for resolving them.
 - **Improved Compliance:** Ensure your applications adhere to critical accessibility guidelines like **WCAG 2.2 AA** or previous versions: WCAG 2.0 A, WCAG 2.0 AA, WCAG 2.1 A, WCAG 2.1 AA, WCAG 2.1 AAA, and WCAG 2.2 A, helping you avoid legal risks and create a better experience for all users.
 
 ### How to Use:
 - **For Selenium Users:**
 To start accessibility testing with Selenium, you have to pass `"accessibility", true` capability in your test files.
-> 📕 Check out our detailed guide on [HyperExecute integration — Selenium accessibility automation](/support/docs/selenium-hyperexecute-accessibility-tests/).
+> 📕 Check out our detailed guide on [HyperExecute integration: Selenium accessibility automation](/support/docs/selenium-hyperexecute-accessibility-tests/).
 
 - **For Cypress Users:**
 To start accessibility testing with Cypress, you have to pass `accessibility: true` capability in the [cypressOps](/support/docs/deep-dive-into-hyperexecute-yaml/#cypressops) flag of your YAML file as well as update other necessary configurations in your project.

--- a/docs/hyperexecute-release-notes-2025.md
+++ b/docs/hyperexecute-release-notes-2025.md
@@ -96,7 +96,7 @@ Performance testing often needs more than a single test run. Workflows allow you
 
 ## Version 3.1.4
 ### Enhanced Support for Azure Repositories in HyperExecute Projects
-We have introduced an enhancement to the HyperExecute [Custom Project feature](/support/docs/hyperexecute-projects/#setup-custom-project) to support Azure Repos. This enables you with code repositories hosted in Azure DevOps to execute tests directly on HyperExecute—without relying on Jenkins or any external CI/CD tool.
+We have introduced an enhancement to the HyperExecute [Custom Project feature](/support/docs/hyperexecute-projects/#setup-custom-project) to support Azure Repos. This enables you with code repositories hosted in Azure DevOps to execute tests directly on HyperExecute, without relying on Jenkins or any external CI/CD tool.
 
 With this update, you can now configure Azure Repos in the same intuitive manner as GitHub, or Bitbucket. Simply provide the repository details and Personal Access Token (PAT), and HyperExecute will fetch the code and trigger workflows seamlessly.
 
@@ -161,7 +161,7 @@ HyperExecute categorizes logs into Errors and Warnings using intelligent pattern
 
 ## Version 3.0.5
 ### Feature: syncStart
-HyperExecute now supports the `syncStart` directive in the job YAML. When enabled, all VMs in `autosplit` or `matrix` mode start their tasks simultaneously after allocation—ideal for benchmarking or comparative test runs.
+HyperExecute now supports the `syncStart` directive in the job YAML. When enabled, all VMs in `autosplit` or `matrix` mode start their tasks simultaneously after allocation, ideal for benchmarking or comparative test runs.
 
 If some VMs are not ready within 15 minutes, the job starts with the available ones.
 
@@ -370,7 +370,7 @@ framework:
 
 ## Version 2.9.4
 ### YAML-Based Capability Overrides for Selenium Tests
-You can now override Selenium capabilities directly from your `hyperexecute.yaml` file using the new `ltOptions` flag. This enhancement allows you to define key-value pairs—like browser type, version, logs, video, tunnel, and more without changing your test scripts.
+You can now override Selenium capabilities directly from your `hyperexecute.yaml` file using the new `ltOptions` flag. This enhancement allows you to define key-value pairs, like browser type, version, logs, video, tunnel, and more without changing your test scripts.
 
 **Why it matters?**
 - Avoid code changes for environment-specific needs.

--- a/docs/hyperexecute-run-jmeter-tests.md
+++ b/docs/hyperexecute-run-jmeter-tests.md
@@ -95,8 +95,8 @@ Download or Clone the code sample for the JMeter Performance Testing from the <B
 
 Override selected JMeter properties for this run. The following [user properties](https://jmeter.apache.org/usermanual/test_plan.html#properties) are currently configurable:
 
-- **`jmeter.save.saveservice.subresults`** — Whether sub-results (for example, sub-samples generated within a transaction or by HTTP redirects) are written to the results file. Set to `false` to reduce result file size.
-- **`httpclient.socket.https.cps`** — Characters per second cap on HTTPS downloads for the HttpClient sampler. Use it to simulate low-bandwidth conditions; `0` means unlimited.
+- **`jmeter.save.saveservice.subresults`**: Whether sub-results (for example, sub-samples generated within a transaction or by HTTP redirects) are written to the results file. Set to `false` to reduce result file size.
+- **`httpclient.socket.https.cps`**: Characters per second cap on HTTPS downloads for the HttpClient sampler. Use it to simulate low-bandwidth conditions; `0` means unlimited.
 
 - Click on the **Run Test** button.
 

--- a/docs/hyperexecute-shared-cloud-usage-limit.md
+++ b/docs/hyperexecute-shared-cloud-usage-limit.md
@@ -45,7 +45,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 To ensure fair usage, maintain system stability, and promote optimal test practices across all our users, <BrandName /> enforces a daily usage limit on test execution time at the organization level. Each organization is allocated a maximum allowable test duration per day, calculated based on the number of concurrent (parallel) sessions provisioned to the account. This safeguard helps prevent overutilization and ensures equitable access to resources across the platform.
 
 ## Why This Matters
-Running long-duration test sessions—especially those exceeding 120 minutes—can cause memory and CPU spikes that impact system performance and reliability. To prevent such disruptions and improve the efficiency of test execution, we encourage users to:
+Running long-duration test sessions, especially those exceeding 120 minutes, can cause memory and CPU spikes that impact system performance and reliability. To prevent such disruptions and improve the efficiency of test execution, we encourage users to:
 
 - Split long-running tests into smaller, modular suites.
 - Implement test retries, timeouts, and teardown routines to handle edge cases and resource leaks.

--- a/docs/hyperexecute-status.md
+++ b/docs/hyperexecute-status.md
@@ -71,9 +71,9 @@ All the tests on HyperExecute get executed as a Job. Each Job has a Status, a un
 
 You can abort a running job directly from the HyperExecute portal. Once a job is in **Running** state, click on the job to open the Job Details page. You will see an **Abort** option that provides the following choices:
 
-- **Abort Current Job** — Stops only the selected running job.
-- **Abort All Jobs** — Stops all currently running jobs.
-- **Abort Selected Jobs** — Allows you to select specific jobs to abort.
+- **Abort Current Job**: Stops only the selected running job.
+- **Abort All Jobs**: Stops all currently running jobs.
+- **Abort Selected Jobs**: Allows you to select specific jobs to abort.
 
 When a job is aborted, all active test sessions within that job are terminated immediately and no residual processes remain. The remaining tests that were not yet executed will be marked as **Cancelled**.
 

--- a/docs/hyperexecute-testng-use-cases.md
+++ b/docs/hyperexecute-testng-use-cases.md
@@ -2,7 +2,7 @@
 id: hyperexecute-testng-use-cases
 title: HyperExecute TestNG Use Cases
 sidebar_label: TestNG Use Cases
-description: Practical TestNG automation use cases on HyperExecute—parallel execution, data-driven tests, and Java workflows to accelerate QA delivery.
+description: "Practical TestNG automation use cases on HyperExecute: parallel execution, data-driven tests, and Java workflows to accelerate QA delivery."
 keywords:
   - TestMu AI Hyperexecute
   - TestMu AI Hyperexecute help

--- a/docs/hyperexecute-vs-traditional-test-grids.md
+++ b/docs/hyperexecute-vs-traditional-test-grids.md
@@ -86,6 +86,6 @@ As seen above, tests are securely run on dedicated machines on the Azure cloud. 
 
 - <b>Fine-Grained Concurrency Control:</b> Hyperscale of HyperExecute allows users to have fine grain control over test execution concurrency using YAML files.
 
-- <b>Linux Autoscaling:</b> HyperExecute automatically scales computing resources up or down based on workload. When test demand increases, additional resources are provisioned dynamically, and when demand decreases, resources are released — ensuring optimal performance without manual intervention.
+- <b>Linux Autoscaling:</b> HyperExecute automatically scales computing resources up or down based on workload. When test demand increases, additional resources are provisioned dynamically, and when demand decreases, resources are released, ensuring optimal performance without manual intervention.
 
 > For more details, please refer to our guide on [Key Features of HyperExecute](/support/docs/key-features-of-hyperexecute/)

--- a/docs/hyperexecute-workflows.md
+++ b/docs/hyperexecute-workflows.md
@@ -92,9 +92,9 @@ During workflow creation (Step 2 of 3), you can configure the **Triggering Sched
 
 You can choose from three trigger options:
 
-- **Once** — The workflow runs automatically as soon as it is created. No manual execution needed.
-- **Later** — Schedule the workflow to run at a specific date and time.
-- **Every** — Set up recurring execution by selecting specific days of the week (Mon–Sun) and a time. For example, you can schedule a workflow to run every Monday, Wednesday, and Friday at 9:00 AM.
+- **Once**: The workflow runs automatically as soon as it is created. No manual execution needed.
+- **Later**: Schedule the workflow to run at a specific date and time.
+- **Every**: Set up recurring execution by selecting specific days of the week (Mon–Sun) and a time. For example, you can schedule a workflow to run every Monday, Wednesday, and Friday at 9:00 AM.
 
 :::note
 The schedule is set in your **local timezone** and stored internally in UTC. This ensures workflows trigger at the correct time regardless of where team members are located.
@@ -122,9 +122,9 @@ Click the **Play** button (▶) next to a workflow to manually trigger it. This 
 
 Click the **three dots menu** (⋯) on any workflow to access the following actions:
 
-- **Edit Workflow** — Modify the workflow name, branch, YAML path, schedule, linked workflows, or variables.
-- **Clone Workflow** — Duplicate an existing workflow configuration. This creates a copy with the same settings, which you can then modify as needed.
-- **Delete Workflow** — Permanently remove a workflow. This does not delete any jobs that were previously triggered by the workflow.
+- **Edit Workflow**: Modify the workflow name, branch, YAML path, schedule, linked workflows, or variables.
+- **Clone Workflow**: Duplicate an existing workflow configuration. This creates a copy with the same settings, which you can then modify as needed.
+- **Delete Workflow**: Permanently remove a workflow. This does not delete any jobs that were previously triggered by the workflow.
 
 <img loading="lazy" src={require('../assets/images/hyperexecute/features/workflows/workflow-actions-menu.png').default} alt="Workflow Actions Menu" className="doc_img"/>
 

--- a/docs/hyperexecute-yaml-capability-overrides.md
+++ b/docs/hyperexecute-yaml-capability-overrides.md
@@ -41,7 +41,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
       })
     }}
 ></script>
-In Selenium-based testing, [capabilities](/support/docs/selenium-automation-capabilities/) are key-value pairs that define how and where your tests should run—such as browser type, version, OS, console logs, video recording, and more.
+In Selenium-based testing, [capabilities](/support/docs/selenium-automation-capabilities/) are key-value pairs that define how and where your tests should run, such as browser type, version, OS, console logs, video recording, and more.
 
 Previously, these capabilities were typically defined within the test script. With this new feature, you can now override or inject these directly from your **HyperExecute YAML** file. This gives you greater flexibility and eliminates the need to modify test scripts every time you change execution parameters.
 

--- a/docs/hyperexecute-yaml-creation-for-playwright.md
+++ b/docs/hyperexecute-yaml-creation-for-playwright.md
@@ -2,7 +2,7 @@
 id: hyperexecute-yaml-creation-for-playwright
 title: HyperExecute YAML Creation for Playwright
 sidebar_label: YAML Creation for Playwright
-description: A step-by-step guide to creating a HyperExecute YAML configuration for Playwright tests—matrix strategy, dependencies, and parallel runs.
+description: "A step-by-step guide to creating a HyperExecute YAML configuration for Playwright tests: matrix strategy, dependencies, and parallel runs."
 keywords:
   - TestMu AI Hyperexecute
   - TestMu AI Hyperexecute help

--- a/docs/ios-keychain-cleanup.md
+++ b/docs/ios-keychain-cleanup.md
@@ -58,12 +58,12 @@ Certain iOS apps may retain user data such as login details across different tes
 This happens because when an app is uninstalled, any Keychain data associated with it **remains on the device**, as iOS does not automatically clear it.  
 While this data is isolated from other apps, it can persist unless specifically removed.
 
-To prevent data from carrying over across sessions, <BrandName /> offers an option to automatically clear all Keychain entries after your test ends — ensuring a clean environment for every run.
+To prevent data from carrying over across sessions, <BrandName /> offers an option to automatically clear all Keychain entries after your test ends, ensuring a clean environment for every run.
 
 ## Keychain Access Groups During App Resigning
 
 When <BrandName /> resigns your iOS application using a wildcard provisioning profile (to enable installation on real devices), the app’s **keychain-access-groups** entitlement is preserved.  
-However, the **Bundle Seed ID** (also known as Team ID) — a critical part of access groups — gets replaced during resigning.
+However, the **Bundle Seed ID** (also known as Team ID), a critical part of access groups, gets replaced during resigning.
 
 As a result, app functionalities that depend on the original access group may break if not handled properly.  
 By enabling Keychain support, <BrandName /> takes care of these changes, allowing your app to continue using Keychain securely even after resigning.

--- a/docs/ip-geolocation-on-real-devices-app.md
+++ b/docs/ip-geolocation-on-real-devices-app.md
@@ -55,7 +55,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 Location-specific behavior is crucial to ensure your mobile apps and websites deliver accurate and localized experiences to users worldwide. Whether it's testing region-based content, geo-restricted features, or local SEO implementations, manually simulating different geolocations is essential for a robust QA process.
 
-<BrandName />'s Geolocation Simulation feature allows you to manually set and update the GPS location on real Android devices during live app testing sessions. This empowers you to verify how your app behaves for users across various regions—without needing to physically move devices or use external GPS spoofing tools.
+<BrandName />'s Geolocation Simulation feature allows you to manually set and update the GPS location on real Android devices during live app testing sessions. This empowers you to verify how your app behaves for users across various regions, without needing to physically move devices or use external GPS spoofing tools.
 
 
 ## Update Geolocation for Real Devices on <BrandName />

--- a/docs/ip-geolocation-on-real-devices-browser.md
+++ b/docs/ip-geolocation-on-real-devices-browser.md
@@ -61,7 +61,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 Understanding how your website behaves across different geographies is essential for delivering a personalized and compliant user experience. Whether you're targeting region-specific pricing, content, or legal requirements, geolocation simulation is a critical part of cross-border testing.
 
-With <BrandName />’s Geolocation Change feature for Real Device Browsers, you can manually simulate a different country during a live browser testing session—on actual Android devices. This allows you to test how your mobile website responds to users from specific locations without using a VPN or emulator.
+With <BrandName />’s Geolocation Change feature for Real Device Browsers, you can manually simulate a different country during a live browser testing session, on actual Android devices. This allows you to test how your mobile website responds to users from specific locations without using a VPN or emulator.
 
 ## Update Geolocation for Real Devices on <BrandName />
 

--- a/docs/kane-ai-automation-code-generation.md
+++ b/docs/kane-ai-automation-code-generation.md
@@ -137,17 +137,17 @@ After code generation completes, the **Code** tab shows the status of each gener
 
 Once code is generated, the following actions are available:
 
-- **Execute & Verify** — Triggers a Sample Run Execution on HyperExecute. This runs the generated code the same way a real KaneAI test run would, including respecting assertion outcomes. While the run is in progress, the status changes to **Verifying** and a **Sample execution in progress · View in HyperExecute** link appears. Once complete, the status updates to **Verified** and the button label changes to **Execute**.
-- **Download** — Downloads the generated code to your local machine.
+- **Execute & Verify**: Triggers a Sample Run Execution on HyperExecute. This runs the generated code the same way a real KaneAI test run would, including respecting assertion outcomes. While the run is in progress, the status changes to **Verifying** and a **Sample execution in progress · View in HyperExecute** link appears. Once complete, the status updates to **Verified** and the button label changes to **Execute**.
+- **Download**: Downloads the generated code to your local machine.
 
 ### Sample Run Execution Behavior
 
 - Sample Run Execution can only be initiated from the **Code** tab of a test case.
-- The **Execute** button is always enabled — you can proceed to run the test on HyperExecute regardless of whether a Sample Run Execution has passed, failed, or not been triggered.
+- The **Execute** button is always enabled. You can proceed to run the test on HyperExecute regardless of whether a Sample Run Execution has passed, failed, or not been triggered.
 
 ### Adding Test Cases to a Test Run
 
-Test cases with generated code can be added to a Test Run regardless of the Sample Run Execution status — whether it passed, failed, or was never triggered. The only cases where a test case is not available for selection in a Test Run are:
+Test cases with generated code can be added to a Test Run regardless of the Sample Run Execution status, whether it passed, failed, or was never triggered. The only cases where a test case is not available for selection in a Test Run are:
 
 - Code generation failed or was not initiated.
 - Code generation is still in progress.

--- a/docs/kane-ai-click-interactions.md
+++ b/docs/kane-ai-click-interactions.md
@@ -49,20 +49,20 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-KaneAI supports advanced click variants beyond a standard single click — **press and hold (long press)**, **multi-click (double / triple / N-click)**, and **right click (context click)** — across Desktop Web, Android apps, iOS apps, and Mobile Web. Each can be authored with natural language or captured via Manual Interaction, and renders as a distinct step with its own icon and pill label.
+KaneAI supports advanced click variants beyond a standard single click: **press and hold (long press)**, **multi-click (double / triple / N-click)**, and **right click (context click)**, across Desktop Web, Android apps, iOS apps, and Mobile Web. Each can be authored with natural language or captured via Manual Interaction, and renders as a distinct step with its own icon and pill label.
 
 ## Overview
 
 You can author any of the three click variants in two ways:
 
-- **Natural Language (NL)** — describe the click in plain English (e.g. `long press the menu icon for 5 seconds`).
-- **Manual Interaction** — perform the gesture on the device or browser viewport and have it captured as a step.
+- **Natural Language (NL)**: describe the click in plain English (e.g. `long press the menu icon for 5 seconds`).
+- **Manual Interaction**: perform the gesture on the device or browser viewport and have it captured as a step.
 
 | Click Type | Pill Label | Typical Use |
 |------------|------------|-------------|
 | **Press and Hold** | LONG PRESS | Developer mode entry, context menus, multi-select, hidden settings, push-to-talk |
 | **Multi-Click** | MULTI CLICK | Text selection, zoom, list opening, counter interactions |
-| **Right Click** | RIGHT CLICK | Context menus on web — duplicate, rename, delete, custom actions |
+| **Right Click** | RIGHT CLICK | Context menus on web: duplicate, rename, delete, custom actions |
 
 ## Supported Platforms
 
@@ -74,7 +74,7 @@ You can author any of the three click variants in two ways:
 | **Mobile Web** | ✅ | ✅ | ❌ | ❌ (NL only) |
 
 :::warning
-**Right click is web-only.** On mobile, use **long press** to open context menus — KaneAI does not silently convert one to the other because they have different semantics.
+**Right click is web-only.** On mobile, use **long press** to open context menus. KaneAI does not silently convert one to the other because they have different semantics.
 :::
 
 ---
@@ -227,9 +227,9 @@ The three click modifiers cannot be combined on a single operation. Attempting t
 
 | Combination | Result |
 |-------------|--------|
-| Long press + Multi-click | Invalid — duration and frequency cannot both be set |
-| Right click + Long press | Invalid — right click cannot combine with duration |
-| Right click + Multi-click | Invalid — right click cannot combine with frequency |
+| Long press + Multi-click | Invalid: duration and frequency cannot both be set |
+| Right click + Long press | Invalid: right click cannot combine with duration |
+| Right click + Multi-click | Invalid: right click cannot combine with frequency |
 
 **NL examples that fail:**
 - `long press the button 3 times`
@@ -255,12 +255,12 @@ Each click type displays a distinct icon and pill label in the **Sidebar**, **Te
 
 ## Best Practices
 
-- **Use NL for most interactions** — fastest authoring path; produces element-first steps.
-- **Use Manual Interaction for precise timing** — when exact hold duration matters (e.g. 10 s developer mode).
+- **Use NL for most interactions**: fastest authoring path; produces element-first steps.
+- **Use Manual Interaction for precise timing**: when exact hold duration matters (e.g. 10 s developer mode).
 - **On mobile, use `long press` instead of `right click`** to open context menus.
-- **Don't combine modifiers** in a single instruction — they are mutually exclusive.
+- **Don't combine modifiers** in a single instruction, they are mutually exclusive.
 - For `click N times`, ensure the target element stays **stable** (doesn't move, disappear, or change) between clicks.
-- Allow **1–2 seconds after navigation** before performing a click — gives the page time to stabilize.
+- Allow **1–2 seconds after navigation** before performing a click, gives the page time to stabilize.
 - Use **variables** to parameterize: `long press the button for ${hold_duration} seconds`.
 - Use **conditionals** to apply click types contextually: `if popup is visible then right click on it`.
 
@@ -284,7 +284,7 @@ Yes. `double click` and `double tap` are interchangeable on mobile.
 20 clicks per instruction. Higher values are rejected as `INVALID_PARAMETER`.
 
 **Why does right click fail on mobile?**
-Right click is a mouse-specific interaction that doesn't exist on touchscreens. Use `long press` instead — it opens context menus in most apps.
+Right click is a mouse-specific interaction that doesn't exist on touchscreens. Use `long press` instead. It opens context menus in most apps.
 
 **Does `click the right panel` trigger a right click?**
 No. KaneAI treats positional `right` as a description of the panel, not a gesture modifier.
@@ -302,7 +302,7 @@ Yes. `long press the button for ${hold_duration} seconds` and `click the button 
 Yes. Autoheal re-locates the element on a modified page; the click modifier (duration, frequency, right-click flag) is preserved.
 
 **Can I use these click types inside a Module?**
-Yes. All three work inside Modules — create, import, edit, and version-bump as usual.
+Yes. All three work inside Modules: create, import, edit, and version-bump as usual.
 
 ---
 
@@ -311,12 +311,12 @@ Yes. All three work inside Modules — create, import, edit, and version-bump as
 1. **Right click is web-only.** Returns `UNSUPPORTED_OPERATION` on mobile.
 2. **Mutual exclusivity.** Long press, multi-click, and right click cannot be combined in a single instruction.
 3. **Long press duration range.** Limited to 0.5–30 seconds only.
-4. **Multi-click frequency cap.** Maximum 20 clicks per instruction. The literal phrase `triple click X` is not supported — use `click X 3 times` instead.
-5. **Mobile Web — no Manual Interaction.** Only NL instructions are available for long press and multi-click on mobile browsers.
-6. **iOS Landscape — no Manual Interaction.** Long press and multi-click MI capture are not supported in Landscape orientation.
+4. **Multi-click frequency cap.** Maximum 20 clicks per instruction. The literal phrase `triple click X` is not supported. Use `click X 3 times` instead.
+5. **Mobile Web: no Manual Interaction.** Only NL instructions are available for long press and multi-click on mobile browsers.
+6. **iOS Landscape: no Manual Interaction.** Long press and multi-click MI capture are not supported in Landscape orientation.
 7. **Duration accuracy.** Long press is accurate to ±200 ms. Use cases requiring millisecond precision should account for this tolerance.
 8. **Multi-click on dynamic elements.** If the target moves, disappears, or changes between clicks, later clicks may miss. Ensure element stability.
 9. **Nested if-else not supported.** Single-level if-else with click modifiers works (e.g. `if popup is visible then right click on it`), but nested if-else inside another conditional is not supported.
-10. **Secrets as duration values.** `long press for {{secrets.user.DURATION}} seconds` is not supported — secret values cannot be parsed as numeric durations.
+10. **Secrets as duration values.** `long press for {{secrets.user.DURATION}} seconds` is not supported. Secret values cannot be parsed as numeric durations.
 11. **No silent conversion.** Right click is not auto-converted to long press on mobile, and long press is not auto-converted to right click on web. Each gesture must be authored explicitly.
 

--- a/docs/kane-ai-command-guide.md
+++ b/docs/kane-ai-command-guide.md
@@ -54,9 +54,9 @@ Use the below commands to move around the page:
 |--------------|------------------------------------------------|
 | Open URL     | `go to https://example.com`  ,  `open https://example.com` |
 | Click        | `click on login button`                        |
-| Double / N-Click | `double click the title`  ,  `click the button 5 times` — see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
-| Right Click  | `right click on the file row` (web only) — see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
-| Long Press   | `long press the menu icon for 3 seconds` — see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
+| Double / N-Click | `double click the title`  ,  `click the button 5 times`, see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
+| Right Click  | `right click on the file row` (web only), see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
+| Long Press   | `long press the menu icon for 3 seconds`, see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
 | Type Text    | `enter "user@example.com"`  ,  `type "password123"` |
 | Clear Field  | `clear email input field`                      |
 | Select Date  | `select 21st september date`                   |
@@ -89,7 +89,7 @@ If you prefer, you can also set custom wait timeouts directly in the step menu:
 2. Select **Step Timeout**
 3. Enter your preferred timeout value (min 1 second, max 300 seconds)
 
-Use custom wait timeout when dealing with slow page loads or dynamic content. Step Timeout is a dynamic ceiling — the step proceeds as soon as the element is ready and only uses the extra time on genuinely slow loads.
+Use custom wait timeout when dealing with slow page loads or dynamic content. Step Timeout is a dynamic ceiling. The step proceeds as soon as the element is ready and only uses the extra time on genuinely slow loads.
 
 :::note
 Step Timeout is supported across **Web**, **Mobile Web**, and **App (Android and iOS)** testing.

--- a/docs/kane-ai-drag-drop.md
+++ b/docs/kane-ai-drag-drop.md
@@ -33,24 +33,24 @@ KaneAI lets you author drag interactions across **Desktop Web, Android apps, iOS
 
 You can author a drag step in two ways:
 
-- **Natural Language (NL)** — describe the drag in plain English (e.g. `drag "Card A" to "Column B"`).
-- **Manual Interaction** — perform the gesture on the device or browser viewport and have it captured as a step.
+- **Natural Language (NL)**: describe the drag in plain English (e.g. `drag "Card A" to "Column B"`).
+- **Manual Interaction**: perform the gesture on the device or browser viewport and have it captured as a step.
 
 ## Drag and Drop vs Click and Drag
 
 KaneAI supports two distinct drag interactions. They look similar but behave differently, and they are **not interchangeable**:
 
-- **Drag and Drop** — the element is first **long-pressed** to pick it up, and only then moved to the target. This is the standard gesture for moving items between containers and works on **all platforms**.
-- **Click and Drag** — the element is pressed and moved **immediately, without any long press**. This is how interactions such as sliders, canvas drawing, and element resizing work, and it is available on **Desktop Web only**.
+- **Drag and Drop**: the element is first **long-pressed** to pick it up, and only then moved to the target. This is the standard gesture for moving items between containers and works on **all platforms**.
+- **Click and Drag**: the element is pressed and moved **immediately, without any long press**. This is how interactions such as sliders, canvas drawing, and element resizing work, and it is available on **Desktop Web only**.
 
 | | Drag and Drop | Click and Drag |
 | --- | --- | --- |
-| **Gesture** | Long press on the element first, then move it to the target | Press and move in one continuous motion — no long press |
+| **Gesture** | Long press on the element first, then move it to the target | Press and move in one continuous motion, no long press |
 | **Platforms** | Desktop Web, Android App, iOS App, Mobile Web | Desktop Web only |
 | **Typical scenarios** | Kanban cards, list reordering, container-to-container transfer | Sliders, canvas drawing, element resizing, range selection |
 
 :::note
-If a drag step fails on an element that doesn't respond to a long press (for example a slider thumb or a canvas), the element likely expects **Click and Drag** rather than Drag and Drop. Click and Drag has its own constraints — see [Limitations](#limitations).
+If a drag step fails on an element that doesn't respond to a long press (for example a slider thumb or a canvas), the element likely expects **Click and Drag** rather than Drag and Drop. Click and Drag has its own constraints, see [Limitations](#limitations).
 :::
 
 
@@ -78,7 +78,7 @@ If a drag step fails on an element that doesn't respond to a long press (for exa
 | Drag with no stable element identifier                                     | Manual (recommended)   |
 
 :::warning
-**Sliders and confirmation gestures cannot be authored with NL.** Use Manual Interaction to capture the gesture directly — KaneAI records source, target, and drag vector in a coordinate-safe form.
+**Sliders and confirmation gestures cannot be authored with NL.** Use Manual Interaction to capture the gesture directly. KaneAI records source, target, and drag vector in a coordinate-safe form.
 :::
 
 ## Author with Natural Language
@@ -135,8 +135,8 @@ For tap, long-press, multi-click, and right-click authoring, see [Click Interact
 
 ### When Manual Interaction is Required
 
-- **Sliders** — volume, range, vertical, payment-style (e.g., slide-to-pay).
-- **Confirmation gestures** — slide-to-confirm, drag-to-pay, swipe-to-unlock.
+- **Sliders**: volume, range, vertical, payment-style (e.g., slide-to-pay).
+- **Confirmation gestures**: slide-to-confirm, drag-to-pay, swipe-to-unlock.
 - **Custom drag handles** without a stable accessibility ID or selector.
 - **Canvas-based interactions**, drawing tools, and flow chart manipulation.
 - **Element resizing** and precise positioning.
@@ -161,11 +161,11 @@ Manual recording is recommended for any scenario where the **drop location isn't
 
 ## Best Practices
 
-- **Use NL for static layouts** — Kanban boards, sortable grids, multi-container drags. Fastest authoring path.
+- **Use NL for static layouts**: Kanban boards, sortable grids, multi-container drags. Fastest authoring path.
 - **Use Manual for sliders, confirmation gestures, and dynamic targets.** These require touch-driven capture.
 - Prefer elements with stable **accessibility IDs / resource IDs** to maximize cross-device replay success.
 - For long lists, **scroll the source element into view** before recording the drag.
-- Allow **1–2 seconds after a navigation step** before recording the next drag — gives the page time to stabilize.
+- Allow **1–2 seconds after a navigation step** before recording the next drag, gives the page time to stabilize.
 - For payment / KYC slider flows, capture the gesture once via Manual and **reuse the step inside a Module**.
 - Use `{{variable_name}}` syntax to **parameterize** source / target references for data-driven runs.
 
@@ -185,7 +185,7 @@ move task card from "To Do" column to "In Progress" column
 
 ### Mobile Slider (Manual Interaction)
 
-Use Manual Interaction to capture brightness, volume, or price-range sliders on Android and iOS — NL cannot resolve a moving slider thumb.
+Use Manual Interaction to capture brightness, volume, or price-range sliders on Android and iOS. NL cannot resolve a moving slider thumb.
 
 ### Payment Confirmation Gesture (Manual Interaction)
 
@@ -201,18 +201,18 @@ Use Manual Interaction to adjust date-range sliders, resize chart panels, and re
 
 ## Limitations
 
-- **Multi-touch gestures** (two-finger drag, pinch-drag) — not supported.
-- **Drag path waypoints** — only start and end coordinates are captured; intermediate path points are not preserved.
-- **Mobile Browser manual recording** — not supported. Use NL only.
-- **Cross-context dragging** — drags between iframes or shadow DOMs are not supported.
-- **Multi-element dragging** — cannot drag multiple elements simultaneously.
-- **Advanced NL** (e.g., `drag X up by 50px`, offset-based reorder) — on the roadmap; currently rejected with a graceful error.
-- **Click and Drag via NL** — not supported as a natural language test step; supported only via Manual Interaction. Desktop Web only.
-- **Click and Drag speed** — executes slowly by design so the dragged element stays in focus during the movement; faster execution could cause the element to lose focus mid-drag.
-- **NL slider authoring** — not supported. Use Manual Interaction.
-- **NL confirmation gestures** (slide-to-confirm) — not supported. Use Manual Interaction.
-- **Drag and drop on canvas-based elements via NL** — canvas elements rely on custom rendering; use Manual Interaction.
-- **Editing manual drag steps** — source/target locators and step-level config can be edited; the drag vector and gesture timing are immutable to preserve replay fidelity.
+- **Multi-touch gestures** (two-finger drag, pinch-drag): not supported.
+- **Drag path waypoints**: only start and end coordinates are captured; intermediate path points are not preserved.
+- **Mobile Browser manual recording**: not supported. Use NL only.
+- **Cross-context dragging**: drags between iframes or shadow DOMs are not supported.
+- **Multi-element dragging**: cannot drag multiple elements simultaneously.
+- **Advanced NL** (e.g., `drag X up by 50px`, offset-based reorder): on the roadmap; currently rejected with a graceful error.
+- **Click and Drag via NL**: not supported as a natural language test step; supported only via Manual Interaction. Desktop Web only.
+- **Click and Drag speed**: executes slowly by design so the dragged element stays in focus during the movement; faster execution could cause the element to lose focus mid-drag.
+- **NL slider authoring**: not supported. Use Manual Interaction.
+- **NL confirmation gestures** (slide-to-confirm): not supported. Use Manual Interaction.
+- **Drag and drop on canvas-based elements via NL**: canvas elements rely on custom rendering; use Manual Interaction.
+- **Editing manual drag steps**: source/target locators and step-level config can be edited; the drag vector and gesture timing are immutable to preserve replay fidelity.
 
 ## FAQs
 
@@ -220,7 +220,7 @@ Use Manual Interaction to adjust date-range sliders, resize chart panels, and re
 Drag and Drop long-presses the element to pick it up before moving it, and works on all platforms. Click and Drag presses and moves the element immediately without a long press, and is available on Desktop Web only. See [Drag and Drop vs Click and Drag](#drag-and-drop-vs-click-and-drag).
 
 **Why is my Click and Drag step slow?**
-This is expected. Click and Drag executes deliberately slowly to keep the dragged element in focus throughout the movement — a faster gesture could cause the element to lose focus mid-drag and fail the step.
+This is expected. Click and Drag executes deliberately slowly to keep the dragged element in focus throughout the movement. A faster gesture could cause the element to lose focus mid-drag and fail the step.
 
 **Can I author a slider drag with natural language?**
 No. Sliders have moving targets that NL cannot resolve reliably. Use Manual Interaction to capture the slider gesture directly. The captured step replays at ≥ 95% success rate across devices.
@@ -229,7 +229,7 @@ No. Sliders have moving targets that NL cannot resolve reliably. Use Manual Inte
 No. Confirmation gestures depend on dynamic UI state and must be captured via Manual Interaction.
 
 **My drag step passes on the recording device but fails on another device. What's wrong?**
-KaneAI replays use element resolution by default — cross-device failures usually indicate that the source or target element identifier changed across builds. Inspect the step logs to see the resolution path used (element vs. coordinate) and ensure the elements expose stable accessibility IDs.
+KaneAI replays use element resolution by default. Cross-device failures usually indicate that the source or target element identifier changed across builds. Inspect the step logs to see the resolution path used (element vs. coordinate) and ensure the elements expose stable accessibility IDs.
 
 **Why isn't manual recording available on Mobile Web?**
 The KaneAI agent does not enter Recording state for mobile browser sessions. Use natural language instructions or slash commands instead.
@@ -238,7 +238,7 @@ The KaneAI agent does not enter Recording state for mobile browser sessions. Use
 You can edit the source / target locators and step-level configuration. The drag vector and gesture timing are immutable for Manual steps to preserve replay fidelity.
 
 **Does drag work inside a KaneAI Module?**
-Yes — drag steps can be saved into Modules and reused across test cases. Module versioning applies as usual.
+Yes, drag steps can be saved into Modules and reused across test cases. Module versioning applies as usual.
 
 **Can I parameterize a drag step?**
 Yes. Use `{{variable_name}}` in the source or target reference. Local variables, global variables, smart variables, parameters, and dataset rows are all supported.
@@ -247,6 +247,6 @@ Yes. Use `{{variable_name}}` in the source or target reference. Local variables,
 Yes. Drag steps can be placed inside conditional blocks (`if X is visible then drag Y to Z`) and while loops. Each iteration re-resolves elements at runtime.
 
 **Is drag and drop supported on real devices?**
-Yes — drag works on both real devices and the device cloud for App testing. Real Device Web also supports manual drag.
+Yes, drag works on both real devices and the device cloud for App testing. Real Device Web also supports manual drag.
 
 

--- a/docs/kane-ai-jira-integration.md
+++ b/docs/kane-ai-jira-integration.md
@@ -88,7 +88,7 @@ KaneAI uses the following fields from the Jira ticket as context to generate tes
 
 - **Summary** and **Description** of the ticket
 - **Comments** on the ticket
-- **Textual custom fields** — You can configure which custom fields are included from the <BrandName /> Cloud app settings in Jira. Only text-based custom fields are supported; non-textual fields (e.g., dropdowns, number fields, user pickers, linked tickets) are not used for generation.
+- **Textual custom fields**: You can configure which custom fields are included from the <BrandName /> Cloud app settings in Jira. Only text-based custom fields are supported; non-textual fields (e.g., dropdowns, number fields, user pickers, linked tickets) are not used for generation.
 
 :::tip
 To configure which custom fields are used as context, go to the <BrandName /> Cloud app settings in your Jira instance and select the desired textual custom fields.
@@ -99,8 +99,8 @@ After you post the comment, KaneAI will process the request and respond with a c
 <img loading="lazy" src={require('../assets/images/kane-ai/features/jira-integration/jira-test-case.webp').default} alt="kenai-jira integration" className="doc_img"/>
 
 ### Step 4: Review and Refine the Generated Test Cases
-Click on the link provided by KaneAI in the Jira comment to open the [AI Test Case Generator](/support/docs/generate-test-cases-with-ai/). The AI will begin [analyzing your Jira ticket content and generating test cases](/support/docs/generate-test-cases-with-ai/#step-3-generate-test-cases) in real time — you can watch scenarios and test cases stream in as they are created.
+Click on the link provided by KaneAI in the Jira comment to open the [AI Test Case Generator](/support/docs/generate-test-cases-with-ai/). The AI will begin [analyzing your Jira ticket content and generating test cases](/support/docs/generate-test-cases-with-ai/#step-3-generate-test-cases) in real time. You can watch scenarios and test cases stream in as they are created.
 
 Once the generation is complete, review the test cases grouped across scenarios. Each scenario represents a theme or functional area and is labeled with priority tags such as **Must have**, **Should have**, and **Could have**. Individual test cases are categorized as **Positive**, **Negative**, or **Edge** to indicate their test type.
 
-You can further refine the generated test cases using the [Conversation Layer](/support/docs/generate-test-cases-with-ai/#conversation-layer-refine-your-test-cases) — describe changes in natural language and the AI applies them in real time. Once satisfied, save the test cases to your Test Manager repository or automate them with KaneAI.
+You can further refine the generated test cases using the [Conversation Layer](/support/docs/generate-test-cases-with-ai/#conversation-layer-refine-your-test-cases): describe changes in natural language and the AI applies them in real time. Once satisfied, save the test cases to your Test Manager repository or automate them with KaneAI.

--- a/docs/kane-ai-modules.md
+++ b/docs/kane-ai-modules.md
@@ -42,7 +42,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-Modules in KaneAI let you group a sequence of test steps into a single reusable unit. Instead of re-authoring the same steps in every test case, you create a module once and import it wherever it is needed. This reduces duplication, improves consistency, and makes maintenance easier — when a workflow changes, you update the module and propagate the change across test cases.
+Modules in KaneAI let you group a sequence of test steps into a single reusable unit. Instead of re-authoring the same steps in every test case, you create a module once and import it wherever it is needed. This reduces duplication, improves consistency, and makes maintenance easier. When a workflow changes, you update the module and propagate the change across test cases.
 
 Modules support **variables**, **parameters**, and **secrets**, so you can pass dynamic data into each module execution rather than hard-coding values.
 
@@ -79,9 +79,9 @@ Begin by authoring your test in KaneAI and executing the steps that you want to 
 
 1. Click **Create Module**.
 2. Enter the module details:
-   - **Name** — A descriptive name (e.g., `[Web] Login Flow`)
-   - **Description** — What the module does and when to use it
-   - **Tags** — Keywords for easier discovery
+   - **Name**: A descriptive name (e.g., `[Web] Login Flow`)
+   - **Description**: What the module does and when to use it
+   - **Tags**: Keywords for easier discovery
 3. Click **Create Module** to save.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/modules/3.png').default} alt="create-module-dialog" className="doc_img"/>
@@ -168,15 +168,15 @@ Modules in KaneAI are **platform-specific**. Each platform has distinct interact
 
 Adopt a consistent **name prefix** and **tag** strategy to make platform context immediately clear and modules easy to filter.
 
-**Name prefixes** — Add a platform prefix at the start of every module name:
+**Name prefixes**: Add a platform prefix at the start of every module name:
 
-- **`[Web]`** — Desktop Web modules
-- **`[Android-App]`** — Android native app modules
-- **`[Android-Browser]`** — Android browser modules
-- **`[iOS-App]`** — iOS native app modules
-- **`[iOS-Browser]`** — iOS browser modules
+- **`[Web]`**: Desktop Web modules
+- **`[Android-App]`**: Android native app modules
+- **`[Android-Browser]`**: Android browser modules
+- **`[iOS-App]`**: iOS native app modules
+- **`[iOS-Browser]`**: iOS browser modules
 
-**Tags** — Add platform tags to each module so you can filter the module listing by platform:
+**Tags**: Add platform tags to each module so you can filter the module listing by platform:
 
 - `desktop-web`, `android-app`, `android-browser`, `ios-app`, `ios-browser`
 
@@ -184,13 +184,13 @@ Using both prefixes and tags together gives you the best of both worlds: prefixe
 
 You can extend this convention for other distinctions:
 
-- **`[Web][Staging]`** — Environment-specific modules
-- **`[Android-App][Auth]`** — Feature-area grouping
-- Tags like `login`, `checkout`, `onboarding` — Workflow-based categorization
+- **`[Web][Staging]`**: Environment-specific modules
+- **`[Android-App][Auth]`**: Feature-area grouping
+- Tags like `login`, `checkout`, `onboarding`: Workflow-based categorization
 
 ### Keep Modules Focused
 
-Each module should represent a **single, cohesive workflow** (e.g., login, checkout, form submission). Avoid creating overly large modules that combine unrelated steps — they become harder to maintain and less reusable.
+Each module should represent a **single, cohesive workflow** (e.g., login, checkout, form submission). Avoid creating overly large modules that combine unrelated steps. They become harder to maintain and less reusable.
 
 ### Use Variables and Parameters
 
@@ -204,8 +204,8 @@ Add a meaningful description to every module so other team members understand wh
 
 ## Related Guides
 
-- [Versioning and Enhancements](/support/docs/kaneai-modules-versions-and-enhancement/) — Track changes, compare versions, and revert modules
-- [Bulk Module Update](/support/docs/kaneai-bulk-module-update/) — Update a module version across multiple test cases in one action
+- [Versioning and Enhancements](/support/docs/kaneai-modules-versions-and-enhancement/): Track changes, compare versions, and revert modules
+- [Bulk Module Update](/support/docs/kaneai-bulk-module-update/): Update a module version across multiple test cases in one action
 
 ---
 

--- a/docs/kane-ai-using-parameters.md
+++ b/docs/kane-ai-using-parameters.md
@@ -73,7 +73,7 @@ Reference any parameter using **dollar-curly braces syntax** (e.g.,`${phone_numb
 
 ## From a Manual Interaction step
 
-You can also convert a hard-coded value in a Manual Interaction step into a Parameter directly — without deleting or re-recording the step. This flow is available on both **Desktop** and **Mobile App** Manual Interaction sessions.
+You can also convert a hard-coded value in a Manual Interaction step into a Parameter directly, without deleting or re-recording the step. This flow is available on both **Desktop** and **Mobile App** Manual Interaction sessions.
 
 1. Open the recorded Manual Interaction step.
 2. **Select the portion** of the instruction text you want to parameterize (for example, highlight `test.com`).

--- a/docs/kane-ai-using-variables.md
+++ b/docs/kane-ai-using-variables.md
@@ -93,7 +93,7 @@ You can edit the session value for the variables here which will lead to updatio
 
 ### From a Manual Interaction step
 
-While reviewing a Manual Interaction step, you can replace any hard-coded value in the step's instruction with a Parameter, Variable, or Secret — without deleting or re-recording the step. This flow is available on both **Desktop** and **Mobile App** Manual Interaction sessions.
+While reviewing a Manual Interaction step, you can replace any hard-coded value in the step's instruction with a Parameter, Variable, or Secret, without deleting or re-recording the step. This flow is available on both **Desktop** and **Mobile App** Manual Interaction sessions.
 
 #### Steps to convert a value
 
@@ -101,9 +101,9 @@ While reviewing a Manual Interaction step, you can replace any hard-coded value 
 2. **Select the portion** of the instruction text you want to replace (for example, highlight `test.com`).
 <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/variables/HighlightScreenshot.png').default} alt="Image" className="doc_img img_center"/>
 3. In the **Convert as** popover that appears, choose one of the three tabs:
-   - **`{$}` Parameter** — test-level variable, supports selecting an existing parameter or creating a new one.
-   - **`{x}` Variable** — Global or Environment variable, supports selecting an existing variable or creating a new one.
-   - **🔒 Secret** — encrypted value that resolves only at execution time. Only new secrets can be created from this tab.
+   - **`{$}` Parameter**: test-level variable, supports selecting an existing parameter or creating a new one.
+   - **`{x}` Variable**: Global or Environment variable, supports selecting an existing variable or creating a new one.
+   - **🔒 Secret**: encrypted value that resolves only at execution time. Only new secrets can be created from this tab.
 4. Either pick an existing entry from the searchable list, or click **`+` Create Parameter / Variable / Secret** to define a new one inline.
 5. The selected text in the step is replaced with the variable reference (for example, `{{search_query}}`). The step updates in place.
 
@@ -118,7 +118,7 @@ While reviewing a Manual Interaction step, you can replace any hard-coded value 
 
 
 :::note
-- Existing secrets cannot be reused from the Convert as popover — the Secret tab only exposes the **`+` Create Secret** action. This is enforced for security, so a fresh secret must be created each time one is assigned to a Manual Interaction step.
+- Existing secrets cannot be reused from the Convert as popover. The Secret tab only exposes the **`+` Create Secret** action. This is enforced for security, so a fresh secret must be created each time one is assigned to a Manual Interaction step.
 - This is only supported for `Click` and `Type` Commands
 :::
 

--- a/docs/kane-ai-web-test-writing-guidelines.md
+++ b/docs/kane-ai-web-test-writing-guidelines.md
@@ -48,7 +48,7 @@ The KaneAI Web Agent is an automation tool that executes web interactions based 
 ## General Instruction
 
 ### 1. Clarity and Specificity
-Always provide clear and specific instructions for the action you wish to perform. Use the appropriate terminology from the list of supported commands. Avoid vague terms such as `do this` or `click that`—be explicit about which element to interact with.
+Always provide clear and specific instructions for the action you wish to perform. Use the appropriate terminology from the list of supported commands. Avoid vague terms such as `do this` or `click that`. Be explicit about which element to interact with.
 
 ### 2. Context
 When the action is dependent on a specific element or section of a webpage, provide enough context to help identify the element. Example: `Click the 'Submit' button on the top right corner of the form`.

--- a/docs/kane-cli-api-calls.md
+++ b/docs/kane-cli-api-calls.md
@@ -38,7 +38,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-api-calls/
       }) }}
 ></script>
 
-Objectives can have the agent **make an API call directly** — not just observe the requests a page makes. This is useful for seeding data before a flow, hitting a backend to set up state, or checking a service, then asserting on or reusing the response.
+Objectives can have the agent **make an API call directly**, not just observe the requests a page makes. This is useful for seeding data before a flow, hitting a backend to set up state, or checking a service, then asserting on or reusing the response.
 
 ## Making a call
 
@@ -50,7 +50,7 @@ Hit GET https://api.example.com/orders/123, save the response as fetched
 Call DELETE https://api.example.com/orders/123
 ```
 
-A pasted `curl` works too and is kept exactly as written — method, headers, body, and auth:
+A pasted `curl` works too and is kept exactly as written: method, headers, body, and auth:
 
 ```
 curl -X POST https://api.example.com/login -H 'Content-Type: application/json' -d '{"u":"a","p":"b"}', save the response as login
@@ -66,7 +66,7 @@ Once you've saved a response under a name, reference it elsewhere in the objecti
 | `{{order.response_body}}` | the whole response body |
 | `{{order.response_body.<field>}}` | a field from the JSON response body |
 
-Assert on it, or feed it into later actions — API calls and browser actions mix freely in one objective:
+Assert on it, or feed it into later actions. API calls and browser actions mix freely in one objective:
 
 ```
 Call POST https://api.example.com/login with body {"u": "{{user}}", "p": "{{password}}"}, save the response as login,
@@ -92,7 +92,7 @@ curl -X DELETE https://api.example.com/records/42 -H "Authorization: Bearer {{ap
 
 These are two different things:
 
-- **Make a call (this page)** — *you* tell the agent to send a request: seed a record, call a backend, set up state.
-- **[Network assertions](/support/docs/kane-cli-checkpoint-devtools-network/)** — *observe* the requests the page itself makes during a UI flow (status codes, bodies, timing).
+- **Make a call (this page)**: *you* tell the agent to send a request: seed a record, call a backend, set up state.
+- **[Network assertions](/support/docs/kane-cli-checkpoint-devtools-network/)**: *observe* the requests the page itself makes during a UI flow (status codes, bodies, timing).
 
 They compose: seed state with a direct call, drive the UI, then assert on the page's own network traffic.

--- a/docs/kane-cli-authentication.md
+++ b/docs/kane-cli-authentication.md
@@ -54,8 +54,8 @@ import {YOUR_LAMBDATEST_USERNAME, YOUR_LAMBDATEST_ACCESS_KEY} from "@site/src/co
 
 Kane CLI authenticates against your <BrandName /> account before it can run tests, upload sessions, or interact with Test Manager. There are two authentication methods:
 
-- **OAuth** — recommended for everyday local use. Opens a browser, you approve once, and tokens are stored on your machine.
-- **Basic auth** — your <BrandName /> username and access key. Use this in CI and other non-interactive environments where no browser is available.
+- **OAuth**: recommended for everyday local use. Opens a browser, you approve once, and tokens are stored on your machine.
+- **Basic auth**: your <BrandName /> username and access key. Use this in CI and other non-interactive environments where no browser is available.
 
 ---
 
@@ -65,7 +65,7 @@ Kane CLI authenticates against your <BrandName /> account before it can run test
 kane-cli login --oauth
 ```
 
-Kane CLI opens your default browser to the <BrandName /> consent page. Sign in and approve the request. When the browser hands control back, Kane CLI stores your tokens locally and you are signed in. You usually do not need to log in again on the same machine — Kane CLI reuses the stored session on subsequent runs.
+Kane CLI opens your default browser to the <BrandName /> consent page. Sign in and approve the request. When the browser hands control back, Kane CLI stores your tokens locally and you are signed in. You usually do not need to log in again on the same machine. Kane CLI reuses the stored session on subsequent runs.
 
 If you run `kane-cli login` interactively without flags, Kane CLI launches a guided login wizard that walks you through choosing a method, profile, and (for basic auth) entering credentials.
 
@@ -103,7 +103,7 @@ Saved basic auth is used automatically for subsequent commands run under that pr
 
 ### Where to Find Your Access Key
 
-Sign in to the <BrandName /> [dashboard](https://www.testmuai.com/login/?redirectTo=https://accounts.lambdatest.com/dashboard) > **Credentials** and copy your access key. Treat it like a password — anyone with your username and access key can run tests on your account.
+Sign in to the <BrandName /> [dashboard](https://www.testmuai.com/login/?redirectTo=https://accounts.lambdatest.com/dashboard) > **Credentials** and copy your access key. Treat it like a password. Anyone with your username and access key can run tests on your account.
 
 ---
 
@@ -120,7 +120,7 @@ kane-cli login --oauth --profile work
 kane-cli login --oauth --profile personal
 ```
 
-You can mix methods — one profile can use OAuth and another can use basic auth.
+You can mix methods. One profile can use OAuth and another can use basic auth.
 
 ### List Profiles
 
@@ -158,7 +158,7 @@ A few commands accept `--profile <name>` so you can target a profile for a singl
 kane-cli whoami
 ```
 
-`whoami` prints an identity card showing the active profile, environment, authentication method (OAuth or basic), the username (when known), and — for OAuth — whether the stored token is valid, expired, or missing, along with its expiry date.
+`whoami` prints an identity card showing the active profile, environment, authentication method (OAuth or basic), the username (when known), and (for OAuth) whether the stored token is valid, expired, or missing, along with its expiry date.
 
 Pass `--profile <name>` to inspect a profile other than the active one.
 
@@ -182,4 +182,4 @@ Credentials live under your home directory:
 ~/.testmuai/kaneai/profiles/<profile>/<env>/credentials
 ```
 
-The file is created with restricted permissions (mode `0600`) so only your user account can read it. There is no need to inspect or edit this file by hand — use `kane-cli login`, `kane-cli logout`, and the `kane-cli profiles` commands to manage it.
+The file is created with restricted permissions (mode `0600`) so only your user account can read it. There is no need to inspect or edit this file by hand. Use `kane-cli login`, `kane-cli logout`, and the `kane-cli profiles` commands to manage it.

--- a/docs/kane-cli-browser-state.md
+++ b/docs/kane-cli-browser-state.md
@@ -39,7 +39,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-browser-state/
       }) }}
 ></script>
 
-Objectives can directly manage cookies, localStorage, and the clipboard — useful for seeding state before a flow (skip a login, dismiss a consent banner) and for testing copy/paste behavior.
+Objectives can directly manage cookies, localStorage, and the clipboard, useful for seeding state before a flow (skip a login, dismiss a consent banner) and for testing copy/paste behavior.
 
 ## Cookies
 
@@ -51,7 +51,7 @@ Clear all cookies
 ```
 
 - Values accept `{{variables}}`: `set a cookie named session with value {{auth_token}}`
-- A cookie without an explicit domain applies to the **current page's site** — navigate first
+- A cookie without an explicit domain applies to the **current page's site**. Navigate first
 - Reload or navigate after setting if the page must pick the cookie up
 - Provide `path` together with a domain; a path alone is rejected by the browser
 
@@ -63,13 +63,13 @@ Delete the lang key from localStorage
 Clear localStorage
 ```
 
-- Storage is **per-site** — navigate to the target site before setting
+- Storage is **per-site**. Navigate to the target site before setting
 - Reload after setting if the app only reads storage on page load
 - Values accept `{{variables}}`
 
 ## Clipboard
 
-The run uses an **isolated test clipboard** — your real OS clipboard is never read or written. Site Copy buttons are captured into it automatically.
+The run uses an **isolated test clipboard**. Your real OS clipboard is never read or written. Site Copy buttons are captured into it automatically.
 
 ```
 Write "John Tester" to the clipboard
@@ -77,13 +77,13 @@ Click the message field, then paste from the clipboard
 Clear the clipboard
 ```
 
-- **Paste targets the focused field** — click or focus the field first, then paste (`Ctrl/Cmd+V` in an objective works the same way)
+- **Paste targets the focused field**: click or focus the field first, then paste (`Ctrl/Cmd+V` in an objective works the same way)
 - Text and images both paste; rich editors receive a real paste event
 - Typical flows: *write → click field → paste*, or *click the site's Copy button → click field → paste*
 
 ## Verifying state
 
-Each of these has a matching assertion family — see [Cookies](/support/docs/kane-cli-checkpoint-devtools-cookies/), [localStorage](/support/docs/kane-cli-checkpoint-devtools-localstorage/), and [Clipboard](/support/docs/kane-cli-checkpoint-devtools-clipboard/):
+Each of these has a matching assertion family. See [Cookies](/support/docs/kane-cli-checkpoint-devtools-cookies/), [localStorage](/support/docs/kane-cli-checkpoint-devtools-localstorage/), and [Clipboard](/support/docs/kane-cli-checkpoint-devtools-clipboard/):
 
 ```
 Set a cookie named session with value abc123, reload, and verify the page shows you as logged in

--- a/docs/kane-cli-checkpoint-devtools-clipboard.md
+++ b/docs/kane-cli-checkpoint-devtools-clipboard.md
@@ -44,7 +44,7 @@ Clipboard assertions let you verify what a "Copy" button actually copied, extrac
 
 Every run uses an **isolated test clipboard**:
 
-- **Your real clipboard is safe**: the OS clipboard is never read and never written — tests can't leak your copied data into results, and nothing you copy mid-run interferes with the test
+- **Your real clipboard is safe**: the OS clipboard is never read and never written. Tests can't leak your copied data into results, and nothing you copy mid-run interferes with the test
 - **Automatic capture**: when the page copies something (a Copy button, Ctrl/Cmd+C on a selection), it lands in the test clipboard
 - **One current entry**: like a real clipboard, every copy or clipboard write **replaces** the previous content
 - **Multi-format**: a single entry can carry plain text, HTML, and an image together (e.g. a "Copy image" button)
@@ -54,7 +54,7 @@ Every run uses an **isolated test clipboard**:
 
 Because the clipboard holds one entry at a time:
 
-- Verify a copied value **immediately after** the copy or write that produced it — a later clipboard write/clear replaces it
+- Verify a copied value **immediately after** the copy or write that produced it. A later clipboard write/clear replaces it
 - To check several copies, interleave: copy A → verify → copy B → verify
 
 ## What You Can Query
@@ -82,11 +82,11 @@ Click the Copy button, store the copied coupon code as 'coupon'
 Store the clipboard text as 'copied_link'
 ```
 
-Stored values work like any other variable — fill `{{coupon}}` into a field later, or assert on it.
+Stored values work like any other variable. Fill `{{coupon}}` into a field later, or assert on it.
 
 ## Writing and Pasting (actions)
 
-The clipboard isn't read-only — objectives can also drive it. See [Browser State Actions](/support/docs/kane-cli-browser-state/):
+The clipboard isn't read-only. Objectives can also drive it. See [Browser State Actions](/support/docs/kane-cli-browser-state/):
 
 ```
 Write "John Tester" to the clipboard, click the message field, then paste from the clipboard
@@ -94,6 +94,6 @@ Write "John Tester" to the clipboard, click the message field, then paste from t
 
 ## Tips
 
-- **Don't paste to verify** — assert on the clipboard directly instead of pasting into a field and reading it back
+- **Don't paste to verify**: assert on the clipboard directly instead of pasting into a field and reading it back
 - **Prefer positive phrasing** for empties: "verify the clipboard text is empty" rather than "verify X is not on the clipboard"
-- Clipboard actions need a page loaded first — navigate before writing or pasting
+- Clipboard actions need a page loaded first. Navigate before writing or pasting

--- a/docs/kane-cli-checkpoint-devtools-console.md
+++ b/docs/kane-cli-checkpoint-devtools-console.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-devtools-console
 title: Console Assertions
 sidebar_label: Console
-description: "Verify browser console output — errors, warnings, log messages, and JavaScript exceptions captured during test execution."
+description: "Verify browser console output: errors, warnings, log messages, and JavaScript exceptions captured during test execution."
 keywords:
   - console assertion
   - javascript errors
@@ -39,7 +39,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-co
       }) }}
 ></script>
 
-Console assertions let you verify browser console output — error messages, warnings, log messages, and uncaught JavaScript exceptions.
+Console assertions let you verify browser console output: error messages, warnings, log messages, and uncaught JavaScript exceptions.
 
 ## How Capture Works
 
@@ -48,7 +48,7 @@ KaneAI captures all browser console output automatically during each test step:
 - **Continuous capture**: Every `console.log()`, `console.warn()`, `console.error()`, and uncaught JS exception is recorded
 - **Per-step scope**: Each test step starts with a fresh capture. Console messages from previous steps are not carried over
 - **Limits**: Up to 50,000 messages are stored per step. When the limit is reached, the oldest 10% are dropped
-- **No truncation**: Message text is stored in full — unlike network response bodies, console messages are never truncated
+- **No truncation**: Message text is stored in full. Unlike network response bodies, console messages are never truncated
 - **Object resolution**: When JavaScript logs an object (`console.log({status: "ok"})`), KaneAI resolves it to the actual value instead of storing "JSHandle@object"
 - **Multi-tab support**: Console messages from new tabs and popups are also captured
 - **Top-frame only**: Messages from embedded iframes (payment widgets, third-party components) are not captured
@@ -86,7 +86,7 @@ Console message levels are normalized to 5 values:
 ### Errors vs Exceptions
 
 - **`errors`** includes ALL error-level messages: both `console.error()` calls AND uncaught exceptions
-- **`exceptions`** is a subset of errors — only uncaught JavaScript exceptions
+- **`exceptions`** is a subset of errors: only uncaught JavaScript exceptions
 - To check for app-level errors without exceptions: query errors where `is_exception` is false
 
 ## Example Assertions

--- a/docs/kane-cli-checkpoint-devtools-cookies.md
+++ b/docs/kane-cli-checkpoint-devtools-cookies.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-devtools-cookies
 title: Cookies Assertions
 sidebar_label: Cookies
-description: "Verify browser cookies — names, values, and flags such as httpOnly, secure, and sameSite — set during test execution."
+description: "Verify browser cookies (names, values, and flags such as httpOnly, secure, and sameSite) set during test execution."
 keywords:
   - cookies assertion
   - session cookie
@@ -40,13 +40,13 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-co
       }) }}
 ></script>
 
-Cookie assertions let you verify browser cookies — check existence, values, and security attributes like httpOnly, secure, and sameSite.
+Cookie assertions let you verify browser cookies: check existence, values, and security attributes like httpOnly, secure, and sameSite.
 
 ## How Capture Works
 
 Cookies are captured as a **point-in-time snapshot** when the checkpoint triggers:
 
-- **On-demand capture**: Cookies are read from the browser context at the moment the assertion runs — not accumulated over time
+- **On-demand capture**: Cookies are read from the browser context at the moment the assertion runs, not accumulated over time
 - **Current state only**: You see exactly what cookies exist right now, including any set by the page's JavaScript or server responses
 - **All cookies visible**: Unlike `document.cookie` in JavaScript, KaneAI can see httpOnly cookies too
 - **Domain-scoped**: Cookies are captured for all domains the browser has visited in this session
@@ -57,7 +57,7 @@ Because cookies are captured at assertion time:
 
 - If you need to check cookies set by a specific page, assert on the **same page** or **after** you've visited it
 - If cookies are needed in a later step (e.g., after navigating away), extract and store them first
-- Cookies persist in the browser across steps (unlike network/console which reset) — but asserting on a different domain may show different cookies
+- Cookies persist in the browser across steps (unlike network/console which reset), but asserting on a different domain may show different cookies
 
 ## What You Can Query
 

--- a/docs/kane-cli-checkpoint-devtools-localstorage.md
+++ b/docs/kane-cli-checkpoint-devtools-localstorage.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-devtools-localstorage
 title: localStorage Assertions
 sidebar_label: localStorage
-description: "Verify key-value pairs stored in the browser localStorage during test execution — auth tokens, feature flags, cached data."
+description: "Verify key-value pairs stored in the browser localStorage during test execution: auth tokens, feature flags, cached data."
 keywords:
   - localstorage assertion
   - browser storage
@@ -39,7 +39,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-lo
       }) }}
 ></script>
 
-localStorage assertions let you verify data stored in the browser's `window.localStorage` — check key existence, values, and item counts.
+localStorage assertions let you verify data stored in the browser's `window.localStorage`: check key existence, values, and item counts.
 
 ## How Capture Works
 
@@ -54,7 +54,7 @@ localStorage is captured as a **point-in-time snapshot** when the checkpoint tri
 
 Because localStorage is captured at assertion time:
 
-- Assert on localStorage while you're **on the page** that set the values — navigating to a different domain means a different localStorage
+- Assert on localStorage while you're **on the page** that set the values. Navigating to a different domain means a different localStorage
 - If values are needed later, extract and store them before navigating away
 - localStorage persists across steps (unlike network/console) as long as you stay on the same origin
 

--- a/docs/kane-cli-checkpoint-devtools-network.md
+++ b/docs/kane-cli-checkpoint-devtools-network.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-devtools-network
 title: Network Assertions
 sidebar_label: Network
-description: "Verify HTTP traffic — API responses, status codes, headers, response bodies, and request timing — captured by KaneAI in the background."
+description: "Verify HTTP traffic (API responses, status codes, headers, response bodies, and request timing) captured by KaneAI in the background."
 keywords:
   - network assertion
   - http response
@@ -39,7 +39,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools-ne
       }) }}
 ></script>
 
-Network assertions let you verify HTTP traffic — API responses, status codes, headers, response bodies, and request timing.
+Network assertions let you verify HTTP traffic: API responses, status codes, headers, response bodies, and request timing.
 
 ## How Capture Works
 

--- a/docs/kane-cli-checkpoint-devtools-performance.md
+++ b/docs/kane-cli-checkpoint-devtools-performance.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-devtools-performance
 title: Performance Assertions
 sidebar_label: Performance
-description: "Verify Core Web Vitals and other performance metrics — LCP, CLS, INP, FCP, TTFB — captured during test execution."
+description: "Verify Core Web Vitals and other performance metrics (LCP, CLS, INP, FCP, TTFB) captured during test execution."
 keywords:
   - performance assertion
   - core web vitals
@@ -45,7 +45,7 @@ Performance assertions let you verify [Core Web Vitals](https://web.dev/articles
 
 ## How Capture Works
 
-Performance data is **navigation-based** — metrics are measured for the most recent page navigation:
+Performance data is **navigation-based**. Metrics are measured for the most recent page navigation:
 
 - **Automatic measurement**: KaneAI uses the [web-vitals](https://github.com/GoogleChrome/web-vitals) library to capture metrics
 - **Per-navigation scope**: Metrics reflect the last full page load. If you navigate to a new page, the metrics reset for that navigation
@@ -53,7 +53,7 @@ Performance data is **navigation-based** — metrics are measured for the most r
 
 ### What This Means for Your Tests
 
-- Performance metrics describe the **last navigation** — if you navigate to Page A then Page B, the metrics reflect Page B
+- Performance metrics describe the **last navigation**. If you navigate to Page A then Page B, the metrics reflect Page B
 - Place performance assertions **after** the page you want to measure has fully loaded
 - Use a wait step if the page needs time to settle before measuring
 
@@ -61,11 +61,11 @@ Performance data is **navigation-based** — metrics are measured for the most r
 
 | Metric | What It Measures | Good Threshold | Learn More |
 |--------|-----------------|----------------|------------|
-| **LCP** | Largest Contentful Paint — when the largest visible element finishes rendering | < 2,500ms | [web.dev/lcp](https://web.dev/articles/lcp) |
-| **CLS** | Cumulative Layout Shift — visual stability, how much the page layout shifts | < 0.1 | [web.dev/cls](https://web.dev/articles/cls) |
-| **INP** | Interaction to Next Paint — responsiveness to user input | < 200ms | [web.dev/inp](https://web.dev/articles/inp) |
-| **FCP** | First Contentful Paint — when the first content appears on screen | < 1,800ms | [web.dev/fcp](https://web.dev/articles/fcp) |
-| **TTFB** | Time to First Byte — server response time | < 800ms | [web.dev/ttfb](https://web.dev/articles/ttfb) |
+| **LCP** | Largest Contentful Paint: when the largest visible element finishes rendering | < 2,500ms | [web.dev/lcp](https://web.dev/articles/lcp) |
+| **CLS** | Cumulative Layout Shift: visual stability, how much the page layout shifts | < 0.1 | [web.dev/cls](https://web.dev/articles/cls) |
+| **INP** | Interaction to Next Paint: responsiveness to user input | < 200ms | [web.dev/inp](https://web.dev/articles/inp) |
+| **FCP** | First Contentful Paint: when the first content appears on screen | < 1,800ms | [web.dev/fcp](https://web.dev/articles/fcp) |
+| **TTFB** | Time to First Byte: server response time | < 800ms | [web.dev/ttfb](https://web.dev/articles/ttfb) |
 
 > **Note**: Not all metrics are available for every page. INP requires user interaction to trigger. Some metrics may be `null` if the browser hasn't measured them yet.
 
@@ -96,5 +96,5 @@ If LCP is under 2500ms then continue, else report performance issue
 ## Tips
 
 - **Wait for load**: Place a wait step before performance assertions to ensure the page has fully loaded and metrics are available
-- **Navigate first**: Metrics are per-navigation — make sure you've navigated to the target page before asserting
+- **Navigate first**: Metrics are per-navigation. Make sure you've navigated to the target page before asserting
 - **Not all metrics are instant**: CLS accumulates over time, INP requires interaction. LCP and FCP are typically available after the page visually completes loading

--- a/docs/kane-cli-checkpoint-devtools.md
+++ b/docs/kane-cli-checkpoint-devtools.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-devtools
 title: DevTools Assertions
 sidebar_label: Overview
-description: "Verify data that is not visible on the page — HTTP network traffic, console output, performance metrics, cookies, localStorage, and clipboard."
+description: "Verify data that is not visible on the page: HTTP network traffic, console output, performance metrics, cookies, localStorage, and clipboard."
 keywords:
   - devtools assertion
   - network
@@ -41,7 +41,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-devtools/
       }) }}
 ></script>
 
-DevTools assertions let you verify data that isn't visible on the page — HTTP network traffic, browser console output, performance metrics, cookies, localStorage, and clipboard. KaneAI captures this data automatically in the background; you just write what to check.
+DevTools assertions let you verify data that isn't visible on the page: HTTP network traffic, browser console output, performance metrics, cookies, localStorage, and clipboard. KaneAI captures this data automatically in the background; you just write what to check.
 
 ## Available Domains
 
@@ -58,12 +58,12 @@ DevTools assertions let you verify data that isn't visible on the page — HTTP 
 
 Each DevTools domain follows the same pattern:
 
-1. **Capture** — KaneAI captures the data automatically during your test run
-2. **Generate** — When a checkpoint triggers, the AI generates code to query the captured data
-3. **Execute** — The code runs in an isolated sandbox and returns a result
-4. **Assert** — The result is compared against your expected value
+1. **Capture**: KaneAI captures the data automatically during your test run
+2. **Generate**: When a checkpoint triggers, the AI generates code to query the captured data
+3. **Execute**: The code runs in an isolated sandbox and returns a result
+4. **Assert**: The result is compared against your expected value
 
-You don't write code — you write natural language objectives, and KaneAI handles the rest.
+You don't write code. You write natural language objectives, and KaneAI handles the rest.
 
 ## Examples
 
@@ -79,12 +79,12 @@ Assert: auth_token is stored in localStorage
 
 DevTools assertions support all three checkpoint types:
 
-- **Assert**: "Assert: no console errors" — fails the test if there are errors
-- **Extract**: "Store all cookies" — saves the data for later steps
-- **If/Else**: "If the API returned 200 then proceed, else retry" — branch on the result
+- **Assert**: "Assert: no console errors", fails the test if there are errors
+- **Extract**: "Store all cookies", saves the data for later steps
+- **If/Else**: "If the API returned 200 then proceed, else retry", branch on the result
 
 ## Important Notes
 
-- DevTools data is **not visible in a screenshot** — KaneAI will never try to open the browser DevTools panel
-- Each domain captures data differently — see individual pages for details on timing and scope
-- All assertions run in an isolated sandbox — generated code cannot access the file system or network
+- DevTools data is **not visible in a screenshot**. KaneAI will never try to open the browser DevTools panel
+- Each domain captures data differently. See individual pages for details on timing and scope
+- All assertions run in an isolated sandbox. Generated code cannot access the file system or network

--- a/docs/kane-cli-checkpoint-textual.md
+++ b/docs/kane-cli-checkpoint-textual.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-textual
 title: Textual (DOM) Assertions
 sidebar_label: Textual (DOM)
-description: "Extract data from the DOM — element states, attributes, and computed styles — and assert on values that may not be visible in a screenshot."
+description: "Extract data from the DOM (element states, attributes, and computed styles) and assert on values that may not be visible in a screenshot."
 keywords:
   - dom assertion
   - textual assertion
@@ -38,7 +38,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-textual/
       }) }}
 ></script>
 
-Textual assertions extract data from the page's DOM — element states, attributes, and computed styles that aren't always visible in a screenshot.
+Textual assertions extract data from the page's DOM: element states, attributes, and computed styles that aren't always visible in a screenshot.
 
 ## When It's Used
 

--- a/docs/kane-cli-checkpoint-title.md
+++ b/docs/kane-cli-checkpoint-title.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-title
 title: Title Assertions
 sidebar_label: Title
-description: "Verify the browser tab document.title — useful for confirming navigation reached the expected page."
+description: "Verify the browser tab document.title, useful for confirming navigation reached the expected page."
 keywords:
   - page title assertion
   - document.title
@@ -63,4 +63,4 @@ Store the page title
 
 1. KaneAI reads `page.title()` directly
 2. The title string is compared against the expected value
-3. No screenshot or DOM analysis needed — this is a direct read
+3. No screenshot or DOM analysis needed, this is a direct read

--- a/docs/kane-cli-checkpoint-url.md
+++ b/docs/kane-cli-checkpoint-url.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoint-url
 title: URL Assertions
 sidebar_label: URL
-description: "Check values in the browser address bar — current URL path, query parameters, fragments, and redirect targets."
+description: "Check values in the browser address bar: current URL path, query parameters, fragments, and redirect targets."
 keywords:
   - url assertion
   - query parameter assertion
@@ -37,7 +37,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-url/
       }) }}
 ></script>
 
-URL assertions check values in the browser's address bar — the current URL path, query parameters, fragments, and redirect targets.
+URL assertions check values in the browser's address bar: the current URL path, query parameters, fragments, and redirect targets.
 
 ## When It's Used
 
@@ -73,4 +73,4 @@ If URL contains /login then enter credentials, else go to profile
 
 1. KaneAI reads the current `page.url` value directly
 2. The URL string is compared against the expected value using the specified operator
-3. No screenshot or DOM analysis needed — this is a direct read
+3. No screenshot or DOM analysis needed, this is a direct read

--- a/docs/kane-cli-checkpoint-visual.md
+++ b/docs/kane-cli-checkpoint-visual.md
@@ -38,7 +38,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-checkpoint-visual/
       }) }}
 ></script>
 
-Visual assertions verify what's visible on screen by analyzing the current screenshot. This is the default method — when in doubt, KaneAI uses visual analysis.
+Visual assertions verify what's visible on screen by analyzing the current screenshot. This is the default method, when in doubt, KaneAI uses visual analysis.
 
 ## When It's Used
 

--- a/docs/kane-cli-checkpoints.md
+++ b/docs/kane-cli-checkpoints.md
@@ -2,7 +2,7 @@
 id: kane-cli-checkpoints
 title: Checkpoints
 sidebar_label: Overview
-description: "Checkpoints are verification points KaneAI evaluates during test execution — assert conditions, branch on results, or extract values for later use."
+description: "Checkpoints are verification points KaneAI evaluates during test execution: assert conditions, branch on results, or extract values for later use."
 keywords:
   - kane cli checkpoints
   - assertions
@@ -45,7 +45,7 @@ Checkpoints are verification points that KaneAI evaluates during test execution.
 
 | Type | What it does |
 |------|-------------|
-| **Assertion** | Verify a condition is true — fails the test if not |
+| **Assertion** | Verify a condition is true, fails the test if not |
 | **If/Else** | Branch execution based on a condition |
 | **Extraction** | Store a value for use in later steps |
 
@@ -104,8 +104,8 @@ Assertions support these comparison operators:
 
 ## Learn More
 
-- [Visual Assertions](/support/docs/kane-cli-checkpoint-visual/) — screenshot-based text and visibility checks
-- [Textual (DOM) Assertions](/support/docs/kane-cli-checkpoint-textual/) — element states and attributes
-- [URL Assertions](/support/docs/kane-cli-checkpoint-url/) — URL-based checks
-- [Title Assertions](/support/docs/kane-cli-checkpoint-title/) — page title checks
-- [DevTools Assertions](/support/docs/kane-cli-checkpoint-devtools/) — network, console, performance, cookies, localStorage, clipboard
+- [Visual Assertions](/support/docs/kane-cli-checkpoint-visual/): screenshot-based text and visibility checks
+- [Textual (DOM) Assertions](/support/docs/kane-cli-checkpoint-textual/): element states and attributes
+- [URL Assertions](/support/docs/kane-cli-checkpoint-url/): URL-based checks
+- [Title Assertions](/support/docs/kane-cli-checkpoint-title/): page title checks
+- [DevTools Assertions](/support/docs/kane-cli-checkpoint-devtools/): network, console, performance, cookies, localStorage, clipboard

--- a/docs/kane-cli-cicd.md
+++ b/docs/kane-cli-cicd.md
@@ -53,7 +53,7 @@ These patterns apply to every CI system; the platform-specific recipes below dif
 
 - **Always pass `--headless`**. CI runners have no display.
 - **Always set `--timeout <seconds>`**. A hung run cannot be allowed to block the pipeline.
-- **Authenticate with `--username` and `--access-key`** from CI secrets. Do not call `kane-cli login` in CI — that flow opens a browser for OAuth and will not work on a runner.
+- **Authenticate with `--username` and `--access-key`** from CI secrets. Do not call `kane-cli login` in CI. That flow opens a browser for OAuth and will not work on a runner.
 - **Load test data with `--variables-file <path>`**. Check the file into your repo (without secret values), or generate it before the step.
 - **Check the exit code**. `0` passed, `1` failed, `2` error, `3` timeout or cancellation.
 
@@ -273,7 +273,7 @@ kane-cli run "Open the pricing page and verify the Pro plan is listed" \
     --variables-file ./tests/variables.json
 ```
 
-If your CI image cannot install Chrome — for example, a minimal Node Alpine image — point Kane CLI at a remote browser instead:
+If your CI image cannot install Chrome (for example, a minimal Node Alpine image), point Kane CLI at a remote browser instead:
 
 ```bash
 kane-cli run "Open the pricing page and verify the Pro plan is listed" \

--- a/docs/kane-cli-cli-reference.md
+++ b/docs/kane-cli-cli-reference.md
@@ -144,7 +144,7 @@ kane-cli profiles switch <name>  # Switch the active profile
 kane-cli profiles delete <name>  # Delete a profile
 ```
 
-See [Authentication — Profiles](/support/docs/kane-cli-authentication/#profiles) for details.
+See [Authentication: Profiles](/support/docs/kane-cli-authentication/#profiles) for details.
 
 ---
 
@@ -162,7 +162,7 @@ kane-cli config folder [id]                # Set Test Manager folder (interactiv
 ```
 
 :::note
-Commands without arguments (`chrome-profile`, `project`, `folder`) launch an interactive picker UI. AI agents cannot run these — ask the user to run them directly.
+Commands without arguments (`chrome-profile`, `project`, `folder`) launch an interactive picker UI. AI agents cannot run these. Ask the user to run them directly.
 :::
 
 See [Configuration](/support/docs/kane-cli-configuration/) for the full settings reference.

--- a/docs/kane-cli-configuration.md
+++ b/docs/kane-cli-configuration.md
@@ -50,7 +50,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 Kane CLI stores persistent settings at `~/.testmuai/kaneai/tui-config.json`. Most settings are managed through `kane-cli config` subcommands; a few are managed through interactive pickers in TUI mode, and one (code export) is toggled from the TUI menu.
 
-Authentication credentials are managed separately under `~/.testmuai/kaneai/profiles/` — see [Authentication](/support/docs/kane-cli-authentication/).
+Authentication credentials are managed separately under `~/.testmuai/kaneai/profiles/`. See [Authentication](/support/docs/kane-cli-authentication/).
 
 ---
 
@@ -163,8 +163,8 @@ kane-cli config set-mode testing
 
 `mode` controls how the agent behaves when a run hits an authentication wall, a blocked page, or an error page:
 
-- **`testing`** (default) — the agent treats those pages as part of the run and continues. Use this when you expect the agent to push through gates that would otherwise stop a real user.
-- **`action`** — the agent hard-stops on authentication, blocked, and error pages so you can intervene manually before the run proceeds.
+- **`testing`** (default): the agent treats those pages as part of the run and continues. Use this when you expect the agent to push through gates that would otherwise stop a real user.
+- **`action`**: the agent hard-stops on authentication, blocked, and error pages so you can intervene manually before the run proceeds.
 
 You can override the saved mode for a single run with `--mode <action|testing>` on `kane-cli run`.
 
@@ -172,7 +172,7 @@ You can override the saved mode for a single run with `--mode <action|testing>` 
 
 The `code_export` block enables and configures generated code output produced after a successful Test Manager upload. There is no `kane-cli config` subcommand for this block. Set it from one of:
 
-- **The TUI** — open the config menu, choose Code Export, and toggle the `enabled` and `skip_validation` switches.
+- **The TUI**: open the config menu, choose Code Export, and toggle the `enabled` and `skip_validation` switches.
 - **Per-run flags** on `kane-cli run`:
   - `--code-export` to enable for this run only
   - `--code-language <lang>` to pick the output language (only `python` is supported)

--- a/docs/kane-cli-generate-workflow.md
+++ b/docs/kane-cli-generate-workflow.md
@@ -2,7 +2,7 @@
 id: kane-cli-generate-workflow
 title: The Generate Workflow
 sidebar_label: Workflow
-description: "Walk the kane-cli generate loop end to end — generate, refine in plain language, save functional cases as _test.md files, and run them with testmd. Includes worked examples, agent/CI automation, and exit codes."
+description: "Walk the kane-cli generate loop end to end: generate, refine in plain language, save functional cases as _test.md files, and run them with testmd. Includes worked examples, agent/CI automation, and exit codes."
 keywords:
   - kane cli generate workflow
   - kane cli test case generation
@@ -69,7 +69,7 @@ kane-cli generates scenarios and cases and prints the result, ending with a **re
   Save:    kane-cli generate --save --req 23271
 ```
 
-Keep the request id — every later command uses it.
+Keep the request id, every later command uses it.
 
 Bound the size with limits when you want a tighter or broader set:
 
@@ -92,13 +92,13 @@ Each refine returns the updated result. Repeat until the set looks right.
 
 ### When generation asks a question
 
-Sometimes a turn ends by asking you something instead of finishing — for example, *"Which environment should these target, staging or production?"* This is a normal outcome, not a failure (the command exits `0`). Answer it by refining with your answer:
+Sometimes a turn ends by asking you something instead of finishing, for example, *"Which environment should these target, staging or production?"* This is a normal outcome, not a failure (the command exits `0`). Answer it by refining with your answer:
 
 ```bash
 kane-cli generate "target staging" --refine --req 23271
 ```
 
-(Driving this from a script or agent? Add `--agent` — or rely on it being auto-on when stdin is not a TTY — and read the answer-needed signal from the NDJSON, then re-invoke the same way.)
+(Driving this from a script or agent? Add `--agent` (or rely on it being auto-on when stdin is not a TTY) and read the answer-needed signal from the NDJSON, then re-invoke the same way.)
 
 ## 3. Save
 
@@ -127,7 +127,7 @@ Choose a different location with `--out`, and name the suite with `--name`:
 kane-cli generate --save --req 23271 --out ./tests --name checkout-suite
 ```
 
-Only functional cases are written — non-functional cases (Security, Performance, …) are part of the generated result but are not saved as runnable tests. See [Saving is functional-only](/support/docs/kane-cli-generate/#saving-is-functional-only).
+Only functional cases are written: non-functional cases (Security, Performance, …) are part of the generated result but are not saved as runnable tests. See [Saving is functional-only](/support/docs/kane-cli-generate/#saving-is-functional-only).
 
 ## 4. Run
 
@@ -137,7 +137,7 @@ The saved files are ordinary `_test.md` tests. Run any of them with `testmd`:
 kane-cli testmd run .testmuai/tests/checkout-23271/checkout/guest-checkout_test.md
 ```
 
-From here, everything in the [testmd docs](/support/docs/kane-cli-testmd/) applies — replay from cache, edit steps, compose with `@import`, and commit the output to git.
+From here, everything in the [testmd docs](/support/docs/kane-cli-testmd/) applies: replay from cache, edit steps, compose with `@import`, and commit the output to git.
 
 ## Automating it (agents / CI)
 
@@ -155,15 +155,15 @@ Each command prints one JSON object per line; the final line is the terminal eve
 
 | Code | Meaning |
 |---|---|
-| `0` | Turn completed — including a turn that ended with a clarification question |
+| `0` | Turn completed, including a turn that ended with a clarification question |
 | `1` | Generation failed |
-| `2` | Error — authentication / setup / transport, or an invalid combination of flags |
+| `2` | Error: authentication / setup / transport, or an invalid combination of flags |
 | `3` | Generation stopped or cancelled |
 | `130` | Interrupted (Ctrl-C) |
 
-Invalid flag combinations exit `2` with a message explaining the fix — for example using `--refine` without `--req`, passing a description with `--save`, using `--out` without `--save`, or `--req` without `--refine` or `--save`.
+Invalid flag combinations exit `2` with a message explaining the fix, for example using `--refine` without `--req`, passing a description with `--save`, using `--out` without `--save`, or `--req` without `--refine` or `--save`.
 
 ## Next steps
 
-- [Generating test cases with AI](/support/docs/kane-cli-generate/) — overview, modes, and the full option reference.
-- [Running tests with testmd](/support/docs/kane-cli-testmd/) — run and replay the files `--save` produces.
+- [Generating test cases with AI](/support/docs/kane-cli-generate/): overview, modes, and the full option reference.
+- [Running tests with testmd](/support/docs/kane-cli-testmd/): run and replay the files `--save` produces.

--- a/docs/kane-cli-generate.md
+++ b/docs/kane-cli-generate.md
@@ -2,7 +2,7 @@
 id: kane-cli-generate
 title: Generating Test Cases with AI
 sidebar_label: Overview
-description: "Turn a plain-language description of what you want to test into structured test scenarios and test cases with kane-cli generate — refine in plain language, then save the functional cases as runnable _test.md files."
+description: "Turn a plain-language description of what you want to test into structured test scenarios and test cases with kane-cli generate: refine in plain language, then save the functional cases as runnable _test.md files."
 keywords:
   - kane cli generate
   - kane cli test case generation
@@ -41,17 +41,17 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-generate/
     }}
 ></script>
 
-`kane-cli generate` turns a plain-language description of *what you want to test* into structured **test scenarios** and **test cases** — without writing them by hand and without launching a browser. This page covers AI test-case generation from both the command line and the interactive kane-cli TUI.
+`kane-cli generate` turns a plain-language description of *what you want to test* into structured **test scenarios** and **test cases**, without writing them by hand and without launching a browser. This page covers AI test-case generation from both the command line and the interactive kane-cli TUI.
 
 A generation produces:
 
-- **Test Scenarios** — logical groupings of related checks (e.g. "Login", "Checkout").
-- **Test Cases** — the individual checks inside each scenario, each typed **Positive**, **Negative**, or **Edge**.
+- **Test Scenarios**: logical groupings of related checks (e.g. "Login", "Checkout").
+- **Test Cases**: the individual checks inside each scenario, each typed **Positive**, **Negative**, or **Edge**.
 
 You generate, review the result, **refine** it in plain language as many times as you like, and optionally **save** the functional cases as runnable `_test.md` files that [`kane-cli testmd`](/support/docs/kane-cli-testmd/) can execute and replay.
 
 :::note
-For the full picture of AI test-case generation — including richer inputs (files, PDFs, issue links) and pushing cases into Test Manager or automation — see the [AI test-case generation guide](https://www.testmuai.com/support/docs/generate-test-cases-with-ai/). The **CLI here takes a text description** (optionally with local files attached via [`--files`](#attaching-files-for-context)) and writes local `_test.md` files. See [Limits and scope](#limits-and-scope).
+For the full picture of AI test-case generation, including richer inputs (files, PDFs, issue links) and pushing cases into Test Manager or automation, see the [AI test-case generation guide](https://www.testmuai.com/support/docs/generate-test-cases-with-ai/). The **CLI here takes a text description** (optionally with local files attached via [`--files`](#attaching-files-for-context)) and writes local `_test.md` files. See [Limits and scope](#limits-and-scope).
 :::
 
 ## Quick start
@@ -75,12 +75,12 @@ The request id (`23271` above) is printed at the end of each generation and is h
 
 ## The three modes
 
-`generate` runs **one turn per command, then exits** — you continue a request by running the command again with `--req <id>`. (That's the scripted/headless surface; run interactively, kane-cli opens a live TUI session instead — see [Interactive mode (TUI)](#interactive-mode-tui).)
+`generate` runs **one turn per command, then exits**. You continue a request by running the command again with `--req <id>`. (That's the scripted/headless surface; run interactively, kane-cli opens a live TUI session instead, see [Interactive mode (TUI)](#interactive-mode-tui).)
 
 | Mode | Command | What it does |
 |---|---|---|
 | **New** | `kane-cli generate "<what to test>"` | Starts a fresh request and generates scenarios + cases. Prints a request id. |
-| **Refine** | `kane-cli generate "<change>" --refine --req <id>` | Adjusts an existing request in plain language — add coverage, narrow scope, change focus. |
+| **Refine** | `kane-cli generate "<change>" --refine --req <id>` | Adjusts an existing request in plain language: add coverage, narrow scope, change focus. |
 | **Save** | `kane-cli generate --save --req <id> [--out <dir>]` | Writes the request's **functional** cases to `_test.md` files. No new generation. |
 
 `--refine` and `--save` both require `--req`. `--refine` needs a change description; `--save` takes no description.
@@ -94,64 +94,64 @@ The request id (`23271` above) is printed at the end of each generation and is h
 | `--name <name>` | Names the run and the saved suite folder. |
 | `--scenario-limit <n>` | Maximum number of scenarios to generate. |
 | `--per-scenario-limit <n>` | Maximum test cases per scenario. |
-| `--memory` | Use the **memory layer** — reuse relevant existing test cases and reduce duplicates. |
+| `--memory` | Use the **memory layer**: reuse relevant existing test cases and reduce duplicates. |
 | `--files <paths>` | Comma-separated local files to attach as context (new generations and refines only). See [Attaching files for context](#attaching-files-for-context). |
 | `--project <id>` / `--folder <id>` | Test Manager project / folder. |
 | `--agent` | Emit structured NDJSON on stdout (auto-on when run non-interactively / piped). |
-| `--env`, `--username`, `--access-key` | Environment and authentication — same as [`kane-cli run`](/support/docs/kane-cli-quickstart/). See [Authentication](/support/docs/kane-cli-authentication/). |
+| `--env`, `--username`, `--access-key` | Environment and authentication, same as [`kane-cli run`](/support/docs/kane-cli-quickstart/). See [Authentication](/support/docs/kane-cli-authentication/). |
 
 ## Attaching files for context
 
-Give the generator more to work from by attaching local files with `--files` — a comma-separated list of paths — on a **new** generation or a **refine**:
+Give the generator more to work from by attaching local files with `--files` (a comma-separated list of paths) on a **new** generation or a **refine**:
 
 ```bash
 kane-cli generate "test the login flow described in the attached spec" --files ./login-spec.pdf,./wireframe.png
 ```
 
-The files are sent along with your description and reflected in the generated scenarios and cases — attach a spec, a screenshot of the UI, a PDF or Word document, or a CSV of inputs.
+The files are sent along with your description and reflected in the generated scenarios and cases: attach a spec, a screenshot of the UI, a PDF or Word document, or a CSV of inputs.
 
-- **Supported types** — documents (`.txt`, `.json`, `.xml`, `.csv`, `.pdf`, `.docx`, `.xlsx`), images (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.webp`), audio (`.mp3`, `.wav`, `.m4a`), and video (`.mp4`, `.mov`, `.webm`, `.mpeg`, `.mpga`).
-- **Limits** — up to **10 files**, each **50 MB** or smaller.
-- **Checked before anything is sent** — all paths are validated as a set. If any is missing, an unsupported type, too large, or over the count, the command stops and lists the offending paths so nothing is uploaded by mistake. Files outside the current directory are allowed but flagged with a warning.
-- **Not with `--save`** — files attach to a generation or refine, not a save (`--files` with `--save` is rejected).
+- **Supported types**: documents (`.txt`, `.json`, `.xml`, `.csv`, `.pdf`, `.docx`, `.xlsx`), images (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.webp`), audio (`.mp3`, `.wav`, `.m4a`), and video (`.mp4`, `.mov`, `.webm`, `.mpeg`, `.mpga`).
+- **Limits**: up to **10 files**, each **50 MB** or smaller.
+- **Checked before anything is sent**: all paths are validated as a set. If any is missing, an unsupported type, too large, or over the count, the command stops and lists the offending paths so nothing is uploaded by mistake. Files outside the current directory are allowed but flagged with a warning.
+- **Not with `--save`**: files attach to a generation or refine, not a save (`--files` with `--save` is rejected).
 
 In the interactive TUI, type `@` in the generate prompt to attach a file inline instead of passing `--files`.
 
 ## Interactive mode (TUI)
 
-The commands above are the scripted surface. The kane-cli TUI **launches in Run mode** (for running tests) by default — switch to **Generate mode** with **`/generate`**, and back with `/run`. Or jump straight in: running `kane-cli generate "<objective>"` in a terminal (without `--agent`) opens the TUI directly in Generate mode and submits your objective.
+The commands above are the scripted surface. The kane-cli TUI **launches in Run mode** (for running tests) by default. Switch to **Generate mode** with **`/generate`**, and back with `/run`. Or jump straight in: running `kane-cli generate "<objective>"` in a terminal (without `--agent`) opens the TUI directly in Generate mode and submits your objective.
 
-Unlike the one-turn command-line surface, the TUI is a **live session** — generated scenarios stay pinned in a **Scenarios** box that you refine and browse in place:
+Unlike the one-turn command-line surface, the TUI is a **live session**: generated scenarios stay pinned in a **Scenarios** box that you refine and browse in place:
 
 | Input | Action |
 |---|---|
-| *(type any text)* | **Refine** — describe a change in plain language; the set updates in place |
-| `@<file>` | **Attach a file** — type `@` to pick a local file to add as context (same files as `--files`) |
-| `/view [S<n>]` | Open the **scenario browser** — drill scenarios → cases → case detail |
+| *(type any text)* | **Refine**: describe a change in plain language; the set updates in place |
+| `@<file>` | **Attach a file**: type `@` to pick a local file to add as context (same files as `--files`) |
+| `/view [S<n>]` | Open the **scenario browser**: drill scenarios → cases → case detail |
 | `/save` | Save the functional cases to `<cwd>/.testmuai/tests/…` |
 | `/cancel` | Cancel the current generation |
 | `/run` | Switch back to Run mode |
 
-In the scenario browser: `↑↓` move · `↵` open · `◂ ▸` previous/next sibling · `x` remove a case · `←`/`esc` back. **Non-functional cases** (Security, Performance, …) show a **gray `✓`** with a "won't be saved" note — `/save` writes only functional cases (see [Saving is functional-only](#saving-is-functional-only)).
+In the scenario browser: `↑↓` move · `↵` open · `◂ ▸` previous/next sibling · `x` remove a case · `←`/`esc` back. **Non-functional cases** (Security, Performance, …) show a **gray `✓`** with a "won't be saved" note. `/save` writes only functional cases (see [Saving is functional-only](#saving-is-functional-only)).
 
-If generation asks a **clarifying question**, just type your answer to continue. After `/save`, the files are ordinary `_test.md` tests under `.testmuai/tests/` — run them with [`kane-cli testmd run`](/support/docs/kane-cli-testmd/).
+If generation asks a **clarifying question**, just type your answer to continue. After `/save`, the files are ordinary `_test.md` tests under `.testmuai/tests/`, run them with [`kane-cli testmd run`](/support/docs/kane-cli-testmd/).
 
 ## How a result is shaped
 
 Each generated case carries:
 
 - a **title** and **steps**,
-- a **type** — Positive (expected to pass), Negative (tests failure handling), or Edge (corner cases),
-- a **category** — e.g. *Functional*, *Security*, *Performance*,
+- a **type**: Positive (expected to pass), Negative (tests failure handling), or Edge (corner cases),
+- a **category**: e.g. *Functional*, *Security*, *Performance*,
 - a **priority**.
 
 Scenarios are ordered by importance. The full result is returned at the end of the turn so it can be reviewed before you refine or save.
 
 ## Saving is functional-only
 
-`--save` writes **only test cases whose category is *Functional*** — those are the ones that translate into runnable `_test.md` tests. Non-functional cases (Security, Performance, and so on) are still generated and shown, but they are **not** written to disk. If a request has no functional cases, `--save` writes nothing and tells you so.
+`--save` writes **only test cases whose category is *Functional***: those are the ones that translate into runnable `_test.md` tests. Non-functional cases (Security, Performance, and so on) are still generated and shown, but they are **not** written to disk. If a request has no functional cases, `--save` writes nothing and tells you so.
 
-Saved files are ordinary `_test.md` tests in the standard format — identical to a hand-written one. From there everything in [the testmd docs](/support/docs/kane-cli-testmd/) applies: run them, edit them, replay them from cache, commit them to git.
+Saved files are ordinary `_test.md` tests in the standard format, identical to a hand-written one. From there everything in [the testmd docs](/support/docs/kane-cli-testmd/) applies: run them, edit them, replay them from cache, commit them to git.
 
 This is the intended path: **generate authors test cases → testmd runs them.**
 
@@ -163,6 +163,6 @@ This is the intended path: **generate authors test cases → testmd runs them.**
 
 ## Next steps
 
-- [The generate workflow](/support/docs/kane-cli-generate-workflow/) — the new → refine → save → run loop, worked examples, and exit codes.
-- [Running tests with testmd](/support/docs/kane-cli-testmd/) — run and replay the `_test.md` files `--save` produces.
-- [Authentication](/support/docs/kane-cli-authentication/) — logging in and choosing an environment.
+- [The generate workflow](/support/docs/kane-cli-generate-workflow/): the new → refine → save → run loop, worked examples, and exit codes.
+- [Running tests with testmd](/support/docs/kane-cli-testmd/): run and replay the `_test.md` files `--save` produces.
+- [Authentication](/support/docs/kane-cli-authentication/): logging in and choosing an environment.

--- a/docs/kane-cli-installation.md
+++ b/docs/kane-cli-installation.md
@@ -98,7 +98,7 @@ This removes the `kane-cli` binary but leaves your local data in place. Kane CLI
 rm -rf ~/.testmuai/kaneai
 ```
 
-Only do this if you want a clean reset — it logs you out of all profiles and deletes saved configuration, session history, and command history.
+Only do this if you want a clean reset, it logs you out of all profiles and deletes saved configuration, session history, and command history.
 
 ## Troubleshooting Installation
 

--- a/docs/kane-cli-tms-integration.md
+++ b/docs/kane-cli-tms-integration.md
@@ -57,12 +57,12 @@ This is the default behaviour for every session in both the TUI and the CLI. You
 
 When a session ends, Kane CLI runs an upload pipeline that finalises the test case in Test Manager. Two kinds of artefacts move from your machine to <BrandName />:
 
-- **Screenshots** — uploaded incrementally as the agent runs. By the time the session ends, most of them are already in place. PNG screenshots are converted to WebP before upload.
-- **Run artefacts and metadata** — packaged at session exit. This includes per-run action logs, an execution blob describing the run (objective, status, steps, durations, variables in scope), and the zipped contents of the session run directories.
+- **Screenshots**: uploaded incrementally as the agent runs. By the time the session ends, most of them are already in place. PNG screenshots are converted to WebP before upload.
+- **Run artefacts and metadata**: packaged at session exit. This includes per-run action logs, an execution blob describing the run (objective, status, steps, durations, variables in scope), and the zipped contents of the session run directories.
 
 You see a short progress indicator at exit covering these stages: `convert` (preparing metadata), `zip` (packaging run directories), `presign` (requesting upload URLs), `upload` (sending the zip and metadata), and `finalize` (committing the test case in Test Manager). If code export is enabled, a `code_export` stage runs after `finalize`. If it is disabled, that stage is reported as skipped.
 
-If the upload fails, Kane CLI prints the error and exits. The local session directory is preserved either way — see [Session History on Disk](#session-history-on-disk).
+If the upload fails, Kane CLI prints the error and exits. The local session directory is preserved either way, see [Session History on Disk](#session-history-on-disk).
 
 ---
 
@@ -157,9 +157,9 @@ The same code is also available alongside the test case in Test Manager.
 
 When the upload finishes successfully, Kane CLI prints a small links block to the terminal. You see up to three links, depending on what was generated:
 
-- **ShareLink** — a shareable session URL on <BrandName /> Test Manager. Anyone you send this link to can view the run summary without needing access to the project. Links are issued with a seven-day expiry.
-- **TestCase** — a direct URL to the test case dashboard inside your Test Manager project. Use this when you are signed in to <BrandName /> and want to drill into the run.
-- **CodeExport** — a `file://` link to the directory on your machine that holds the generated Playwright code. Only shown when code export is enabled and produced files.
+- **ShareLink**: a shareable session URL on <BrandName /> Test Manager. Anyone you send this link to can view the run summary without needing access to the project. Links are issued with a seven-day expiry.
+- **TestCase**: a direct URL to the test case dashboard inside your Test Manager project. Use this when you are signed in to <BrandName /> and want to drill into the run.
+- **CodeExport**: a `file://` link to the directory on your machine that holds the generated Playwright code. Only shown when code export is enabled and produced files.
 
 The links survive the terminal exit and remain in your scrollback.
 

--- a/docs/kane-cli-troubleshooting.md
+++ b/docs/kane-cli-troubleshooting.md
@@ -183,7 +183,7 @@ Get credentials from the <BrandName /> [dashboard](https://www.testmuai.com/logi
 
 **Fix:**
 1. **JSON syntax.** Variable files are JSON. A missing comma or unquoted key will cause the file to be skipped silently.
-2. **File location.** Confirm your file is in the right place — see [loading order](/support/docs/kane-cli-variables-and-context/#loading-order).
+2. **File location.** Confirm your file is in the right place, see [loading order](/support/docs/kane-cli-variables-and-context/#loading-order).
 3. **Inline test.** Bypass file loading by passing the variable on the command line:
    ```bash
    kane-cli run "log in as {{user}}" \
@@ -308,7 +308,7 @@ Two other triggers: npm configured to skip optional dependencies (`npm config ge
 
 Kane CLI checks the public npm registry for a newer release once every 24 hours. The result is cached locally so the check itself is non-blocking and silent on failure. When a newer version exists, Kane CLI surfaces an "update available" notification with the current and latest versions and a severity label (`major`, `minor`, or `patch`).
 
-The notice is informational — your current version still works. To upgrade, follow the steps in [Updates](/support/docs/kane-cli-installation/#update).
+The notice is informational, your current version still works. To upgrade, follow the steps in [Updates](/support/docs/kane-cli-installation/#update).
 
 ---
 

--- a/docs/kane-cli-variables-and-context.md
+++ b/docs/kane-cli-variables-and-context.md
@@ -44,7 +44,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-**Variables** keep credentials and test data out of your objectives. **Context files** give the agent persistent background information — guidance, conventions, and notes that apply across runs.
+**Variables** keep credentials and test data out of your objectives. **Context files** give the agent persistent background information: guidance, conventions, and notes that apply across runs.
 
 ---
 
@@ -63,7 +63,7 @@ Variables are JSON objects keyed by name. Each entry describes a single variable
 
 | Field | Required | Type | Default | Description |
 |-------|----------|------|---------|-------------|
-| `value` | Yes | string | — | The variable's value. Entries without `value` are ignored. |
+| `value` | Yes | string | None | The variable's value. Entries without `value` are ignored. |
 | `secret` | No | boolean | `false` | When `true`, the value is masked in logs and routed to the <BrandName /> secrets store instead of being synced as plain Test Manager variables. |
 
 ### Usage in Objectives
@@ -86,10 +86,10 @@ Before the objective is sent to the agent, `{{email}}` and `{{password}}` are re
 
 Variables are merged from four sources in this order. Later sources override earlier ones for the same key:
 
-1. **Global directory** — `~/.testmuai/kaneai/variables/*.json`
-2. **Local project directory** — `.testmuai/variables/*.json` (relative to where you invoke `kane-cli`)
-3. **File flag** — `--variables-file <path>`
-4. **Inline flag** — `--variables '<json>'` (highest priority)
+1. **Global directory**: `~/.testmuai/kaneai/variables/*.json`
+2. **Local project directory**: `.testmuai/variables/*.json` (relative to where you invoke `kane-cli`)
+3. **File flag**: `--variables-file <path>`
+4. **Inline flag**: `--variables '<json>'` (highest priority)
 
 Within a directory, files are read in alphabetical order; later files override earlier files for duplicate keys. Files that fail to parse as JSON are skipped with a warning.
 
@@ -136,7 +136,7 @@ For values you want available across every project on your machine, place `*.jso
 └── shared.json
 ```
 
-Global variables have the lowest precedence — anything else with the same key wins.
+Global variables have the lowest precedence, anything else with the same key wins.
 
 ### Example Variable File
 
@@ -171,7 +171,7 @@ Do not commit credential files to version control. Add `.testmuai/variables/` to
 
 ## Context Files
 
-Context files are plain Markdown files whose contents are passed to the agent alongside your objective. Use them for standing instructions — coding conventions, accounts to use, sites to avoid, or domain knowledge the agent should always have.
+Context files are plain Markdown files whose contents are passed to the agent alongside your objective. Use them for standing instructions: coding conventions, accounts to use, sites to avoid, or domain knowledge the agent should always have.
 
 ### Two Levels
 
@@ -223,7 +223,7 @@ kane-cli run "your objective" \
   --local-context ./custom-local.md
 ```
 
-If a context file is missing or empty, it is silently ignored — no error is raised.
+If a context file is missing or empty, it is silently ignored, no error is raised.
 
 ### What to Put in Context
 

--- a/docs/kaneai-advanced-settings.md
+++ b/docs/kaneai-advanced-settings.md
@@ -46,7 +46,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-KaneAI allows you to edit the advanced settings of an existing test case directly from the **Test Summary** page. This gives you the flexibility to update configurations like network settings, timezone, Chrome options, and custom headers after a test has already been authored — without having to recreate it from scratch.
+KaneAI allows you to edit the advanced settings of an existing test case directly from the **Test Summary** page. This gives you the flexibility to update configurations like network settings, timezone, Chrome options, and custom headers after a test has already been authored, without having to recreate it from scratch.
 
 This feature is supported across all platforms: **Desktop Web**, **Mobile App**, and **Mobile Web**.
 
@@ -54,8 +54,8 @@ This feature is supported across all platforms: **Desktop Web**, **Mobile App**,
 
 When you edit advanced settings for a test case, you have two options:
 
-- **Apply Settings** — Saves the updated settings and generates a new version of the test case with regenerated code. Use this when the setting changes do not affect the test steps themselves.
-- **Edit Test Steps** — Saves the updated settings and opens the playground so you can make relevant changes to your test steps. Use this when the updated settings may require modifications to the test flow.
+- **Apply Settings**: Saves the updated settings and generates a new version of the test case with regenerated code. Use this when the setting changes do not affect the test steps themselves.
+- **Edit Test Steps**: Saves the updated settings and opens the playground so you can make relevant changes to your test steps. Use this when the updated settings may require modifications to the test flow.
 
 ## Platform-Specific Advanced Settings
 
@@ -132,14 +132,14 @@ For more details on mobile app capabilities like biometric authentication, image
 
 Android Web test cases share most settings with [Android App](#android-app), with the following differences:
 
-- **Custom Headers** is available (Toggle + multi-input — add up to 10 custom HTTP headers)
+- **Custom Headers** is available (Toggle + multi-input, add up to 10 custom HTTP headers)
 - **Biometric Authentication**, **Image Injection**, and **Video Injection** are **not** available
 
 ### iOS Web
 
 iOS Web test cases share most settings with [iOS App](#ios-app), with the following differences:
 
-- **Custom Headers** is available (Toggle + multi-input — add up to 10 custom HTTP headers)
+- **Custom Headers** is available (Toggle + multi-input, add up to 10 custom HTTP headers)
 - **Biometric Authentication**, **Image Injection**, and **Video Injection** are **not** available
 
 ## How to Edit Advanced Settings
@@ -171,8 +171,8 @@ Settings that have been modified will display an **Edited** badge next to them.
 
 Choose one of the two actions at the bottom of the dialog:
 
-- **Apply Settings** — Saves the settings and generates a new version with updated code. The test case remains on the Test Summary page.
-- **Edit Test Steps** — Saves the settings and opens the playground so you can adjust the test steps to reflect the new configuration.
+- **Apply Settings**: Saves the settings and generates a new version with updated code. The test case remains on the Test Summary page.
+- **Edit Test Steps**: Saves the settings and opens the playground so you can adjust the test steps to reflect the new configuration.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/edit-advanced-settings/edited-advanced-settings.png').default} alt="Apply Settings or Edit Test Steps" className="doc_img"/>
 
@@ -180,12 +180,12 @@ Choose one of the two actions at the bottom of the dialog:
 
 Every time you apply updated settings, a new version of the test case is created. You can view and compare changes between versions from the **Version History** tab.
 
-The version comparison view shows a diff of what changed — for example, updated network configuration or timezone values — so you can track exactly what was modified in each version.
+The version comparison view shows a diff of what changed, for example, updated network configuration or timezone values, so you can track exactly what was modified in each version.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/edit-advanced-settings/advanced-settings-version-history.png').default} alt="Advanced Settings Version History" className="doc_img"/>
 
 ## Limitations
 
-- **Advanced settings only** — Only advanced settings (network configuration, timezone, Chrome options, custom headers, and mobile session settings) can be edited from the test summary page. To change test steps, OS, browser, or device configurations, you need to open the playground.
-- **New version generated on every apply** — Applying updated settings always creates a new version of the test case with regenerated code. There is no way to update settings in-place without generating a new version.
-- **Version history diff for pre-rollout versions** — If you compare a version created after this feature was rolled out with a version created before it, the diff will have no advanced settings changes to display since the older version never tracked them. Similarly, if you open a pre-rollout version and click on advanced settings, only the latest settings are shown as the original settings were not recorded for that version.
+- **Advanced settings only**: Only advanced settings (network configuration, timezone, Chrome options, custom headers, and mobile session settings) can be edited from the test summary page. To change test steps, OS, browser, or device configurations, you need to open the playground.
+- **New version generated on every apply**: Applying updated settings always creates a new version of the test case with regenerated code. There is no way to update settings in-place without generating a new version.
+- **Version history diff for pre-rollout versions**: If you compare a version created after this feature was rolled out with a version created before it, the diff will have no advanced settings changes to display since the older version never tracked them. Similarly, if you open a pre-rollout version and click on advanced settings, only the latest settings are shown as the original settings were not recorded for that version.

--- a/docs/kaneai-app-test-writing-guidelines.md
+++ b/docs/kaneai-app-test-writing-guidelines.md
@@ -116,7 +116,7 @@ By default, each App step waits up to **10 seconds** for its target element to a
 2. Select **Step Timeout**.
 3. Enter the timeout value in seconds (min **1**, max **300**) and save the step.
 
-Step Timeout is a **dynamic ceiling** — the step proceeds as soon as the element is ready and only uses the extra time on genuinely slow loads. It applies to element-based interactions (Tap/Click, Type/Input, Search, Clear) and has no effect on fixed `wait` steps, assertions, or API steps. Leaving it unset keeps the default 10-second behavior.
+Step Timeout is a **dynamic ceiling**: the step proceeds as soon as the element is ready and only uses the extra time on genuinely slow loads. It applies to element-based interactions (Tap/Click, Type/Input, Search, Clear) and has no effect on fixed `wait` steps, assertions, or API steps. Leaving it unset keeps the default 10-second behavior.
 
 :::note
 Step Timeout is supported on KaneAI App automation for **Android and iOS** real devices, bringing App testing in line with Web and Mobile Web, which already support per-step timeouts.

--- a/docs/kaneai-auto-heal.md
+++ b/docs/kaneai-auto-heal.md
@@ -52,7 +52,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 ## What is Auto-Heal in KaneAI & HyperExecute?
 
-KaneAI, the GenAI Native testing assistant from <BrandName />, generates automation test scripts across multiple languages and frameworks using natural language instructions. When these scripts are executed via **HyperExecute**, <BrandName />’s high-performance test orchestration platform, they come with an added layer of reliability—the **Auto-Heal** feature.
+KaneAI, the GenAI Native testing assistant from <BrandName />, generates automation test scripts across multiple languages and frameworks using natural language instructions. When these scripts are executed via **HyperExecute**, <BrandName />’s high-performance test orchestration platform, they come with an added layer of reliability: the **Auto-Heal** feature.
 
 **Auto-Heal** ensures your automation scripts remain robust, even when the application under test undergoes changes like modified element locators (IDs, XPaths, CSS selectors). Instead of failing the test immediately when locators break, KaneAI dynamically finds new locators at runtime by leveraging the original natural language instruction used to execute the test case.
 

--- a/docs/kaneai-bulk-module-update.md
+++ b/docs/kaneai-bulk-module-update.md
@@ -252,5 +252,5 @@ The following limitations apply currently to the Bulk Module Update Feature:
 
 ## Related Guides
 
-- [Modules](/support/docs/kane-ai-modules/) — Create, use, and manage modules
-- [Versioning and Enhancements](/support/docs/kaneai-modules-versions-and-enhancement/) — Track changes, compare versions, and revert modules
+- [Modules](/support/docs/kane-ai-modules/): Create, use, and manage modules
+- [Versioning and Enhancements](/support/docs/kaneai-modules-versions-and-enhancement/): Track changes, compare versions, and revert modules

--- a/docs/kaneai-ci-cd-automation.md
+++ b/docs/kaneai-ci-cd-automation.md
@@ -93,7 +93,7 @@ Replace `<TestRunID>` with the actual ID from the URL and set additional optiona
 - **accessibility**: Set as true if you want to run accessibility test on all your tests in the test run. Setting this as true could potentially slow down the execution time.
 - **replaced_url :** To be used to dynamically replace any pattern URL in test cases with the replacement URL for entire test run.
 - **report_enabled**: Set to `true` to generate an HTML report for the test run. The report can be accessed from the HyperExecute Job page after execution. See [Reports](/support/docs/kaneai-hyperexecute-test-run-execution/#reports) for details.
-- **extent_report_enabled**: Set to `true` to generate an Extent report for the test run. The report can be accessed from the HyperExecute Job page after execution. Only one report type can be enabled at a time — use either `report_enabled` or `extent_report_enabled`, not both.
+- **extent_report_enabled**: Set to `true` to generate an Extent report for the test run. The report can be accessed from the HyperExecute Job page after execution. Only one report type can be enabled at a time. Use either `report_enabled` or `extent_report_enabled`, not both.
 - **report_email_to**: An array of email addresses to receive the test run report via email after execution. Maximum 10 email addresses. Only works when `report_enabled` is set to `true`.
 
 :::note

--- a/docs/kaneai-conditional-logic.md
+++ b/docs/kaneai-conditional-logic.md
@@ -45,7 +45,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 ## Introduction
 
-KaneAI supports conditional branching in your test cases using **If / Else‑If / Else** blocks. This lets you handle dynamic application behavior — for example, clicking a login button only when it is visible, or choosing between different checkout flows based on a variable value.
+KaneAI supports conditional branching in your test cases using **If / Else‑If / Else** blocks. This lets you handle dynamic application behavior, for example, clicking a login button only when it is visible, or choosing between different checkout flows based on a variable value.
 
 Each branch can contain multiple steps, including regular actions, **modules**, **JavaScript**, **API**, and **DB** steps, giving you full flexibility to build complex, real‑world test scenarios.
 
@@ -54,8 +54,8 @@ Each branch can contain multiple steps, including regular actions, **modules**, 
 1. Insert a conditional block from the **/** slash command menu during authoring or from the **+ Add step** option during a paused state.
 2. Define a condition using variables and comparison operators.
 3. Optionally add **Else‑If** branches for additional conditions.
-4. Add steps — including modules, JS, API, and DB steps — inside each branch.
-5. During authoring, only the branch whose condition is true gets executed — steps in the remaining branches are queued.
+4. Add steps, including modules, JS, API, and DB steps, inside each branch.
+5. During authoring, only the branch whose condition is true gets executed. Steps in the remaining branches are queued.
 6. In automation, KaneAI evaluates the conditions top‑to‑bottom at runtime and executes the first matching branch automatically.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/if-else/slash-if-else.png').default} alt="If / Else-If / Else block in the KaneAI authoring panel" className="doc\_img"/>
@@ -67,27 +67,27 @@ Each branch can contain multiple steps, including regular actions, **modules**, 
 
 ## Step‑by‑step Guide
 
-### Step 1 — Add a Conditional Block
+### Step 1: Add a Conditional Block
 
 1. In your authoring session, press **/** to open the slash command menu.
 2. Select **Add If-Else** option.
 3. KaneAI inserts an **If / Else** block into your test flow.
 
-### Step 2 — Define the Condition
+### Step 2: Define the Condition
 
-Click the **If** header to open the condition editor. You can define conditions in two ways — toggle between them using the **switcher icon** (`&&`).
+Click the **If** header to open the condition editor. You can define conditions in two ways. Toggle between them using the **switcher icon** (`&&`).
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/if-else/condition-switcher.png').default} alt="Condition mode switcher" className="doc\_img"/>
 
-#### Option A — Natural Language
+#### Option A: Natural Language
 
 Type your condition as a plain-English sentence (e.g., "login button is visible"). KaneAI interprets the intent and evaluates it at runtime.
 
-#### Option B — Operand & Operator
+#### Option B: Operand & Operator
 
 Build the condition explicitly using left operand, operator, and right operand:
 
-1. Enter a **left operand** — this can be a variable (e.g., `{{login_button_visible}}`), extracted text, or a literal value.
+1. Enter a **left operand**: this can be a variable (e.g., `{{login_button_visible}}`), extracted text, or a literal value.
 2. Choose a **comparison operator** from the dropdown:
 
 | Operator | Description |
@@ -117,22 +117,22 @@ You can combine conditions using **AND** / **OR** logic:
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/if-else/add-conditions.png').default} alt="Condition editor with AND / OR logic" className="doc\_img"/>
 
-### Step 3 — Add Steps Inside a Branch
+### Step 3: Add Steps Inside a Branch
 
 Each branch (**If**, **Else‑If**, **Else**) supports multiple steps. You can add:
 
-- **Regular test steps** — type your instruction in the step input field.
-- **Modules** — reuse existing modules by adding them inside any branch.
-- **JavaScript steps** — execute custom JS within a branch.
-- **API steps** — make API calls as part of a conditional flow.
-- **DB steps** — run database queries conditionally.
-- **Manual interaction** — click the **manual interaction icon** next to the step input field to perform actions directly on the browser within the branch.
+- **Regular test steps**: type your instruction in the step input field.
+- **Modules**: reuse existing modules by adding them inside any branch.
+- **JavaScript steps**: execute custom JS within a branch.
+- **API steps**: make API calls as part of a conditional flow.
+- **DB steps**: run database queries conditionally.
+- **Manual interaction**: click the **manual interaction icon** next to the step input field to perform actions directly on the browser within the branch.
 
 Use the step input field or press **/** inside a branch to access the slash command menu.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/if-else/slash-command-add-steps.png').default} alt="Adding steps and manual interaction inside a conditional branch" className="doc\_img"/>
 
-### Step 4 — Add Else‑If Branches
+### Step 4: Add Else‑If Branches
 
 To handle additional conditions beyond the initial **If**:
 
@@ -142,14 +142,14 @@ To handle additional conditions beyond the initial **If**:
 4. Repeat to add as many **Else‑If** branches as needed.
 
 :::note Authoring vs. Automation behavior
-During authoring only one condition can be true at a time, so only the matching branch's steps are executed — steps under the remaining branches go into a **queued** state. When the test runs in automation, all queued branches are evaluated automatically and the first matching branch is executed.
+During authoring only one condition can be true at a time, so only the matching branch's steps are executed. Steps under the remaining branches go into a **queued** state. When the test runs in automation, all queued branches are evaluated automatically and the first matching branch is executed.
 :::
 
-### Step 5 — Add Steps to the Else Branch
+### Step 5: Add Steps to the Else Branch
 
 The **Else** block executes when none of the preceding conditions are met. Click **+ Add step** inside the **Else** block and add your fallback steps.
 
-### Step 6 — Close the Block
+### Step 6: Close the Block
 
 Click **End If** at the bottom of the conditional block to finalize it. You can then continue adding steps after the conditional block as usual.
 
@@ -188,7 +188,7 @@ You can add up to **5** Else‑If branches per conditional block.
 
 ### Can I use modules, JS, API, and DB steps inside every branch?
 
-Yes. All branch types — If, Else‑If, and Else — support the full range of step types including modules, JavaScript, API, and DB steps.
+Yes. All branch types (If, Else‑If, and Else) support the full range of step types including modules, JavaScript, API, and DB steps.
 
 ### Are nested If / Else blocks supported?
 

--- a/docs/kaneai-create-pr.md
+++ b/docs/kaneai-create-pr.md
@@ -47,7 +47,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-KaneAI lets you export generated test code directly to your GitHub or GitLab repository as a pull request (PR) or merge request (MR). Instead of downloading ZIP files and manually copying code, you can raise PRs from the Test Manager in a few clicks — or automatically whenever code is generated.
+KaneAI lets you export generated test code directly to your GitHub or GitLab repository as a pull request (PR) or merge request (MR). Instead of downloading ZIP files and manually copying code, you can raise PRs from the Test Manager in a few clicks, or automatically whenever code is generated.
 
 This guide covers how to integrate your Git provider, configure PR settings, create pull requests from test cases, and track their status.
 
@@ -139,8 +139,8 @@ In Multiple Repositories mode, you can map individual projects to specific repos
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/create-pr/pr-settings-multi.png').default} alt="Pull Requests settings tab showing Multiple Repositories configuration with project mapping" className="doc_img"/>
 
-- **Unmapped Projects** — Any project without a specific mapping uses the default repository configuration.
-- **+ Add Project** — Click to map a specific project to a different repository. Only KaneAI-enabled projects are available for mapping.
+- **Unmapped Projects**: Any project without a specific mapping uses the default repository configuration.
+- **+ Add Project**: Click to map a specific project to a different repository. Only KaneAI-enabled projects are available for mapping.
 
 Click **Update Setup** to save any changes.
 
@@ -152,8 +152,8 @@ Once the integration and repository settings are configured, you can create PRs 
 
 Each test case in the listing displays its PR status inline:
 
-- **PR number with icon** (e.g., `#2`, `#3`, `#4`) — A PR exists for this test case. Hover over the PR indicator to see the status (Open, Merged, or Closed), creation details, and a **View on GitHub** link that opens the PR directly.
-- **No PR** — No pull request has been created for this test case yet.
+- **PR number with icon** (e.g., `#2`, `#3`, `#4`): A PR exists for this test case. Hover over the PR indicator to see the status (Open, Merged, or Closed), creation details, and a **View on GitHub** link that opens the PR directly.
+- **No PR**: No pull request has been created for this test case yet.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/create-pr/tc-listing-page-PR.png').default} alt="Test case listing showing PR status indicators and PR details tooltip" className="doc_img"/>
 
@@ -167,14 +167,14 @@ Each test case in the listing displays its PR status inline:
 
 ### Diff-Based Updates
 
-KaneAI automatically tracks whether each code export version already has an associated PR. This detection happens in the background — the **Create PR** button only appears for a version when there is no existing PR for it.
+KaneAI automatically tracks whether each code export version already has an associated PR. This detection happens in the background. The **Create PR** button only appears for a version when there is no existing PR for it.
 
 In the **Code** section of a test case, each code export version shows its PR status alongside the **Create PR** and **Execute** actions. If a PR already exists for that version, the **Create PR** button is disabled with a tooltip: "PR already exists for this version."
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/create-pr/pr-diff-code-export.png').default} alt="Code section showing Create PR button for new version and disabled state for version with existing PR" className="doc_img"/>
 
-- **New version without a PR** — The **Create PR** button is active. Click it to raise a PR with that version's code.
-- **Version with an existing PR** — The PR number is shown (e.g., `#2`) and the **Create PR** button is disabled since the code is already synced.
+- **New version without a PR**: The **Create PR** button is active. Click it to raise a PR with that version's code.
+- **Version with an existing PR**: The PR number is shown (e.g., `#2`) and the **Create PR** button is disabled since the code is already synced.
 
 ### Auto-PR
 
@@ -217,9 +217,9 @@ your-repo/
 │           └── test.py
 ```
 
-- **`{project_name}`** — Derived from the Test Manager project name.
-- **`{test_id}_{test_name}`** — The test case ID and name combined for uniqueness.
-- **`{version_no}`** — The code export version number.
+- **`{project_name}`**: Derived from the Test Manager project name.
+- **`{test_id}_{test_name}`**: The test case ID and name combined for uniqueness.
+- **`{version_no}`**: The code export version number.
 
 You can customize this pattern during setup or in the Pull Requests settings tab.
 

--- a/docs/kaneai-custom-headers.md
+++ b/docs/kaneai-custom-headers.md
@@ -114,15 +114,15 @@ You can also click **View details** in the test case sidebar to see the full lis
 
 ## Example Use Cases
 
-- **Session Management** — Send a custom `X-Session-ID` header to track user sessions across requests:
+- **Session Management**: Send a custom `X-Session-ID` header to track user sessions across requests:
   ```
   X-Session-ID: 1234567890
   ```
-- **Authentication Tokens** — Use the **Secret** type to inject API keys or bearer tokens without exposing them in plain text:
+- **Authentication Tokens**: Use the **Secret** type to inject API keys or bearer tokens without exposing them in plain text:
   ```
   Authorization: {{secrets.org.BearerToken}}
   ```
-- **Content Negotiation** — Override the `Accept` header to test specific response formats:
+- **Content Negotiation**: Override the `Accept` header to test specific response formats:
   ```
   Accept: application/json
   ```

--- a/docs/kaneai-github-app.md
+++ b/docs/kaneai-github-app.md
@@ -3,7 +3,7 @@ id: github-app-integration
 title: TestMu Cloud GitHub App Integration
 hide_title: true
 sidebar_label: KaneAI GitHub App Integration
-description: Transform every pull request into a validation surface with AI-powered test generation, execution on HyperExecute, and Root Cause Analysis — all without leaving GitHub.
+description: Transform every pull request into a validation surface with AI-powered test generation, execution on HyperExecute, and Root Cause Analysis, all without leaving GitHub.
 keywords:
   - github app
   - testmu ai integration
@@ -51,7 +51,7 @@ import { CookieTrackingSignup } from '@site/src/component/CookieTracking';
 
 **Your pull requests should deliver proof, not just code.**
 
-The <BrandName /> Cloud GitHub App brings KaneAI — our AI testing agent — directly into your GitHub workflow. When a developer opens a pull request, KaneAI analyzes the changes, generates targeted test cases, executes them at scale on HyperExecute, and reports back with AI-powered Root Cause Analysis. The entire cycle runs in minutes, and every update appears right inside your PR.
+The <BrandName /> Cloud GitHub App brings KaneAI, our AI testing agent, directly into your GitHub workflow. When a developer opens a pull request, KaneAI analyzes the changes, generates targeted test cases, executes them at scale on HyperExecute, and reports back with AI-powered Root Cause Analysis. The entire cycle runs in minutes, and every update appears right inside your PR.
 
 No context switching. No manual test authoring. No waiting.
 
@@ -63,19 +63,19 @@ No context switching. No manual test authoring. No waiting.
 
 #### Automated AI Test Authoring
 
-Automatically generate test coverage for every pull request. KaneAI reads your code diff, PR description, README, and custom agent instructions to create automated tests that reflect actual business logic — not generic boilerplate.
+Automatically generate test coverage for every pull request. KaneAI reads your code diff, PR description, README, and custom agent instructions to create automated tests that reflect actual business logic, not generic boilerplate.
 
 #### Smart Intelligence
 
-KaneAI scans your existing test inventory in <BrandName /> Test Manager to find semantically similar test cases relevant to the PR changes. These existing tests are added alongside the newly generated test cases into the test run and executed on HyperExecute — maximizing test coverage by combining new and proven tests in a single validation cycle.
+KaneAI scans your existing test inventory in <BrandName /> Test Manager to find semantically similar test cases relevant to the PR changes. These existing tests are added alongside the newly generated test cases into the test run and executed on HyperExecute, maximizing test coverage by combining new and proven tests in a single validation cycle.
 
 #### Seamless Execution
 
-Tests run automatically and seamlessly on <BrandName />'s HyperExecute infrastructure — in parallel across browsers, devices, and platforms. Time to first signal is measured in minutes, not hours.
+Tests run automatically and seamlessly on <BrandName />'s HyperExecute infrastructure, in parallel across browsers, devices, and platforms. Time to first signal is measured in minutes, not hours.
 
 #### In-Depth Insights
 
-Detailed execution reports enriched with AI-powered Root Cause Analysis, offering actionable recommendations. When tests fail, KaneAI analyzes logs, screenshots, network traces, and stack traces to surface the specific root cause — directly in your PR comment.
+Detailed execution reports enriched with AI-powered Root Cause Analysis, offering actionable recommendations. When tests fail, KaneAI analyzes logs, screenshots, network traces, and stack traces to surface the specific root cause, directly in your PR comment.
 
 ---
 
@@ -197,7 +197,7 @@ tunnel_name: "your_tunnel_name"  # Optional: set if using the same tunnel across
 | `test_url` | The base URL of your application under test (your staging or testing environment URL) |
 | `tunnel_name` | *(Optional)* The name of the LambdaTest tunnel to use for testing. Set this when the same tunnel is reused across all PRs. Can be overridden per PR using the `--tunnel` flag in the trigger comment. |
 
-After installing the GitHub App, you are redirected to the [integration settings page](https://integrations.lambdatest.com/githubci/install) where all configuration values — project ID, folder ID, assignee, and environment ID — are displayed with a **copy button**. Use these to populate your `.lambdatest/config.yaml` file directly.
+After installing the GitHub App, you are redirected to the [integration settings page](https://integrations.lambdatest.com/githubci/install) where all configuration values (project ID, folder ID, assignee, and environment ID) are displayed with a **copy button**. Use these to populate your `.lambdatest/config.yaml` file directly.
 
 <img loading="lazy" src={require('../assets/images/kaneai-github-app/github-actions-three.png').default} alt="Copy configuration values from integration sidebar" className="doc_img"/>
 
@@ -230,7 +230,7 @@ your-repo/
 
 ---
 
-## Try It Out — Sample Repository
+## Try It Out: Sample Repository
 
 Explore the GitHub App workflow using our public sample repository:
 
@@ -245,11 +245,11 @@ Browse the open pull requests to see:
 
 To experience the full workflow hands-on, fork the sample repository and run the GitHub App in your own environment:
 
-1. **Fork the repository** — Click **Fork** on the [sample repository](https://github.com/LambdaTest/ai-native-quality-validation-sample) to create a copy under your GitHub account.
-2. **Install the GitHub App** — Install the [<BrandName /> Cloud GitHub App](https://github.com/apps/lambdatest-ai-cloud) on your forked repository (see [Installation](#installation) above).
-3. **Configure your credentials** — Add the `.lambdatest/config.yaml` file with your <BrandName /> project ID, folder ID, and other configuration values (see [Repository Configuration](#repository-configuration)).
-4. **Set up GitHub Pages & Actions** — Enable GitHub Pages and GitHub Actions in your forked repository to handle deployment and workflows.
-5. **Trigger the workflow** — Open a pull request in your fork and comment `@TestMuAI Validate this PR` to see the full AI testing pipeline in action.
+1. **Fork the repository**: Click **Fork** on the [sample repository](https://github.com/LambdaTest/ai-native-quality-validation-sample) to create a copy under your GitHub account.
+2. **Install the GitHub App**: Install the [<BrandName /> Cloud GitHub App](https://github.com/apps/lambdatest-ai-cloud) on your forked repository (see [Installation](#installation) above).
+3. **Configure your credentials**: Add the `.lambdatest/config.yaml` file with your <BrandName /> project ID, folder ID, and other configuration values (see [Repository Configuration](#repository-configuration)).
+4. **Set up GitHub Pages & Actions**: Enable GitHub Pages and GitHub Actions in your forked repository to handle deployment and workflows.
+5. **Trigger the workflow**: Open a pull request in your fork and comment `@TestMuAI Validate this PR` to see the full AI testing pipeline in action.
 
 ---
 
@@ -269,7 +269,7 @@ The test generation workflow is triggered through a simple comment on any pull r
 
 | Command | Description |
 |---------|-------------|
-| `@TestMuAI Validate this PR` | Triggers the full AI testing workflow — analysis, generation, execution, and reporting |
+| `@TestMuAI Validate this PR` | Triggers the full AI testing workflow: analysis, generation, execution, and reporting |
 | `@KaneAI Validate this PR` | Alias for the above |
 
 <img loading="lazy" src={require('../assets/images/kaneai-github-app/1-flow_triggered.png').default} alt="Trigger KaneAI workflow" className="doc_img"/>
@@ -289,7 +289,7 @@ You can extend any trigger command with optional parameters to customize test ex
 @TestMuAI Validate this PR --url https://preview-123.your-app.com --tunnel my-tunnel-name
 ```
 
-Both parameters are independent — use `--url` alone to override the URL, `--tunnel` alone for private environments, or combine them when both apply.
+Both parameters are independent. Use `--url` alone to override the URL, `--tunnel` alone for private environments, or combine them when both apply.
 
 #### Setting Up Tunnel Testing
 
@@ -314,14 +314,14 @@ After you post the trigger comment, KaneAI immediately begins working:
 4. **Test Generation**: Intelligent test cases are created with appropriate assertions, validations, and edge case handling.
 
 :::tip Fast Feedback
-The first signal — test plan and progress tracker — appears in your PR within approximately **1 minute** of triggering the workflow. Full execution and reporting typically completes within minutes, depending on test volume and complexity.
+The first signal, test plan and progress tracker, appears in your PR within approximately **1 minute** of triggering the workflow. Full execution and reporting typically completes within minutes, depending on test volume and complexity.
 :::
 
 ---
 
 ## Live PR Updates, Step by Step
 
-From the moment you trigger the workflow, KaneAI posts real-time updates directly in your pull request. Every phase — from analysis through execution to reporting — is visible without leaving GitHub. Here is what happens at each stage.
+From the moment you trigger the workflow, KaneAI posts real-time updates directly in your pull request. Every phase, from analysis through execution to reporting, is visible without leaving GitHub. Here is what happens at each stage.
 
 #### Step 1: Real-Time Progress Tracker
 
@@ -335,14 +335,14 @@ As soon as the workflow begins, KaneAI posts a comprehensive progress tracker co
 - **Test Run Management**: Execution status, including configuration, triggering, monitoring, and completion
 - **Reporting Status**: Final report generation and PR approval recommendation
 
-The tracker automatically updates as each stage completes — no manual refreshes required.
+The tracker automatically updates as each stage completes, no manual refreshes required.
 
 <img loading="lazy" src={require('../assets/images/kaneai-github-app/2-progress-tracker.png').default} alt="KaneAI Progress Tracker" className="doc_img"/>
 
 
 #### Step 2: Automated AI Test Authoring
 
-Once KaneAI completes test generation, a detailed comment lists every test case that was created. These are not generic tests — they reflect the specific code changes in your PR and your application's business context.
+Once KaneAI completes test generation, a detailed comment lists every test case that was created. These are not generic tests. They reflect the specific code changes in your PR and your application's business context.
 
 Each entry includes:
 
@@ -359,13 +359,13 @@ This comment updates dynamically as test authoring progresses, so you can monito
 <img loading="lazy" src={require('../assets/images/kaneai-github-app/3-test-cases-generated.png').default} alt="AI Generated Test Cases" className="doc_img"/>
 
 
-#### Step 3: Smart Intelligence — Similar Test Detection
+#### Step 3: Smart Intelligence (Similar Test Detection)
 
 KaneAI does not rely solely on newly generated tests. It scans your existing test inventory in <BrandName /> Test Manager to find semantically similar test cases that are relevant to the PR changes. These existing tests are added on top of the newly generated test cases into the test run for execution on HyperExecute. This is **Smart Intelligence** at work.
 
-- **Maximizes coverage** — Combines AI-generated tests with proven existing test cases, ensuring both new and established scenarios are validated in a single run.
-- **Leverages your test library** — Your team's existing test cases become active participants in every PR validation, not just historical records.
-- **Builds institutional knowledge** — Every test run enriches the system's understanding of your project, making future test suggestions progressively more accurate.
+- **Maximizes coverage**: Combines AI-generated tests with proven existing test cases, ensuring both new and established scenarios are validated in a single run.
+- **Leverages your test library**: Your team's existing test cases become active participants in every PR validation, not just historical records.
+- **Builds institutional knowledge**: Every test run enriches the system's understanding of your project, making future test suggestions progressively more accurate.
 
 <img loading="lazy" src={require('../assets/images/kaneai-github-app/4-similar-test-cases.png').default} alt="Semantically Similar Test Cases" className="doc_img"/>
 
@@ -378,7 +378,7 @@ When test execution begins, a dedicated comment provides live status updates dir
 - **Real-Time Execution Status**: Live updates as tests run, including pass/fail counts and completion percentage
 - **HyperExecute Dashboard Link**: Direct access to detailed logs, screenshots, video recordings, and network traces
 
-Tests run in parallel across browsers, devices, and operating systems on <BrandName />'s HyperExecute infrastructure — delivering results at scale without queuing delays.
+Tests run in parallel across browsers, devices, and operating systems on <BrandName />'s HyperExecute infrastructure, delivering results at scale without queuing delays.
 
 :::note
 Test run link in this comment can be accessed by any user in your organization who has <BrandName /> Test Manager access.
@@ -405,7 +405,7 @@ For any failing test, KaneAI performs automated **Root Cause Analysis (RCA)** by
 - Network request logs and timing
 - Stack traces and error messages
 
-The RCA summary is posted directly in your PR, along with a clear recommendation — approve, request changes, or investigate further. Your team gets a readable diagnosis, not a raw stack dump.
+The RCA summary is posted directly in your PR, along with a clear recommendation: approve, request changes, or investigate further. Your team gets a readable diagnosis, not a raw stack dump.
 
 :::note
 Test run link in this comment can be accessed by any user in your organization who has <BrandName /> Test Manager access.
@@ -420,10 +420,10 @@ Test run link in this comment can be accessed by any user in your organization w
 
 The <BrandName /> Cloud GitHub App eliminates the gap between code change and validated confidence. Instead of treating testing as a separate phase that happens after development, every pull request becomes a self-validating artifact.
 
-- **Automated AI Test Authoring** — KaneAI handles test design, script generation, and execution. Your team reviews results, not writes boilerplate.
-- **Smart Intelligence** — AI finds existing test cases semantically relevant to your PR changes and adds them alongside newly generated tests, maximizing coverage with every validation run.
-- **Seamless Execution** — Tests run automatically inside your PR workflow. Developers, QA engineers, and stakeholders all see the same information in the same place — no context switching required.
-- **In-Depth Insights** — AI Root Cause Analysis transforms cryptic test failures into actionable diagnoses with recommended fixes.
+- **Automated AI Test Authoring**: KaneAI handles test design, script generation, and execution. Your team reviews results, not writes boilerplate.
+- **Smart Intelligence**: AI finds existing test cases semantically relevant to your PR changes and adds them alongside newly generated tests, maximizing coverage with every validation run.
+- **Seamless Execution**: Tests run automatically inside your PR workflow. Developers, QA engineers, and stakeholders all see the same information in the same place, no context switching required.
+- **In-Depth Insights**: AI Root Cause Analysis transforms cryptic test failures into actionable diagnoses with recommended fixes.
 
 :::note
 Every test run, result, and AI recommendation is permanently recorded in your PR history, providing a complete audit trail for compliance and retrospective analysis.
@@ -433,7 +433,7 @@ Every test run, result, and AI recommendation is permanently recorded in your PR
 
 ## Video Walkthrough
 
-Watch the video below for a complete walkthrough of the <BrandName /> Cloud GitHub App in action — from installation to AI-powered test generation and reporting.
+Watch the video below for a complete walkthrough of the <BrandName /> Cloud GitHub App in action, from installation to AI-powered test generation and reporting.
 
 <div className="ytframe">
 <div className="youtube" data-embed="GTiqj7FFWfg" data-loading-attribute="eager">

--- a/docs/kaneai-hyperexecute-test-run-execution.md
+++ b/docs/kaneai-hyperexecute-test-run-execution.md
@@ -125,9 +125,9 @@ Before clicking **Execute**, you can optionally click **Advanced Configurations*
 | **App Profiling** | Enable app performance metrics tracking for native mobile app tests. See [App Performance Analytics](/support/docs/appium-app-performance-analytics/) for details. |
 | **Android App ID** | Specify an Android app ID (`lt://<APP_ID>`) to override the existing app in the test instance configuration. |
 | **iOS App ID** | Specify an iOS app ID (`lt://<APP_ID>`) to override the existing app in the test instance configuration. |
-| **Visual Regression** | Add visual testing configuration — select browsers, viewports, devices, and orientation. See [Visual Testing with SmartUI](/support/docs/kaneai-smartui-visual-testing/) for details. |
+| **Visual Regression** | Add visual testing configuration: select browsers, viewports, devices, and orientation. See [Visual Testing with SmartUI](/support/docs/kaneai-smartui-visual-testing/) for details. |
 | **Accessibility** | Enable accessibility checks (WCAG 2.1 AA) with best practices and needs review options. Available for web with Chrome and Edge browsers only. May slow down execution time. |
-| **Report Enabled** | Set to true to enable report generation for the test run. Select either HTML or Extent report format — only one can be active at a time. Reports are accessible from the HyperExecute Job page after execution. See [below](#reports). |
+| **Report Enabled** | Set to true to enable report generation for the test run. Select either HTML or Extent report format. Only one can be active at a time. Reports are accessible from the HyperExecute Job page after execution. See [below](#reports). |
 | **Report Email To** | An array of email addresses to receive the test run report via email after execution. Maximum 10 email addresses. Only works when report is enabled. |
 
 :::note
@@ -136,11 +136,11 @@ Test case failure retries are supported only for code exported from **May 10, 20
 
 ### Reports
 
-Enable the **Reports** option in Advanced Configurations to generate reports for your test run. You can enable either an HTML report or an Extent report — only one can be active at a time. Reports are supported for both web and mobile test executions.
+Enable the **Reports** option in Advanced Configurations to generate reports for your test run. You can enable either an HTML report or an Extent report. Only one can be active at a time. Reports are supported for both web and mobile test executions.
 
-- **Generate HTML Report** — Toggle to **Yes** to generate an HTML report for the test run, available in the HyperExecute dashboard after execution.
-- **Generate Extent Report** — Toggle to **Yes** to generate an Extent report for the test run, available in the HyperExecute dashboard after execution.
-- **Email Addresses** — Add one or more email addresses (separated by space or enter) to receive the report via email after execution. You can add up to **10 email addresses**.
+- **Generate HTML Report**: Toggle to **Yes** to generate an HTML report for the test run, available in the HyperExecute dashboard after execution.
+- **Generate Extent Report**: Toggle to **Yes** to generate an Extent report for the test run, available in the HyperExecute dashboard after execution.
+- **Email Addresses**: Add one or more email addresses (separated by space or enter) to receive the report via email after execution. You can add up to **10 email addresses**.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/test-manager/test-plan-execute-hyperexecute/reports-advanced-config.png').default} alt="Reports option in Advanced Configurations" className="doc_img"/>
 
@@ -154,8 +154,8 @@ Once your test run execution is complete, you can access the generated HTML repo
 
 The generated HTML report includes:
 
-- **Summary** — Job metadata (job number, labels, username, build time, date), test summary with pass/fail counts and donut charts, scenario summary, task analytics, and browser-level breakdown.
-- **Test Cases** — A detailed list of all test cases with their status (pass/fail), OS, OS version, browser, duration, and links to view the test or watch the video recording.
+- **Summary**: Job metadata (job number, labels, username, build time, date), test summary with pass/fail counts and donut charts, scenario summary, task analytics, and browser-level breakdown.
+- **Test Cases**: A detailed list of all test cases with their status (pass/fail), OS, OS version, browser, duration, and links to view the test or watch the video recording.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/test-manager/test-plan-execute-hyperexecute/reports-html-summary.png').default} alt="HTML report summary page" className="doc_img"/>
 
@@ -165,8 +165,8 @@ The generated HTML report includes:
 
 The generated Extent report provides a rich interactive view of test execution results, accessible from the HyperExecute Job page. It includes:
 
-- **Dashboard** — A visual summary of the test run with pass/fail statistics and trend data.
-- **Test Details** — Step-by-step breakdown of each test case with status and screenshots.
+- **Dashboard**: A visual summary of the test run with pass/fail statistics and trend data.
+- **Test Details**: Step-by-step breakdown of each test case with status and screenshots.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/test-manager/test-plan-execute-hyperexecute/extent-report-overview.png').default} alt="Extent report dashboard overview" className="doc_img"/>
 

--- a/docs/kaneai-kb-api-testing-and-network-assertions.md
+++ b/docs/kaneai-kb-api-testing-and-network-assertions.md
@@ -3,7 +3,7 @@ id: kaneai-kb-api-testing-and-network-assertions
 title: API Testing & Network Assertions
 hide_title: false
 sidebar_label: API Testing & Network Assertions
-description: Combine API testing with UI testing in KaneAI — make API calls, assert network responses, validate backend behavior alongside frontend interactions
+description: Combine API testing with UI testing in KaneAI, make API calls, assert network responses, validate backend behavior alongside frontend interactions
 keywords:
   - testmu ai automation
   - testmu ai kaneai
@@ -43,7 +43,7 @@ import TabItem from '@theme/TabItem';
     }}
 ></script>
 
-KaneAI isn't just a UI testing tool — it also supports API testing and network-level assertions, allowing you to validate both frontend behavior and backend responses in a single test flow. This is critical for scenarios where the UI depends on API data, or where you need to verify that the correct API calls are being made behind the scenes.
+KaneAI isn't just a UI testing tool. It also supports API testing and network-level assertions, allowing you to validate both frontend behavior and backend responses in a single test flow. This is critical for scenarios where the UI depends on API data, or where you need to verify that the correct API calls are being made behind the scenes.
 
 ## API Testing in KaneAI
 
@@ -53,7 +53,7 @@ You can add API calls to your test using the `/` (slash) command:
 
 1. Type `/` in the input field
 2. Select **API** from the options
-3. Paste your **curl command** — KaneAI will auto-populate all request details (URL, method, headers, body)
+3. Paste your **curl command**. KaneAI will auto-populate all request details (URL, method, headers, body)
 4. Click **Validate** to execute the API and see the response
 5. If the response is successful (2xx), click **Add to Test** to include it as a test step
 
@@ -131,7 +131,7 @@ assert the email field shows {{api_user.response.email}}
 
 ## Network Logs Assertions
 
-The **Network Logs Assertions** feature lets you validate actual network calls that your application makes during a test session. This is different from making your own API calls — it captures what the app itself is doing behind the scenes.
+The **Network Logs Assertions** feature lets you validate actual network calls that your application makes during a test session. This is different from making your own API calls. It captures what the app itself is doing behind the scenes.
 
 ### How It Works
 
@@ -140,7 +140,7 @@ The **Network Logs Assertions** feature lets you validate actual network calls t
 3. Filter by **Status Code** (200, 404, 500, etc.) or **HTTP Method** (GET, POST, etc.)
 4. Select the specific request you want to assert on
 5. Choose which **request headers**, **request body**, or **response body** keys to validate
-6. Click **Add Assertion** — all chosen values are validated in a single step
+6. Click **Add Assertion**. All chosen values are validated in a single step
 
 ### Accessing Network Data as Variables
 

--- a/docs/kaneai-kb-assertions-and-validation.md
+++ b/docs/kaneai-kb-assertions-and-validation.md
@@ -85,7 +85,7 @@ assert the green checkmark icon appears next to "Verified"
 ```
 
 :::warning
-Visual assertions rely on screenshots. Elements smaller than 12×12 pixels may not be detected reliably. Avoid asserting on exact hex colors — use descriptive colors instead.
+Visual assertions rely on screenshots. Elements smaller than 12×12 pixels may not be detected reliably. Avoid asserting on exact hex colors. Use descriptive colors instead.
 :::
 
 ### URL & Browser State Assertions
@@ -140,8 +140,8 @@ Verify the interactive state of UI elements using natural language.
 
 :::warning Present vs. Visible
 These two assertions behave differently when an element is not found:
-- **"Assert element is hidden"** — Element must exist in the DOM but not be displayed. Returns an **error** if the element is not found at all.
-- **"Assert element is not present"** — Element does not exist in the DOM. Returns **pass** if the element is not found.
+- **"Assert element is hidden"**: Element must exist in the DOM but not be displayed. Returns an **error** if the element is not found at all.
+- **"Assert element is not present"**: Element does not exist in the DOM. Returns **pass** if the element is not found.
 :::
 
 ### DOM Attribute Assertions
@@ -193,7 +193,7 @@ CSS values are automatically normalized before comparison:
 - **Font families:** Surrounding quotes are stripped.
 - **Whitespace:** Extra whitespace is collapsed.
 
-Named color normalization is exact-match only — "red" maps to `rgb(255, 0, 0)`, but shades like `#d10000` will **not** match "red". Use exact RGB values for precision.
+Named color normalization is exact-match only: "red" maps to `rgb(255, 0, 0)`, but shades like `#d10000` will **not** match "red". Use exact RGB values for precision.
 :::
 
 ### Supported Operators
@@ -234,7 +234,7 @@ Negation is supported across all assertion types using "NOT", "is not", "isn't",
 | Good Assertion | Bad Assertion | Why |
 |---|---|---|
 | `assert text "Submit" on the form footer is visible` | `assert that the submit button works and the layout is correct` | Combines multiple concerns; "works" is vague |
-| `assert the textbox contains the exact value "heading1"` | `assert the textbox has heading` | "heading" is ambiguous — which heading? |
+| `assert the textbox contains the exact value "heading1"` | `assert the textbox has heading` | "heading" is ambiguous, which heading? |
 | `assert the TestMu logo is visible` | `assert 3 search results are shown` (as a visual assertion) | Count assertions need text-based evidence, not visual |
 | `assert "Error" is not visible on the page` | `assert there are no errors` | Too vague; specify what kind of error |
 

--- a/docs/kaneai-kb-authentication-and-session-management.md
+++ b/docs/kaneai-kb-authentication-and-session-management.md
@@ -167,7 +167,7 @@ assert "Welcome, Admin" is visible
 ```
 
 :::note
-The `{{totp}}` smart variable generates a time-based 6-digit code based on the registered secret key. KaneAI calculates the correct code at the moment the step executes, so you get a valid code for each step run. Since TOTP codes refresh every 30 seconds, ensure that the step entering the code and the step submitting it execute in quick succession — avoid placing long waits between them.
+The `{{totp}}` smart variable generates a time-based 6-digit code based on the registered secret key. KaneAI calculates the correct code at the moment the step executes, so you get a valid code for each step run. Since TOTP codes refresh every 30 seconds, ensure that the step entering the code and the step submitting it execute in quick succession. Avoid placing long waits between them.
 :::
 
 ### TOTP on Mobile

--- a/docs/kaneai-kb-dynamic-content-waits-and-page-state.md
+++ b/docs/kaneai-kb-dynamic-content-waits-and-page-state.md
@@ -43,7 +43,7 @@ import TabItem from '@theme/TabItem';
     }}
 ></script>
 
-Modern web applications are heavily asynchronous — data loads from APIs, pages render progressively, notifications pop up and disappear, and content appears based on user interaction. This guide teaches you how to handle these dynamic behaviors reliably in KaneAI tests.
+Modern web applications are heavily asynchronous: data loads from APIs, pages render progressively, notifications pop up and disappear, and content appears based on user interaction. This guide teaches you how to handle these dynamic behaviors reliably in KaneAI tests.
 
 ## Understanding Waits in KaneAI
 
@@ -88,7 +88,7 @@ For individual steps that need more time, set a custom timeout via the step menu
 - Waiting for third-party payment gateways to respond
 
 :::tip Recommendation
-Prefer **custom step timeout** over explicit waits when you're waiting for a specific element to appear. Custom timeouts are dynamic — they proceed as soon as the element is ready, while explicit waits always wait the full duration.
+Prefer **custom step timeout** over explicit waits when you're waiting for a specific element to appear. Custom timeouts are dynamic: they proceed as soon as the element is ready, while explicit waits always wait the full duration.
 :::
 
 :::note Supported platforms

--- a/docs/kaneai-kb-finding-and-interacting-with-elements.md
+++ b/docs/kaneai-kb-finding-and-interacting-with-elements.md
@@ -49,11 +49,11 @@ KaneAI converts natural language instructions into automation actions by identif
 
 KaneAI uses a combination of signals to locate elements:
 
-- **Text content** — visible labels, button text, placeholder text
-- **Element type** — button, link, input field, dropdown, checkbox
-- **Position on page** — top, bottom, left sidebar, inside a specific section
-- **Visual appearance** — color, size, icons
-- **Accessibility attributes** — aria-labels, roles, alt text
+- **Text content**: visible labels, button text, placeholder text
+- **Element type**: button, link, input field, dropdown, checkbox
+- **Position on page**: top, bottom, left sidebar, inside a specific section
+- **Visual appearance**: color, size, icons
+- **Accessibility attributes**: aria-labels, roles, alt text
 
 The best instructions combine **what the element is** (type) with **how to identify it** (text or position).
 
@@ -118,7 +118,7 @@ click "Save" inside the modal dialog
 Your page shows a grid of products, each with an "Add to Cart" button.
 
 :::note Bad approach
-`click on Add to Cart` — KaneAI won't know which product you mean.
+`click on Add to Cart`. KaneAI won't know which product you mean.
 :::
 
 :::tip Good approaches
@@ -239,7 +239,7 @@ assert tooltip text "Total revenue for the fiscal year" is visible
 
 ## Drag and Drop
 
-KaneAI supports drag-and-drop interactions on **Desktop Web, Android apps, iOS apps, and Mobile Web** — for sortable lists, kanban boards, sliders, payment confirmation gestures, and similar UI patterns.
+KaneAI supports drag-and-drop interactions on **Desktop Web, Android apps, iOS apps, and Mobile Web**, for sortable lists, kanban boards, sliders, payment confirmation gestures, and similar UI patterns.
 
 ```
 drag "Task: Fix Bug" and drop it on the "In Progress" column
@@ -247,7 +247,7 @@ drag the first item and drop it below the third item in the list
 drag "Card A" to "Column B"
 ```
 
-Use **Manual Interaction** to capture sliders, slide-to-confirm gestures, and other dynamic-target drags that NL cannot resolve reliably. Manual recording is available on Desktop Web, Android, and iOS — Mobile Web is **NL-only**.
+Use **Manual Interaction** to capture sliders, slide-to-confirm gestures, and other dynamic-target drags that NL cannot resolve reliably. Manual recording is available on Desktop Web, Android, and iOS. Mobile Web is **NL-only**.
 
 :::info
 See the [Drag and Drop](/support/docs/kane-ai-drag-drop/) guide for the full platform matrix, gesture classification rules, and replay behavior.
@@ -276,9 +276,9 @@ See the [JS Snippets & Workarounds](/support/docs/kaneai-kb-js-snippets-and-work
 | Action | Example Instructions |
 |---|---|
 | **Click** | `click on the "Submit" button` |
-| **Double / N-Click** | `double click the title` , `click the button 5 times` — see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
-| **Right Click** | `right click on the file row` (web only) — see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
-| **Long Press** | `long press the menu icon for 3 seconds` — see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
+| **Double / N-Click** | `double click the title` , `click the button 5 times`, see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
+| **Right Click** | `right click on the file row` (web only), see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
+| **Long Press** | `long press the menu icon for 3 seconds`, see [Click Interactions](/support/docs/kane-ai-click-interactions/) |
 | **Type** | `type "hello world" in the search input` |
 | **Clear** | `clear the email input field` |
 | **Hover** | `hover on the "Products" menu` |

--- a/docs/kaneai-kb-forms-inputs-and-data-entry.md
+++ b/docs/kaneai-kb-forms-inputs-and-data-entry.md
@@ -43,7 +43,7 @@ import TabItem from '@theme/TabItem';
     }}
 ></script>
 
-Forms are at the heart of most web applications — login pages, registration flows, checkout processes, search filters, and admin panels. This guide covers how to handle every type of form element in KaneAI with real-world testing scenarios.
+Forms are at the heart of most web applications: login pages, registration flows, checkout processes, search filters, and admin panels. This guide covers how to handle every type of form element in KaneAI with real-world testing scenarios.
 
 ## Text Input Fields
 
@@ -232,7 +232,7 @@ enter OTP "567890"
 ```
 
 :::warning
-Do **not** try to type into each OTP box individually (e.g., `type "1" in first box, type "2" in second box`). Use the `OTP` keyword as a single instruction — KaneAI handles the per-box distribution automatically.
+Do **not** try to type into each OTP box individually (e.g., `type "1" in first box, type "2" in second box`). Use the `OTP` keyword as a single instruction. KaneAI handles the per-box distribution automatically.
 :::
 
 ### Scenario: Login with OTP Verification

--- a/docs/kaneai-kb-js-snippets-and-workarounds.md
+++ b/docs/kaneai-kb-js-snippets-and-workarounds.md
@@ -43,7 +43,7 @@ import TabItem from '@theme/TabItem';
     }}
 ></script>
 
-KaneAI's natural language engine handles the vast majority of web testing scenarios. However, some interactions require direct DOM manipulation or precise programmatic control that natural language can't reliably express. For these cases, KaneAI provides **JS Snippets** — the ability to execute JavaScript code directly on the page.
+KaneAI's natural language engine handles the vast majority of web testing scenarios. However, some interactions require direct DOM manipulation or precise programmatic control that natural language can't reliably express. For these cases, KaneAI provides **JS Snippets**: the ability to execute JavaScript code directly on the page.
 
 This guide is organized by common QA scenario, showing you **when** natural language falls short and **exactly what JS snippet** to use as a workaround.
 
@@ -132,7 +132,7 @@ if (lowercase === 'welcome to dashboard') {
 
 ```javascript
 const orderText = document.querySelector('.order-id').textContent;
-// Text is "Order #12345" — extract just the number
+// Text is "Order #12345", extract just the number
 const orderId = orderText.replace('Order #', '');
 if (orderId.length === 5 && !isNaN(orderId)) {
   return 'PASS: Order ID is valid: ' + orderId;

--- a/docs/kaneai-kb-knowledge-base-index.md
+++ b/docs/kaneai-kb-knowledge-base-index.md
@@ -58,7 +58,7 @@ The KaneAI Knowledge Base is your go-to resource for writing effective test case
 
 ## Authoring Guides
 
-Start here to learn how to write reliable test instructions for any scenario — from finding elements on the page to handling complex form interactions.
+Start here to learn how to write reliable test instructions for any scenario, from finding elements on the page to handling complex form interactions.
 
 <div className="support_main">
   <a href="/support/docs/kaneai-kb-finding-and-interacting-with-elements/">
@@ -92,7 +92,7 @@ Start here to learn how to write reliable test instructions for any scenario —
   <a href="/support/docs/kaneai-kb-mobile-app-testing-patterns/">
     <div className="support_inners">
       <h3>Mobile Patterns</h3>
-      <p>Android & iOS specific patterns — keyboard handling, OTP fields, native pickers, gestures, deep links, permission dialogs, and spannable text.</p>
+      <p>Android & iOS specific patterns: keyboard handling, OTP fields, native pickers, gestures, deep links, permission dialogs, and spannable text.</p>
     </div>
   </a>
 </div>
@@ -119,14 +119,14 @@ Guides for complex testing scenarios involving authentication, API validation, a
   <a href="/support/docs/kaneai-kb-js-snippets-and-workarounds/">
     <div className="support_inners">
       <h3>JS Workarounds</h3>
-      <p>When natural language isn't enough — JS snippets for date pickers, CSS validation, string manipulation, table cells, and more.</p>
+      <p>When natural language isn't enough: JS snippets for date pickers, CSS validation, string manipulation, table cells, and more.</p>
     </div>
   </a>
 
   <a href="/support/docs/kaneai-failure-conditions/">
     <div className="support_inners">
       <h3>Failure Conditions</h3>
-      <p>Configure how assertion failures behave — fail immediately, fail and continue, or warn and continue. Set defaults at organization or step level.</p>
+      <p>Configure how assertion failures behave: fail immediately, fail and continue, or warn and continue. Set defaults at organization or step level.</p>
     </div>
   </a>
 </div>
@@ -178,7 +178,7 @@ Manage dynamic data, secrets, and parameterized test inputs.
   <a href="/support/docs/kane-ai-command-guide/">
     <div className="support_inners">
       <h3>Command Types</h3>
-      <p>Complete reference of all supported KaneAI commands — navigation, clicks, typing, waits, tab management, scrolling, assertions, conditional logic, and queries.</p>
+      <p>Complete reference of all supported KaneAI commands: navigation, clicks, typing, waits, tab management, scrolling, assertions, conditional logic, and queries.</p>
     </div>
   </a>
 
@@ -201,11 +201,11 @@ Manage dynamic data, secrets, and parameterized test inputs.
 
 New to KaneAI? Here's the recommended reading order:
 
-1. **[Author Your First Desktop Browser Test](/support/docs/author-your-first-desktop-browser-test/)** — Get started by authoring your first desktop browser test
-2. **[Author Your First Mobile Browser Test](/support/docs/author-your-first-mobile-browser-test/)** — Learn to author mobile browser tests with device selection and configuration
-3. **[Author Your First Mobile App Test](/support/docs/author-your-first-mobile-app-test/)** — Build your first mobile app test with app upload and device configuration
-4. **[Element Interactions](/support/docs/kaneai-kb-finding-and-interacting-with-elements/)** — Learn how to describe elements so KaneAI can find them reliably
-5. **[Forms & Inputs](/support/docs/kaneai-kb-forms-inputs-and-data-entry/)** — Handle every type of form element
-6. **[Assertions Guide](/support/docs/kaneai-kb-assertions-and-validation/)** — Verify your app works correctly
-7. **[Waits & Timing](/support/docs/kaneai-kb-dynamic-content-waits-and-page-state/)** — Handle async behavior and timing
-8. **[JS Workarounds](/support/docs/kaneai-kb-js-snippets-and-workarounds/)** — When natural language isn't enough
+1. **[Author Your First Desktop Browser Test](/support/docs/author-your-first-desktop-browser-test/)**: Get started by authoring your first desktop browser test
+2. **[Author Your First Mobile Browser Test](/support/docs/author-your-first-mobile-browser-test/)**: Learn to author mobile browser tests with device selection and configuration
+3. **[Author Your First Mobile App Test](/support/docs/author-your-first-mobile-app-test/)**: Build your first mobile app test with app upload and device configuration
+4. **[Element Interactions](/support/docs/kaneai-kb-finding-and-interacting-with-elements/)**: Learn how to describe elements so KaneAI can find them reliably
+5. **[Forms & Inputs](/support/docs/kaneai-kb-forms-inputs-and-data-entry/)**: Handle every type of form element
+6. **[Assertions Guide](/support/docs/kaneai-kb-assertions-and-validation/)**: Verify your app works correctly
+7. **[Waits & Timing](/support/docs/kaneai-kb-dynamic-content-waits-and-page-state/)**: Handle async behavior and timing
+8. **[JS Workarounds](/support/docs/kaneai-kb-js-snippets-and-workarounds/)**: When natural language isn't enough

--- a/docs/kaneai-kb-mobile-app-testing-patterns.md
+++ b/docs/kaneai-kb-mobile-app-testing-patterns.md
@@ -97,7 +97,7 @@ assert "Welcome" is visible
 
 ## OTP & PIN Fields
 
-Mobile apps frequently use individual digit boxes for OTP entry. Use the `OTP` keyword — KaneAI automatically distributes digits across the boxes.
+Mobile apps frequently use individual digit boxes for OTP entry. Use the `OTP` keyword. KaneAI automatically distributes digits across the boxes.
 
 ```
 enter OTP "123456"
@@ -121,7 +121,7 @@ assert "Phone verified" is visible
 
 ## Scrolling on Mobile
 
-Mobile scrolling works differently from web — there's no pixel-based scroll. Use count-based or directional scrolling.
+Mobile scrolling works differently from web. There's no pixel-based scroll. Use count-based or directional scrolling.
 
 ```
 scroll down 3 times
@@ -197,7 +197,7 @@ If a picker doesn't respond to natural language:
 
 ## Partially Clickable Text (Spannable Text)
 
-In mobile apps, text labels often contain partially clickable links — for example, "By signing up, you agree to our **Terms and Conditions** and **Privacy Policy**" where only "Terms and Conditions" is tappable.
+In mobile apps, text labels often contain partially clickable links, for example, "By signing up, you agree to our **Terms and Conditions** and **Privacy Policy**" where only "Terms and Conditions" is tappable.
 
 Use the `spannable text` keyword:
 
@@ -295,12 +295,12 @@ assert the profile button's background color is blue
 KaneAI supports deep links for navigating directly to specific screens in your app, bypassing the normal navigation flow using the slash command.
 
 :::tip
-Deep links are excellent for test setup — jump directly to the screen you want to test instead of navigating through the entire app flow. See [Deep Link Support](/support/docs/kane-ai-deeplink-support).
+Deep links are excellent for test setup. Jump directly to the screen you want to test instead of navigating through the entire app flow. See [Deep Link Support](/support/docs/kane-ai-deeplink-support).
 :::
 
 ## Mobile-Specific Testing Scenarios
 
-### Scenario: E-Commerce App — Browse and Purchase
+### Scenario: E-Commerce App - Browse and Purchase
 
 ```
 -- Handle initial permissions --
@@ -329,7 +329,7 @@ assert "Wireless Earbuds" is visible in the cart
 click on "Checkout" button
 ```
 
-### Scenario: Banking App — Check Balance with Biometric
+### Scenario: Banking App - Check Balance with Biometric
 
 ```
 -- App launches with biometric authentication enabled from advanced settings --
@@ -349,7 +349,7 @@ wait for 2 seconds
 assert "Recent Transactions" section is visible
 ```
 
-### Scenario: Social Media App — Post with Image
+### Scenario: Social Media App - Post with Image
 
 ```
 click on the "New Post" button

--- a/docs/kaneai-manual-interaction.md
+++ b/docs/kaneai-manual-interaction.md
@@ -91,7 +91,7 @@ While you are in a Manual Interaction session, you can temporarily pause recordi
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/manual-interaction/pause-recording-confirmation.png').default} alt="Pause Recording confirmation dialog" className="doc_img img_center"/>
 
-4. Interact with the application freely. Pages load, forms accept input, and navigation works as expected, but the step list stops growing — the session transitions to Draft state.
+4. Interact with the application freely. Pages load, forms accept input, and navigation works as expected, but the step list stops growing. The session transitions to Draft state.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/manual-interaction/pause-recording-draft-state.png').default} alt="Manual Interaction session in the draft state with the paused indicator and Start recording control" className="doc_img img_center"/>
 
@@ -101,7 +101,7 @@ While you are in a Manual Interaction session, you can temporarily pause recordi
 
 **What to expect while paused**
 
-- The application is fully interactable — only the recorder is paused.
+- The application is fully interactable. Only the recorder is paused.
 - The step list stays exactly as it was at the moment you paused.
 
 
@@ -297,7 +297,7 @@ Sliders are often easier to handle using Manual Interaction rather than describi
 - Always validate the outcome using an assertion rather than relying only on the recorded movement.
 
 ### Use Case 6: Reaching a setup state without recording it
-This use case applies when you need to navigate your app to a specific starting point — for example, logging in, accepting a cookie banner, or opening a particular screen — but you do not want any of those preparatory steps to appear in your test.
+This use case applies when you need to navigate your app to a specific starting point (for example, logging in, accepting a cookie banner, or opening a particular screen), but you do not want any of those preparatory steps to appear in your test.
 
 **Steps:**
 
@@ -345,7 +345,7 @@ System level popups are not supported through Manual Interaction. These flows ne
 After turning off Manual Interaction, give the application a moment to stabilize before adding new steps or assertions. This helps avoid inconsistencies in recorded steps.
 
 ### My actions stopped getting recorded mid-session
-Check whether recording is paused. When Pause Recording is active, the session is in a draft state — your interactions affect the application but are not captured as test steps. Click Start recording in the Manual Interaction toolbar to resume.
+Check whether recording is paused. When Pause Recording is active, the session is in a draft state. Your interactions affect the application but are not captured as test steps. Click Start recording in the Manual Interaction toolbar to resume.
 
 
 

--- a/docs/kaneai-modules-versions-and-enhancement.md
+++ b/docs/kaneai-modules-versions-and-enhancement.md
@@ -3,7 +3,7 @@ id: kaneai-modules-versions-and-enhancement
 title: Module Versioning and Enhancements
 hide_title: false
 sidebar_label: Versioning and Enhancements
-description: Learn how module versioning works in KaneAI — track changes, compare versions, and revert to previous versions of your test modules.
+description: Learn how module versioning works in KaneAI, track changes, compare versions, and revert to previous versions of your test modules.
 keywords:
   - module versioning
   - version history
@@ -55,14 +55,14 @@ For an overview of creating, using, and managing modules, see [Modules](/support
 
 ## How Versioning Works
 
-When you edit an existing module — for example, by adding, removing, or modifying a test step — KaneAI automatically increments the version number (e.g., from 1.1 to 1.2). You do not need to manually create versions.
+When you edit an existing module (for example, by adding, removing, or modifying a test step), KaneAI automatically increments the version number (e.g., from 1.1 to 1.2). You do not need to manually create versions.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/modules-versioning/image8.png').default} alt="version-increment" className="doc_img img_center"/>
 
 After a new version is created, test cases that use the module can either:
 
-- **Accept the new version** — Update the test case to use the latest module version
-- **Continue using the current version** — Keep the existing version without changes
+- **Accept the new version**: Update the test case to use the latest module version
+- **Continue using the current version**: Keep the existing version without changes
 
 <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/modules-versioning/image9.png').default} alt="version-selection" className="doc_img img_center"/>
 
@@ -91,7 +91,7 @@ You can compare any two versions of a module to see exactly what changed between
 
 1. Open the module and navigate to the **Version History** section.
 2. Select the two versions you want to compare.
-3. Review the differences — added, removed, or modified steps are highlighted.
+3. Review the differences: added, removed, or modified steps are highlighted.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/modules-versioning/image3.png').default} alt="compare-versions" className="doc_img img_center"/>
 
@@ -123,5 +123,5 @@ From this tab you can navigate directly to individual test case summary pages.
 
 ## Related Guides
 
-- [Modules](/support/docs/kane-ai-modules/) — Create, use, and manage modules
-- [Bulk Module Update](/support/docs/kaneai-bulk-module-update/) — Update a module version across multiple test cases in one action
+- [Modules](/support/docs/kane-ai-modules/): Create, use, and manage modules
+- [Bulk Module Update](/support/docs/kaneai-bulk-module-update/): Update a module version across multiple test cases in one action

--- a/docs/kaneai-scroll-until-mobile.md
+++ b/docs/kaneai-scroll-until-mobile.md
@@ -111,7 +111,7 @@ Please be aware of the following constraints in the current version.
 ### Mobile App Authoring
 
 :::tip Now Supported
-Mobile app authoring now supports **horizontal scrolling** and **scrolling inside nested containers** (element scrolling). You can scroll left or right — for example inside carousels — and scroll within specific container elements such as dropdowns, lists, and subsections instead of only the main viewport.
+Mobile app authoring now supports **horizontal scrolling** and **scrolling inside nested containers** (element scrolling). You can scroll left or right, for example inside carousels, and scroll within specific container elements such as dropdowns, lists, and subsections instead of only the main viewport.
 :::
 
 - **Scroll Limit**:  

--- a/docs/kaneai-sequential-test-runs.md
+++ b/docs/kaneai-sequential-test-runs.md
@@ -43,7 +43,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-Sequential test runs let you execute dependent test cases in a specific order. Unlike parallel execution, where test cases run independently and concurrently, sequential execution ensures each test case completes before the next one begins. This is useful when test cases share state or depend on the outcome of a previous test — for example, a login test that must run before an account settings test.
+Sequential test runs let you execute dependent test cases in a specific order. Unlike parallel execution, where test cases run independently and concurrently, sequential execution ensures each test case completes before the next one begins. This is useful when test cases share state or depend on the outcome of a previous test, for example, a login test that must run before an account settings test.
 
 ## Prerequisites
 
@@ -67,7 +67,7 @@ Parameterized test cases must use the default dataset with single values when ru
 
 ### Step 2: Configure for a Single Platform
 
-For a **single-platform sequential run** (e.g., desktop web only), you can select multiple configurations at a global level. For example, you can run the same sequence on both Linux with Chrome 137 and Linux with Firefox — a separate sequential run is created for each configuration.
+For a **single-platform sequential run** (e.g., desktop web only), you can select multiple configurations at a global level. For example, you can run the same sequence on both Linux with Chrome 137 and Linux with Firefox. A separate sequential run is created for each configuration.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/test-manager/sequential-test-runs/image2.png').default} alt="single-platform-configuration" className="doc_img"/>
 
@@ -79,7 +79,7 @@ Click **Show execution preview** to review the test sequence before executing. T
 
 ## Multi-Platform Sequential Runs
 
-You can also configure sequential runs that span multiple platforms — for example, running a web test followed by a mobile app test. When multiple platforms are combined (desktop web, mobile browser, mobile app), the global configuration option is replaced with per-test-case configuration.
+You can also configure sequential runs that span multiple platforms, for example, running a web test followed by a mobile app test. When multiple platforms are combined (desktop web, mobile browser, mobile app), the global configuration option is replaced with per-test-case configuration.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/test-manager/sequential-test-runs/image3.png').default} alt="multi-platform-sequential-test-cases" className="doc_img"/>
 
@@ -91,7 +91,7 @@ Assign the appropriate configuration to each test case individually. Choose conf
 
 ### Step 2: Arrange Execution Order and Preview
 
-Set the execution order based on your test dependencies. Use the execution preview to verify the sequence — for example, a web login test running first, followed by an iOS app verification test.
+Set the execution order based on your test dependencies. Use the execution preview to verify the sequence, for example, a web login test running first, followed by an iOS app verification test.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/test-manager/sequential-test-runs/image5.png').default} alt="multi-platform-execution-preview" className="doc_img"/>
 
@@ -110,7 +110,7 @@ Save and execute the test run. The test instances will run one after another in 
 | Aspect | Single-Platform Run | Multi-Platform Run |
 |---|---|---|
 | **Configurations** | Multiple global configurations allowed (one sequential run per config) | Single configuration per test case only |
-| **Global config** | Supported | Not supported — group configuration is removed when multiple platforms are added |
+| **Global config** | Supported | Not supported: group configuration is removed when multiple platforms are added |
 | **Concurrency** | One per configuration sequence | Limited to one across the entire run |
 
 ---
@@ -119,7 +119,7 @@ Save and execute the test run. The test instances will run one after another in 
 
 - **Multi-platform runs support only a single configuration per test case.** When you add platforms such as mobile browser or mobile app alongside desktop web, the global (group) configuration option is removed.
 - **Concurrency is limited to one for multi-platform sequential runs.** Tests always run one after another since they depend on execution order.
-- **Execution order must be configured carefully.** The sequence directly impacts dependent test behavior — verify the order in the execution preview before saving.
+- **Execution order must be configured carefully.** The sequence directly impacts dependent test behavior. Verify the order in the execution preview before saving.
 
 ---
 
@@ -136,6 +136,6 @@ Save and execute the test run. The test instances will run one after another in 
 
 ## Related Guides
 
-- [Execute Test Runs on HyperExecute](/support/docs/kaneai-hyperexecute-test-run-execution/) — Standard test run creation and execution
-- [Scheduled Test Runs](/support/docs/kaneai-scheduled-test-runs/) — Automate test run scheduling
-- [Test Run Configurations](/support/docs/test-runs-configurations/) — Manage browser and device configurations
+- [Execute Test Runs on HyperExecute](/support/docs/kaneai-hyperexecute-test-run-execution/): Standard test run creation and execution
+- [Scheduled Test Runs](/support/docs/kaneai-scheduled-test-runs/): Automate test run scheduling
+- [Test Run Configurations](/support/docs/test-runs-configurations/): Manage browser and device configurations

--- a/docs/kaneai-test-run-instance-view.md
+++ b/docs/kaneai-test-run-instance-view.md
@@ -94,7 +94,7 @@ Steps that include sub-actions - such as loops, conditionals, or JavaScript snip
 
 #### Auto-Heal Visibility
 
-When [Auto-Heal](/support/docs/kaneai-auto-heal/) recovers a step during execution, that step displays an **auto-heal indicator** icon next to its execution duration in the steps panel. This gives you clear, step-level visibility into exactly which steps were healed in a run — without digging through execution logs.
+When [Auto-Heal](/support/docs/kaneai-auto-heal/) recovers a step during execution, that step displays an **auto-heal indicator** icon next to its execution duration in the steps panel. This gives you clear, step-level visibility into exactly which steps were healed in a run, without digging through execution logs.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/new-test-run-instance/test-run-instance-auto-heal-step.png').default} alt="auto-heal-indicator-on-step" className="doc_img"/>
 
@@ -183,7 +183,7 @@ Click the **View tests** button in the top-right corner to open a panel listing 
 
 ## Share a Test Run Instance
 
-You can share a test run instance page publicly with stakeholders — including people who do not have a <BrandName /> account. Click the **Share** icon in the top-right corner of the instance view to open the share dialog.
+You can share a test run instance page publicly with stakeholders, including people who do not have a <BrandName /> account. Click the **Share** icon in the top-right corner of the instance view to open the share dialog.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/new-test-run-instance/test-run-instance-share.png').default} alt="share-test-run-instance" className="doc_img"/>
 
@@ -193,14 +193,14 @@ The share dialog provides the following options:
 - **Email ID(s)** - Enter one or more email addresses and click **Invite** to send the link directly, with an optional **Message** for context.
 - **Copy Link** - Copy a shareable link to the clipboard and distribute it yourself.
 
-Anyone with an active shared link can view the test run instance — including the steps, screenshots, and execution details — until the link expires.
+Anyone with an active shared link can view the test run instance (including the steps, screenshots, and execution details) until the link expires.
 
 ---
 
 ## Limitations
 
-- **Mobile Browser not supported** — The enhanced Test Run Instance view is currently not supported for Mobile Browser test executions.
-- **Applies to newly generated code only** — This view is available only for test cases whose code was generated after the feature was enabled. For older test cases, the previous automation details page will continue to be shown.
+- **Mobile Browser not supported**: The enhanced Test Run Instance view is currently not supported for Mobile Browser test executions.
+- **Applies to newly generated code only**: This view is available only for test cases whose code was generated after the feature was enabled. For older test cases, the previous automation details page will continue to be shown.
 
 ---
 

--- a/docs/kaneai-totp.md
+++ b/docs/kaneai-totp.md
@@ -43,7 +43,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 ></script>
 ## Introduction
 
-Teams often need to test SSO or MFA‑protected applications where the second factor is a six‑digit OTP. Native TOTP support in KaneAI generates those codes on the fly from the shared secret key, keeps the entire login journey inside KaneAI with identical behavior in Replay, generated code, and CI, and lets you inject the code directly into your test steps — no external scripts or servers required.
+Teams often need to test SSO or MFA‑protected applications where the second factor is a six‑digit OTP. Native TOTP support in KaneAI generates those codes on the fly from the shared secret key, keeps the entire login journey inside KaneAI with identical behavior in Replay, generated code, and CI, and lets you inject the code directly into your test steps, no external scripts or servers required.
 
 TOTP variables are now **global by default**. You create them once and reuse them across all test cases and modules in your organization.
 
@@ -67,17 +67,17 @@ TOTP variables are now **global by default**. You create them once and reuse the
 
 You can create a global TOTP variable in two ways:
 
-#### Option A — From the Variables Page
+#### Option A: From the Variables Page
 
 1. Open **Test Manager** and navigate to **Variables > TOTP Variables**.
 2. Click **+ Create new**.
 3. Enter a **Variable Name** (e.g., `sso_totp`).
-4. Enter the **TOTP Secret Key** — paste the Base32 secret directly or reference an org secret using `{{` syntax.
+4. Enter the **TOTP Secret Key**: paste the Base32 secret directly or reference an org secret using `{{` syntax.
 5. Click **Create TOTP Variable**.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/totp/create-global-totp.png').default} alt="Create TOTP Variable modal" className="doc\_img"/>
 
-#### Option B — From the Authoring Session
+#### Option B: From the Authoring Session
 
 1. Start a KaneAI authoring session and press **/**.
 2. Choose **Add TOTP Authentication Key**.
@@ -87,7 +87,7 @@ You can create a global TOTP variable in two ways:
 ### Use a TOTP Variable in Your Test
 
 1. Navigate to the OTP input field in your application.
-2. Reference the variable in your instruction — for example, "Enter `{{totp.sso_totp}}` in verify field".
+2. Reference the variable in your instruction, for example, "Enter `{{totp.sso_totp}}` in verify field".
 3. KaneAI generates and inserts the current six‑digit code automatically.
 
 ## Migrating Existing Local TOTP Variables

--- a/docs/kaneai-upload-and-download-files.md
+++ b/docs/kaneai-upload-and-download-files.md
@@ -94,7 +94,7 @@ The `FILE_` variable behavior described above applies to **Web tests**. In **App
 
 ## File Upload in App Tests
 
-File upload behaves differently in App tests than in Web tests. In a Web test, <BrandName /> creates a file variable for each upload. App tests skip this step entirely — no file variable is created, so you never reference uploaded files with double-curly-brace syntax.
+File upload behaves differently in App tests than in Web tests. In a Web test, <BrandName /> creates a file variable for each upload. App tests skip this step entirely. No file variable is created, so you never reference uploaded files with double-curly-brace syntax.
 
 ### How it works
 

--- a/docs/kaneai-variables-and-parameters.md
+++ b/docs/kaneai-variables-and-parameters.md
@@ -44,7 +44,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-In KaneAI, one of the core principles of effective test automation is the ability to manage dynamic data efficiently. Testing often requires input that changes frequently or is context-dependent, such as URLs, credentials, or specific device configurations. KaneAI offers a set of powerful tools—variables, secrets, smart variables, parameters and datasets—to simplify the process of managing and using dynamic data in your test cases. Each of these options offers unique functionality that helps you keep your tests flexible, secure, and scalable.
+In KaneAI, one of the core principles of effective test automation is the ability to manage dynamic data efficiently. Testing often requires input that changes frequently or is context-dependent, such as URLs, credentials, or specific device configurations. KaneAI offers a set of powerful tools (variables, secrets, smart variables, parameters and datasets) to simplify the process of managing and using dynamic data in your test cases. Each of these options offers unique functionality that helps you keep your tests flexible, secure, and scalable.
 
 :::tip
 All variables and parameters in KaneAI can be accessed from https://kaneai.lambdatest.com/variables

--- a/docs/kaneai-while-loops.md
+++ b/docs/kaneai-while-loops.md
@@ -54,27 +54,27 @@ This feature is being rolled out gradually. If you don't see **While Loop** in t
 
 ## How It Works
 
-1. Insert a **While Loop** block from the **/** slash command menu — this is the only entry point for adding a loop.
-2. Define the loop condition — either in natural language (default) or using the operand & operator editor.
+1. Insert a **While Loop** block from the **/** slash command menu. This is the only entry point for adding a loop.
+2. Define the loop condition, either in natural language (default) or using the operand & operator editor.
 3. Confirm the condition. The loop body opens.
-4. Add steps inside the loop body — natural language steps, modules, JavaScript, API, DB, or manual interaction.
+4. Add steps inside the loop body: natural language steps, modules, JavaScript, API, DB, or manual interaction.
 5. Click **End While** to finalize the block. Until you finalize, the loop is an authoring‑only placeholder and does not run.
 6. Once finalized, each run of the loop follows the same cycle on every iteration:
    - The condition is evaluated.
    - If the condition is **true**, the loop body runs once.
    - If the condition is **false**, the loop exits successfully and execution moves on to the next step in the test.
-7. A hard safety cap of **30 iterations per execution** prevents runaway loops — see [Max Iteration Safety Limit](#max-iteration-safety-limit).
+7. A hard safety cap of **30 iterations per execution** prevents runaway loops. See [Max Iteration Safety Limit](#max-iteration-safety-limit).
 
 
 ## Prerequisites
 
 - An active KaneAI authoring session.
-- Familiarity with [Conditional Logic (If / Else)](/support/docs/kaneai-conditional-logic/) — While Loops reuse the same condition editor.
+- Familiarity with [Conditional Logic (If / Else)](/support/docs/kaneai-conditional-logic/). While Loops reuse the same condition editor.
 - Any variables, smart variables, or dataset parameters you plan to reference in the loop condition or body.
 
 ## Step‑by‑step Guide
 
-### Step 1 — Insert a While Loop Block
+### Step 1: Insert a While Loop Block
 
 A While Loop can only be added through the **/** slash command menu.
 
@@ -87,13 +87,13 @@ A newly inserted block starts in an empty state with no condition and no body st
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/while-loops/insert-while-loop.png').default} alt="Empty While Loop block inserted into the test flow" className="doc\_img"/>
 
-### Step 2 — Define the Loop Condition
+### Step 2: Define the Loop Condition
 
 The condition editor opens in **natural language mode** by default, matching KaneAI's NL‑first authoring philosophy. You can switch to **operand & operator mode** at any time.
 
 
 
-#### Option A — Natural Language
+#### Option A: Natural Language
 
 Type your condition as a plain‑English sentence. KaneAI interprets the intent and re‑evaluates it at runtime. Examples:
 
@@ -102,11 +102,11 @@ Type your condition as a plain‑English sentence. KaneAI interprets the intent 
 - `while {{count}} is greater than 0`
 - `while {{job_status}} is not "complete"`
 
-#### Option B — Operand & Operator
+#### Option B: Operand & Operator
 
 Build the condition explicitly using a **left operand**, a **comparison operator**, and a **right operand**:
 
-1. Enter a **left operand** — this can be a variable (e.g., `{{active_count}}`), a dataset parameter (e.g., `${max_attempts}`), extracted text, or a literal value.
+1. Enter a **left operand**: this can be a variable (e.g., `{{active_count}}`), a dataset parameter (e.g., `${max_attempts}`), extracted text, or a literal value.
 2. Choose a **comparison operator** from the dropdown:
 
 | Operator | Description |
@@ -124,33 +124,33 @@ Build the condition explicitly using a **left operand**, a **comparison operator
 | `is_visible` | Target element is currently visible on the page |
 | `is_not_visible` | Target element is not currently visible on the page |
 
-3. Enter the **right operand** — a literal, variable, dataset parameter, or extracted value.
+3. Enter the **right operand**: a literal, variable, dataset parameter, or extracted value.
 
 Both operands support variables (`{{var_name}}`), dataset parameters (`${param_name}`), extracted text, and literal values.
 
 #### Confirming the Condition
 
-Confirm the condition to open the loop body. Once confirmed, the condition remains editable until the loop begins executing — you can reopen it to adjust operators, operands, or the natural‑language expression.
+Confirm the condition to open the loop body. Once confirmed, the condition remains editable until the loop begins executing. You can reopen it to adjust operators, operands, or the natural‑language expression.
 
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/while-loops/add-condition.png').default} alt="Toggle between natural language and operand & operator modes" className="doc\_img"/>
 
-### Step 3 — Add Steps Inside the Loop Body
+### Step 3: Add Steps Inside the Loop Body
 
-The loop body becomes available only after the condition is confirmed. Inside the body you get the standard KaneAI step input — the same one used in the main authoring flow — where you can type a natural‑language step or press **/** to open the slash command menu.
+The loop body becomes available only after the condition is confirmed. Inside the body you get the standard KaneAI step input, the same one used in the main authoring flow, where you can type a natural‑language step or press **/** to open the slash command menu.
 
 You can add any of the following inside a loop body:
 
-- **Natural language steps** — type your instruction in plain English.
-- **Modules** — reuse existing modules by adding them via the slash command menu.
-- **JavaScript steps** — execute custom JS for data extraction, array handling, or index management.
-- **API steps** — make API calls as part of the iteration.
-- **DB steps** — run database queries inside each iteration.
-- **Manual interaction** — perform actions directly on the browser within the loop body using the manual interaction control.
-- **If / Else blocks** — insert a conditional block inside the loop body via the slash command menu to add branching logic within iterations.
+- **Natural language steps**: type your instruction in plain English.
+- **Modules**: reuse existing modules by adding them via the slash command menu.
+- **JavaScript steps**: execute custom JS for data extraction, array handling, or index management.
+- **API steps**: make API calls as part of the iteration.
+- **DB steps**: run database queries inside each iteration.
+- **Manual interaction**: perform actions directly on the browser within the loop body using the manual interaction control.
+- **If / Else blocks**: insert a conditional block inside the loop body via the slash command menu to add branching logic within iterations.
 
 
-### Step 4 — Finalize the Loop with "End While"
+### Step 4: Finalize the Loop with "End While"
 
 When your loop body is ready, click **End While** at the bottom of the block to finalize it.
 
@@ -180,7 +180,7 @@ Every While Loop exposes a built‑in **`{{loop_counter}}`** variable inside its
 
 `{{loop_counter}}` is available to all step types inside the loop body, including natural language steps, JavaScript snippets, API and DB steps, and **element selectors**.
 
-**Example — clicking each row of a table one at a time:**
+**Example: clicking each row of a table one at a time:**
 
 > Click the row at position `{{loop_counter}}` in the bookings table
 
@@ -190,8 +190,8 @@ KaneAI substitutes the counter into the underlying element selector before it is
 
 All existing KaneAI [variables](/support/docs/kane-ai-using-variables/) and [dataset parameters](/support/docs/kane-ai-using-datasets/) are fully usable inside loop conditions and loop body steps. No special configuration is required.
 
-- **Variables** use the `{{variable_name}}` syntax — for example, `{{active_count}}`, `{{job_status}}`, or a value extracted from a previous step.
-- **Dataset parameters** use the `${parameter_name}` syntax — for example, `${max_retries}`.
+- **Variables** use the `{{variable_name}}` syntax, for example, `{{active_count}}`, `{{job_status}}`, or a value extracted from a previous step.
+- **Dataset parameters** use the `${parameter_name}` syntax, for example, `${max_retries}`.
 
 **Dynamic iteration count pattern.** You can extract a count from the page or an API response into a variable using a JavaScript step, then reference that variable in the While condition:
 
@@ -200,12 +200,12 @@ All existing KaneAI [variables](/support/docs/kane-ai-using-variables/) and [dat
 3. Add the steps you want to repeat inside the body.
 
 :::note Operand validation
-Both operands of a condition cannot be parameters at the same time. If one operand is a parameter (for example, a dataset parameter like `${max_retries}`), the other operand must be a runtime‑updated value — a local variable, a smart variable, a value read from the UI, or a literal. If both operands are parameters, KaneAI rejects the condition with the `BOTH_OPERANDS_AS_PARAMETERS` error. See [Error Messages and Troubleshooting](#error-messages-and-troubleshooting) for details.
+Both operands of a condition cannot be parameters at the same time. If one operand is a parameter (for example, a dataset parameter like `${max_retries}`), the other operand must be a runtime‑updated value: a local variable, a smart variable, a value read from the UI, or a literal. If both operands are parameters, KaneAI rejects the condition with the `BOTH_OPERANDS_AS_PARAMETERS` error. See [Error Messages and Troubleshooting](#error-messages-and-troubleshooting) for details.
 :::
 
 ## Element Presence / Absence Conditions
 
-While Loop conditions can reference the visibility of UI elements directly — useful for polling, waits, and spinner handling.
+While Loop conditions can reference the visibility of UI elements directly, useful for polling, waits, and spinner handling.
 
 - **Natural language mode:**
   - `while the loading spinner is visible`
@@ -228,11 +228,11 @@ Every While Loop is capped at a hard maximum of **30 iterations per execution**.
 
 This safety cap prevents a mis‑configured or non‑terminating condition from consuming unlimited execution time.
 
-- The maximum iteration value is **not shown** during normal authoring or execution — only the current iteration number is displayed.
+- The maximum iteration value is **not shown** during normal authoring or execution. Only the current iteration number is displayed.
 - When a loop hits the cap, execution stops and an error is reported. The error clearly indicates that termination was caused by the safety limit and not by the exit condition becoming false.
 - The underlying error code is `LOOP_MAX_LIMIT_REACHED`.
 
-Use the safety cap as a last line of defense — design your condition so the loop exits naturally well before the 30th iteration. If your scenario legitimately requires more than 30 iterations, reach out to your <BrandName /> support representative.
+Use the safety cap as a last line of defense. Design your condition so the loop exits naturally well before the 30th iteration. If your scenario legitimately requires more than 30 iterations, reach out to your <BrandName /> support representative.
 
 
 ## Common Use Cases
@@ -248,12 +248,12 @@ Use the safety cap as a last line of defense — design your condition so the lo
 - **Design for a natural exit.** Write conditions that terminate deterministically. Treat the max iteration limit as a safety net, not a control flow mechanism.
 - **Keep loop bodies small.** Extract repeated logic into a [module](/support/docs/kane-ai-modules/) and call the module inside the loop body instead of duplicating steps.
 - **Validate the body first.** Author the steps you intend to repeat outside a loop first, confirm they work, and then move them inside the While block.
-- **Use `{{loop_counter}}` for position‑based targeting.** Prefer `{{loop_counter}}` in selectors over hand‑writing `nth-of-type(…)` indexes — it keeps the intent obvious and avoids off‑by‑one errors.
+- **Use `{{loop_counter}}` for position‑based targeting.** Prefer `{{loop_counter}}` in selectors over hand‑writing `nth-of-type(…)` indexes. It keeps the intent obvious and avoids off‑by‑one errors.
 - **Extract dynamic counts into variables.** Read the number of items from the page or API into a variable first, then reference it in your condition, rather than hard‑coding an iteration count.
 
 ## Editing an Existing While Loop
 
-Once a While Loop has been finalized, you can still change it — the loop itself stays in sync automatically.
+Once a While Loop has been finalized, you can still change it. The loop itself stays in sync automatically.
 
 - **Add, remove, or reorder body steps.** Use the edit instruction action on any step inside the loop; the loop updates automatically to reflect the change.
 - **Change the condition.** Edit the While Loop step directly. The new condition applies on the next test run.
@@ -262,7 +262,7 @@ Once a While Loop has been finalized, you can still change it — the loop itsel
 
 ## Nesting Rules
 
-While Loops can contain **regular If / Else conditional blocks** inside their body, which lets you branch within each iteration. The maximum supported nesting depth is **two levels** — a While Loop containing a conditional, which in turn contains ordinary steps.
+While Loops can contain **regular If / Else conditional blocks** inside their body, which lets you branch within each iteration. The maximum supported nesting depth is **two levels**: a While Loop containing a conditional, which in turn contains ordinary steps.
 
 The following nesting patterns are **not supported**:
 
@@ -276,7 +276,7 @@ The following nesting patterns are **not supported**:
 - **Nested While Loops are not supported.** You cannot place a While Loop inside another While Loop (see [Nesting Rules](#nesting-rules)).
 - **While Loops cannot live inside conditional branches.** A While Loop cannot be placed inside an If / Else branch.
 - **No Break / Continue commands.** There is no way to exit a loop early or skip to the next iteration; structure your condition to terminate naturally.
-- **Natural language cannot create a loop.** Phrases like "repeat this 10 times" or "while the spinner is visible, do X" will not create a loop — you must use the slash command and select **While Loop**. KaneAI surfaces this as the `WHILE_NOT_SUPPORTED_VIA_NL` error.
+- **Natural language cannot create a loop.** Phrases like "repeat this 10 times" or "while the spinner is visible, do X" will not create a loop. You must use the slash command and select **While Loop**. KaneAI surfaces this as the `WHILE_NOT_SUPPORTED_VIA_NL` error.
 - **Both operands in a condition cannot be parameters at the same time.** At least one side must be a runtime‑updated value. See `BOTH_OPERANDS_AS_PARAMETERS` in [Error Messages and Troubleshooting](#error-messages-and-troubleshooting).
 - **Local variables must be defined inside the block.** If a local variable referenced inside a While block was created outside the block, KaneAI shows an error when you click **End While**.
 
@@ -314,11 +314,11 @@ Below are the user‑facing error codes you may encounter when authoring or runn
 
 > Review the loop condition and the actions being performed within the loop to ensure they are correct and will allow the loop to terminate properly.
 
-**When you see it.** KaneAI detected a condition / body combination that cannot terminate — typically a condition that is independent of anything the body changes, or a comparison that is always true.
+**When you see it.** KaneAI detected a condition / body combination that cannot terminate, typically a condition that is independent of anything the body changes, or a comparison that is always true.
 
 **How to resolve.**
 
-- Ensure the body contains at least one step that changes a value referenced by the condition — for example, increment a counter, click a control that updates the UI state, or wait for a status transition.
+- Ensure the body contains at least one step that changes a value referenced by the condition, for example, increment a counter, click a control that updates the UI state, or wait for a status transition.
 - If the condition uses constants only (e.g. `1 == 1`), rewrite it so it depends on a variable or UI state that evolves during the loop.
 
 ### 3. `BOTH_OPERANDS_AS_PARAMETERS`
@@ -331,7 +331,7 @@ Below are the user‑facing error codes you may encounter when authoring or runn
 
 > Please modify the loop condition to ensure that only one operand is a parameter.
 
-**When you see it.** Both sides of the loop condition are test parameters (for example, `${max_retries} > ${default_retries}`). Parameter values are fixed for the lifetime of a run, so such a condition cannot change between iterations — it would either be an infinite loop or never enter.
+**When you see it.** Both sides of the loop condition are test parameters (for example, `${max_retries} > ${default_retries}`). Parameter values are fixed for the lifetime of a run, so such a condition cannot change between iterations. It would either be an infinite loop or never enter.
 
 **How to resolve.** Replace one operand with a runtime‑updated value:
 
@@ -351,7 +351,7 @@ Example valid forms: `{{counter}} < ${max_retries}`, `${status} == "ready"`, `{{
 
 > Use the while loop button in slash commands to create a loop instruction.
 
-**When you see it.** You added a natural‑language step that describes a loop — for example, *"repeat until the cart is empty"*, *"while the spinner is visible, do X"*, or *"keep clicking Next"*. The natural‑language pipeline does not expand these phrases into loops.
+**When you see it.** You added a natural‑language step that describes a loop, for example, *"repeat until the cart is empty"*, *"while the spinner is visible, do X"*, or *"keep clicking Next"*. The natural‑language pipeline does not expand these phrases into loops.
 
 **How to resolve.**
 
@@ -364,15 +364,15 @@ Example valid forms: `{{counter}} < ${max_retries}`, `${status} == "ready"`, `{{
 
 ### How do I exit a While Loop early?
 
-Early exit (Break) and skip‑to‑next‑iteration (Continue) are not supported. Structure your exit condition — for example, combine it with an additional flag variable you set from inside the loop — so the loop terminates naturally on the next re‑evaluation.
+Early exit (Break) and skip‑to‑next‑iteration (Continue) are not supported. Structure your exit condition (for example, combine it with an additional flag variable you set from inside the loop) so the loop terminates naturally on the next re‑evaluation.
 
 ### Can I nest a While Loop inside another While Loop?
 
-No. Nested loops are not supported, and a While Loop cannot be placed inside an If / Else branch either. A While Loop **can** contain conditional (If / Else) blocks in its body — see [Nesting Rules](#nesting-rules). If you need multi‑level iteration, split the logic across multiple test cases or use a single loop combined with JavaScript for inner bookkeeping.
+No. Nested loops are not supported, and a While Loop cannot be placed inside an If / Else branch either. A While Loop **can** contain conditional (If / Else) blocks in its body. See [Nesting Rules](#nesting-rules). If you need multi‑level iteration, split the logic across multiple test cases or use a single loop combined with JavaScript for inner bookkeeping.
 
 ### What happens if my condition is already false on the first check?
 
-The loop body is skipped entirely — zero iterations run — and execution continues with the next step after the block.
+The loop body is skipped entirely, zero iterations run, and execution continues with the next step after the block.
 
 ### What is the maximum number of iterations allowed?
 
@@ -388,7 +388,7 @@ No. The live iteration counter is a Playground‑only view. On the Test Summary 
 
 ### Do dataset parameters and variables work inside loops?
 
-Yes. Both `{{variable}}` and `${dataset_parameter}` syntaxes are fully supported inside loop conditions and body steps with no special configuration. The only restriction is that both operands in a single condition cannot be parameters at the same time — at least one must be a runtime‑updated value such as a local variable, a smart variable, a UI‑derived value, or a literal. See the `BOTH_OPERANDS_AS_PARAMETERS` entry in [Error Messages and Troubleshooting](#error-messages-and-troubleshooting).
+Yes. Both `{{variable}}` and `${dataset_parameter}` syntaxes are fully supported inside loop conditions and body steps with no special configuration. The only restriction is that both operands in a single condition cannot be parameters at the same time. At least one must be a runtime‑updated value such as a local variable, a smart variable, a UI‑derived value, or a literal. See the `BOTH_OPERANDS_AS_PARAMETERS` entry in [Error Messages and Troubleshooting](#error-messages-and-troubleshooting).
 
 ### Why is nothing happening when I click "End While"?
 

--- a/docs/katalon-integration-with-lambdatest.md
+++ b/docs/katalon-integration-with-lambdatest.md
@@ -49,7 +49,7 @@ import { CookieTrackingSignup } from '@site/src/component/CookieTracking';
 
 [Katalon Studio](https://www.katalon.com) is an automation tool for web, API, mobile, and desktop applications testing. Katalon Studio offers a flexible automation platform that fits teams and projects of any size, for any purpose. It supports users from creating tests, execution, reports to seamless integration with the CI/CD ecosystem.
 
-Katalon Studio offers cross-platform testing — from Windows, macOS, and Linux for web automation, to Android and iOS for mobile automation. It also comes with a built-in intuitive interface for codeless automation testing and validating the UI elements of your web application.
+Katalon Studio offers cross-platform testing, from Windows, macOS, and Linux for web automation, to Android and iOS for mobile automation. It also comes with a built-in intuitive interface for codeless automation testing and validating the UI elements of your web application.
 
 This integration between <BrandName /> and Katalon Studio enables you to automate the cross browser testing process through the Selenium Grid of more than 2,000 browsers.
 

--- a/docs/katalon-integration.md
+++ b/docs/katalon-integration.md
@@ -55,7 +55,7 @@ import TabItem from '@theme/TabItem';
 
 [Katalon Studio](https://katalon.com/) is an automation tool for web, API, mobile, and desktop application testing. Katalon Studio offers a flexible automation platform that fits teams and projects of any size, for any purpose. It supports users from creating tests, execution, and reports to seamless integration with the CI/CD ecosystem.
 
-Katalon Studio offers cross-platform testing — from Windows, macOS, and Linux for web automation, to Android and iOS for mobile automation. It also comes with a built-in intuitive interface for codeless automation testing and validating the UI elements of your web application.
+Katalon Studio offers cross-platform testing, from Windows, macOS, and Linux for web automation, to Android and iOS for mobile automation. It also comes with a built-in intuitive interface for codeless automation testing and validating the UI elements of your web application.
 
 This integration between <BrandName /> and Katalon Studio enables you to automate the cross-browser testing process through the Selenium Grid of more than 2,000 real devices.
 

--- a/docs/live-debug-in-app-automation.md
+++ b/docs/live-debug-in-app-automation.md
@@ -52,7 +52,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 <RealDeviceTag value="Real Device" /> <VirtualDeviceTag value="Virtual Device" />
 ---
 
-Optimize your [app automation testing](https://www.testmuai.com/blog/mobile-app-testing-tools/) with <BrandName />'s Real Devices UI Inspector. Now access unparalleled live debugging capabilities right from the app automation dashboard, enabling direct interaction with the test device—not just viewing the script's video. 
+Optimize your [app automation testing](https://www.testmuai.com/blog/mobile-app-testing-tools/) with <BrandName />'s Real Devices UI Inspector. Now access unparalleled live debugging capabilities right from the app automation dashboard, enabling direct interaction with the test device, not just viewing the script's video. 
 
 With features like real-time navigation, detailed UI element inspection, and the ability to capture screenshots, now significantly enhance both the efficiency and effectiveness of your [automated tests](https://www.testmuai.com/automation-testing).
 

--- a/docs/manage-ai-capabilities.md
+++ b/docs/manage-ai-capabilities.md
@@ -116,7 +116,7 @@ When the toggle is set to **OFF**, the following AI features are hidden across a
 ---
 
 :::note
-- **Existing AI-generated content is preserved.** When AI is disabled, all previously AI-generated content — test cases, test steps, RCA reports, autofill values, and scenario tags — remains visible and fully editable. Only new AI invocations are blocked.
+- **Existing AI-generated content is preserved.** When AI is disabled, all previously AI-generated content (test cases, test steps, RCA reports, autofill values, and scenario tags) remains visible and fully editable. Only new AI invocations are blocked.
 - **Only Org Admins** can modify this setting. Non-admin users cannot access the Organization Settings page.
 - **The setting applies organization-wide.** All users in the organization are affected when the toggle is changed.
 :::

--- a/docs/mark-as-bug.md
+++ b/docs/mark-as-bug.md
@@ -73,7 +73,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 <img loading="lazy" src={require('../assets/images/mark_as_bug/mark-as-bug-2.webp').default} alt="Image" width="1344" height="653" className="doc_img"/>
 
-**Step 3:** Once the screenshot testing is complete, you will have all the screenshots categorized by browsers selected from your input—double-click on any screenshot you may want to validate.
+**Step 3:** Once the screenshot testing is complete, you will have all the screenshots categorized by browsers selected from your input. Double-click on any screenshot you may want to validate.
 
 <img loading="lazy" src={require('../assets/images/mark_as_bug/mark-as-bug-screenshot-3.webp').default} alt="Image" width="1344" height="653" className="doc_img"/>
 

--- a/docs/network-configurations-in-browser.md
+++ b/docs/network-configurations-in-browser.md
@@ -22,7 +22,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # Network Logs and Configurations in real devices
 
-Network logs record every network interaction during your test session, from API calls and page requests to server responses and load times. These logs are stored in HAR format, giving you a complete snapshot of **network performance** for each run. By reviewing this data, you can identify slow endpoints, troubleshoot failed requests, and validate that your app communicates with the right services—all without leaving your testing workflow.
+Network logs record every network interaction during your test session, from API calls and page requests to server responses and load times. These logs are stored in HAR format, giving you a complete snapshot of **network performance** for each run. By reviewing this data, you can identify slow endpoints, troubleshoot failed requests, and validate that your app communicates with the right services, all without leaving your testing workflow.
 
 On <BrandName />, you can enable **network configurations** to capture and analyze this traffic in real time on real devices. With flexible options such as content capture and domain-based filtering, you can focus on the most relevant network interactions while reducing noise from unrelated requests. This helps ensure faster debugging, clearer insights, and more efficient test runs.
 

--- a/docs/network-configurations-in-real-devices.md
+++ b/docs/network-configurations-in-real-devices.md
@@ -20,7 +20,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # Network Logs and Configurations in real devices
 
-Network logs record every network interaction during your test session, from API calls and page requests to server responses and load times. These logs are stored in HAR format, giving you a complete snapshot of **network performance** for each run. By reviewing this data, you can identify slow endpoints, troubleshoot failed requests, and validate that your app communicates with the right services—all without leaving your testing workflow.
+Network logs record every network interaction during your test session, from API calls and page requests to server responses and load times. These logs are stored in HAR format, giving you a complete snapshot of **network performance** for each run. By reviewing this data, you can identify slow endpoints, troubleshoot failed requests, and validate that your app communicates with the right services, all without leaving your testing workflow.
 
 On <BrandName />, you can enable **network configurations** to capture and analyze this traffic in real time on real devices. With flexible options such as content capture and domain-based filtering, you can focus on the most relevant network interactions while reducing noise from unrelated requests. This helps ensure faster debugging, clearer insights, and more efficient test runs.
 

--- a/docs/network-configurations.md
+++ b/docs/network-configurations.md
@@ -25,7 +25,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # Network Logs and Configurations
 <RealDeviceTag value="Real Device" />
-Network logs record every network interaction during your test session, from API calls and page requests to server responses and load times. These logs are stored in HAR format, giving you a complete snapshot of **network performance** for each run. By reviewing this data, you can identify slow endpoints, troubleshoot failed requests, and validate that your app communicates with the right services—all without leaving your testing workflow.
+Network logs record every network interaction during your test session, from API calls and page requests to server responses and load times. These logs are stored in HAR format, giving you a complete snapshot of **network performance** for each run. By reviewing this data, you can identify slow endpoints, troubleshoot failed requests, and validate that your app communicates with the right services, all without leaving your testing workflow.
 
 On <BrandName />, you can enable **network configurations** to capture and analyze this traffic in real time on real devices. With flexible options such as content capture and domain-based filtering, you can focus on the most relevant network interactions while reducing noise from unrelated requests. This helps ensure faster debugging, clearer insights, and more efficient test runs.
 
@@ -70,7 +70,7 @@ To enable the following you would need to pass them under `networkLogsOptions` C
 ---
 ## Managing Certificate Pinning in Network Logs
 
-Some mobile apps add an extra layer of security by using **certificate pinning** — a process where the app is hard-coded to trust only a specific certificate or public key for certain hosts. This means that whenever the app communicates with those hosts, it **verifies the server’s certificate** against its pinned copy before allowing the connection.
+Some mobile apps add an extra layer of security by using **certificate pinning**, a process where the app is hard-coded to trust only a specific certificate or public key for certain hosts. This means that whenever the app communicates with those hosts, it **verifies the server’s certificate** against its pinned copy before allowing the connection.
 
 When you enable **network logging** on <BrandName />, traffic passes through a **secure proxy** so requests and responses can be captured. For **certificate-pinned hosts**, this interception may cause the connection to fail because the certificate no longer matches exactly. To avoid such issues, you can exclude pinned hosts from being proxied by adding them to the `networkLogsExcludeHosts` capability. This ensures your tests run smoothly without breaking **secure connections**.
 

--- a/docs/one-click-migration-from-xray.md
+++ b/docs/one-click-migration-from-xray.md
@@ -45,15 +45,15 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # One Click Migration from X-Ray
 
-<BrandName /> Test Manager supports one-click migration from **X-Ray (Jira Cloud)**, allowing you to import your entire test library — including projects, test cases, folder structures, attachments, custom fields, and linked requirements — directly into Test Manager without manual data entry.
+<BrandName /> Test Manager supports one-click migration from **X-Ray (Jira Cloud)**, allowing you to import your entire test library (including projects, test cases, folder structures, attachments, custom fields, and linked requirements) directly into Test Manager without manual data entry.
 
 ## Key Benefits
 
-- **Zero manual effort** — All test cases, steps, attachments, and folder structures are automatically migrated.
-- **Handles both Manual and BDD tests** — Manual step definitions and Gherkin/BDD scenarios are both fully supported.
-- **Custom fields carried over** — Custom fields in your X-Ray tests are automatically detected and created in Test Manager.
-- **Attachments included** — File attachments are downloaded from Jira and re-uploaded to Test Manager, including step-level references.
-- **Real-time progress tracking** — A progress bar shows migration status so you know exactly where things stand.
+- **Zero manual effort**: All test cases, steps, attachments, and folder structures are automatically migrated.
+- **Handles both Manual and BDD tests**: Manual step definitions and Gherkin/BDD scenarios are both fully supported.
+- **Custom fields carried over**: Custom fields in your X-Ray tests are automatically detected and created in Test Manager.
+- **Attachments included**: File attachments are downloaded from Jira and re-uploaded to Test Manager, including step-level references.
+- **Real-time progress tracking**: A progress bar shows migration status so you know exactly where things stand.
 
 :::note
 This migration supports **X-Ray Cloud (Jira Cloud)** only. X-Ray Server and Data Center are not supported at this time.
@@ -141,7 +141,7 @@ Click **Continue**. The system validates both your Jira and X-Ray credentials in
 
 <img loading="lazy" src={require('../assets/images/xray-migration/migration-progress.png').default} alt="migration-progress" className="doc_img" width="1366" height="629"/>
 
-- You can navigate away from the page and continue other work — the migration continues in the background. Once the migration is complete, you will receive an email notification.
+- You can navigate away from the page and continue other work. The migration continues in the background. Once the migration is complete, you will receive an email notification.
 
 <img loading="lazy" src={require('../assets/images/xray-migration/email-completion.png').default} alt="email-completion-notification" className="doc_img" width="1366" height="629"/>
 
@@ -170,7 +170,7 @@ The following entities and data are transferred from X-Ray to Test Manager durin
 | **Manual Test Steps** | Each step's **Step Description** and **Expected Result** are migrated directly. Step ordering is preserved. |
 | **BDD/Gherkin Scenarios** | Full Gherkin scenario text is extracted and stored under the BDD Scenarios template. |
 | **Attachments** | Both test case-level and test step-level attachments are downloaded and re-uploaded to Test Manager. |
-| **Rich Text Fields** | Rich text content — including embedded screenshots, tables, lists, and other supported formatting — is preserved. |
+| **Rich Text Fields** | Rich text content (including embedded screenshots, tables, lists, and other supported formatting) is preserved. |
 | **Custom Fields** | Custom fields are automatically detected in X-Ray and created in Test Manager with matching names. |
 | **Linked Issues / Requirements** | Jira issue links and requirement associations are preserved. Requires [Jira integration](https://www.testmuai.com/support/docs/link-jira-issues-with-test-manager/) to be configured. |
 | **X-Ray Test Key** | The original X-Ray test key is imported within tags, enabling quick reference and filtering in Test Manager. |
@@ -185,7 +185,7 @@ Test Data from X-Ray steps is migrated as a single textarea custom field at the 
 
 ## What Does Not Get Migrated
 
-The migration focuses exclusively on your **test library** — definitions, structure, and metadata. The following entities are not included:
+The migration focuses exclusively on your **test library**: definitions, structure, and metadata. The following entities are not included:
 
 | Entity | Reason |
 |---|---|

--- a/docs/one-click-migration-from-zephyr-scale.md
+++ b/docs/one-click-migration-from-zephyr-scale.md
@@ -45,15 +45,15 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 # One Click Migration from Zephyr Scale
 
-<BrandName /> Test Manager supports one-click migration from **Zephyr Scale (Jira Cloud)**, allowing you to import your entire test library — including projects, test cases, folder structures, custom fields, and linked requirements — directly into Test Manager without manual data entry.
+<BrandName /> Test Manager supports one-click migration from **Zephyr Scale (Jira Cloud)**, allowing you to import your entire test library (including projects, test cases, folder structures, custom fields, and linked requirements) directly into Test Manager without manual data entry.
 
 ## Key Benefits
 
-- **Zero manual effort** — All test cases, steps, and folder structures are automatically migrated.
-- **Handles both Manual and BDD tests** — Manual step definitions and Gherkin/BDD scenarios are both fully supported.
-- **Custom fields carried over** — Custom fields in your Zephyr Scale tests are automatically detected and created in Test Manager.
-- **Rich text content preserved** — Embedded screenshots within rich text fields (description, preconditions, step descriptions, and expected results) are migrated.
-- **Real-time progress tracking** — A progress bar shows migration status so you know exactly where things stand.
+- **Zero manual effort**: All test cases, steps, and folder structures are automatically migrated.
+- **Handles both Manual and BDD tests**: Manual step definitions and Gherkin/BDD scenarios are both fully supported.
+- **Custom fields carried over**: Custom fields in your Zephyr Scale tests are automatically detected and created in Test Manager.
+- **Rich text content preserved**: Embedded screenshots within rich text fields (description, preconditions, step descriptions, and expected results) are migrated.
+- **Real-time progress tracking**: A progress bar shows migration status so you know exactly where things stand.
 
 :::note
 This migration supports **Zephyr Scale (Jira Cloud)** only. Zephyr Enterprise and Data Center are not supported at this time.
@@ -140,7 +140,7 @@ Click **Continue**. The system validates both your Jira and Zephyr Scale credent
 
 <img loading="lazy" src={require('../assets/images/xray-migration/migration-progress.png').default} alt="migration-progress" className="doc_img" width="1366" height="629"/>
 
-- You can navigate away from the page and continue other work — the migration continues in the background. Once the migration is complete, you will receive an email notification.
+- You can navigate away from the page and continue other work. The migration continues in the background. Once the migration is complete, you will receive an email notification.
 
 <img loading="lazy" src={require('../assets/images/xray-migration/email-completion.png').default} alt="email-completion-notification" className="doc_img" width="1366" height="629"/>
 
@@ -168,7 +168,7 @@ The following entities and data are transferred from Zephyr Scale to Test Manage
 | **Manual Test Steps** | Each step's **Step Description** and **Expected Result** are migrated directly. Step ordering is preserved. |
 | **BDD/Gherkin Scenarios** | Full Gherkin scenario text is extracted and stored under the BDD Scenarios template. |
 | **Folders** | Zephyr Scale folder hierarchy is preserved and mapped to Test Manager folders. |
-| **Rich Text Fields** | Rich text content — including embedded screenshots, tables, lists, and other supported formatting within description, preconditions, step descriptions, and expected results — is preserved. |
+| **Rich Text Fields** | Rich text content (including embedded screenshots, tables, lists, and other supported formatting within description, preconditions, step descriptions, and expected results) is preserved. |
 | **Custom Fields** | Custom fields are automatically detected in Zephyr Scale and created in Test Manager with matching names. |
 | **Linked Issues / Requirements** | Jira issue links and requirement associations are preserved. Requires [Jira integration](https://www.testmuai.com/support/docs/link-jira-issues-with-test-manager/) to be configured. |
 | **Zephyr Scale Test Key** | The original Zephyr Scale test key is imported within tags, enabling quick reference and filtering in Test Manager. |
@@ -183,7 +183,7 @@ Test Data from Zephyr Scale steps is migrated as a single textarea custom field 
 
 ## What Does Not Get Migrated
 
-The migration focuses exclusively on your **test library** — definitions, structure, and metadata. The following entities are not included:
+The migration focuses exclusively on your **test library**: definitions, structure, and metadata. The following entities are not included:
 
 | Entity | Reason |
 |---|---|
@@ -197,7 +197,7 @@ The migration focuses exclusively on your **test library** — definitions, stru
 
 ## Test Steps Handling
 
-The migration supports all three Zephyr Scale test script types — **Step by Step**, **BDD-Gherkin**, and **Plain Text**.
+The migration supports all three Zephyr Scale test script types: **Step by Step**, **BDD-Gherkin**, and **Plain Text**.
 
 ### Step by Step and Plain Text
 Manual test cases are migrated with their full step definitions. Each step's **Step Description** and **Expected Result** fields are mapped directly. Step ordering is preserved, and any embedded screenshots within rich text fields are carried over. All Zephyr Scale **Step by Step** and **Plain text** test scripts are mapped to the **Manual Test Steps** template in Test Steps of a Test Case.

--- a/docs/pingone-scim.md
+++ b/docs/pingone-scim.md
@@ -52,7 +52,7 @@ In this guide, we will walk through integrating PingOne SCIM provisioning with <
 
 ## Integrating SCIM User Provisioning with PingOne
 
-### Step 1 — Copy SCIM Credentials from <BrandName />
+### Step 1: Copy SCIM Credentials from <BrandName />
 
 Sign in to your <BrandName /> account. Don't have an account, [register for free](https://www.testmuai.com/register/).
 
@@ -60,7 +60,7 @@ Head to **Settings** > **Organization Settings** > **Security** > **SCIM Provisi
 
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/pingone/10.png').default} alt="Copy SCIM Base URL and Bearer Token from LambdaTest" className="doc_img"/>
 
-### Step 2 — Create a SAML Application in PingOne (if not already done)
+### Step 2: Create a SAML Application in PingOne (if not already done)
 
 If you already have a PingOne SAML application configured for <BrandName /> SSO, skip to [Step 3](#step-3).
 
@@ -70,7 +70,7 @@ Enter a name (e.g., your org name), select **SAML Application**, and click **Sav
 
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/pingone/3.png').default} alt="Create SAML Application in PingOne" className="doc_img"/>
 
-### Step 3 — Create SCIM Provisioning Connection {#step-3}
+### Step 3: Create SCIM Provisioning Connection {#step-3}
 
 In PingOne, go to **Integrations** > **Provisioning** > **Connections** tab.
 
@@ -92,7 +92,7 @@ Enter a **Name** for the connection (e.g., your org name) and click **Next**.
 
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/pingone/9.png').default} alt="Name the SCIM connection" className="doc_img"/>
 
-### Step 4 — Configure Authentication
+### Step 4: Configure Authentication
 
 | Field | Value |
 |---|---|
@@ -108,7 +108,7 @@ Click **Test Connection** to verify, then click **Next**.
 
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/pingone/12.png').default} alt="Configure SCIM authentication in PingOne" className="doc_img"/>
 
-### Step 5 — Configure Preferences
+### Step 5: Configure Preferences
 
 | Field | Value |
 |---|---|
@@ -118,9 +118,9 @@ Click **Test Connection** to verify, then click **Next**.
 | **Group Membership Handling** | `Merge` (recommended) |
 
 Enable the following user actions:
-- **Create Users** — checked
-- **Update Users** — checked
-- **Disable Users** — checked
+- **Create Users**: checked
+- **Update Users**: checked
+- **Disable Users**: checked
 
 Click **Save**.
 
@@ -130,7 +130,7 @@ Click **Save**.
 Add `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:User` to the **Custom Attribute Schema URNs** field to enable sending `OrganizationRole` and `LambdatestGroup` from PingOne.
 :::
 
-### Step 6 — Create a User Provisioning Rule
+### Step 6: Create a User Provisioning Rule
 
 Go to the **Rules** tab in your provisioning connection and click **Add Rule**.
 
@@ -155,7 +155,7 @@ Review the **Attribute Mapping**. PingOne maps the following attributes by defau
 | Formatted | `formattedName` |
 
 :::warning Important
-Make sure **Email Address** is mapped to **`userName`**. This is required — <BrandName /> uses `userName` as the unique identifier for SCIM users, and it must be a valid email address.
+Make sure **Email Address** is mapped to **`userName`**. This is required. <BrandName /> uses `userName` as the unique identifier for SCIM users, and it must be a valid email address.
 :::
 
 Click **Save** to create the rule.
@@ -178,7 +178,7 @@ Group provisioning is **not enabled by default**. Before proceeding, reach out t
 
 Once group provisioning is enabled and user provisioning is working, follow these steps to push PingOne groups to <BrandName />.
 
-### Step 1 — Add Groups to Your Provisioning Rule in PingOne
+### Step 1: Add Groups to Your Provisioning Rule in PingOne
 
 Go back to your SCIM provisioning connection in PingOne > **Rules** tab > edit your provisioning rule.
 
@@ -190,7 +190,7 @@ Select the groups you want to push and click **Save**.
 
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/pingone/16.png').default} alt="Select groups to provision" className="doc_img"/>
 
-### Step 2 — Configure Mapping Rules in <BrandName />
+### Step 2: Configure Mapping Rules in <BrandName />
 
 In <BrandName />, go to **Settings** > **Organization Settings** > **SCIM Group Provisioning** > **Mapping Rules** tab.
 
@@ -199,9 +199,9 @@ Click **Add Mapping Rule** to create a rule that determines how incoming groups 
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/pingone/1.png').default} alt="Mapping rules tab in LambdaTest" className="doc_img"/>
 
 Configure the rule:
-- **Pattern** — match group names by prefix, regex, or match all
-- **Target Entity Type** — Team, Concurrency Group, or Sub-Organization
-- **Auto Approve** — toggle ON to automatically approve matching groups
+- **Pattern**: match group names by prefix, regex, or match all
+- **Target Entity Type**: Team, Concurrency Group, or Sub-Organization
+- **Auto Approve**: toggle ON to automatically approve matching groups
 
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/pingone/2.png').default} alt="Add mapping rule modal" className="doc_img"/>
 
@@ -209,7 +209,7 @@ Configure the rule:
 Set a **Match All → Team** rule with auto-approve enabled to automatically map all incoming groups to teams without manual intervention.
 :::
 
-### Step 3 — Verify Groups in <BrandName />
+### Step 3: Verify Groups in <BrandName />
 
 Once PingOne pushes the groups, go to **SCIM Group Provisioning** > **SCIM Groups** tab to see the synced groups.
 

--- a/docs/playwright-sdk.md
+++ b/docs/playwright-sdk.md
@@ -27,7 +27,7 @@ Key benefits include:
 
 *   **Effortless Execution**: Run your entire test suite on the <BrandName /> platform with a single, simple command. The SDK handles all the underlying complexity of connecting to the grid.
 *   **Zero Code Changes**: Integrate your existing Playwright tests without modifying your test scripts. All configuration is managed externally in the lambdatest.yml file.
-*   **Centralized Capabilities**: Define and manage all your test environments—including browser, platform, and resolution combinations—in a single, easy-to-read YAML file.
+*   **Centralized Capabilities**: Define and manage all your test environments, including browser, platform, and resolution combinations, in a single, easy-to-read YAML file.
 *   **Local & Private Testing**: Seamlessly test internal, pre-production, or locally hosted websites using the <BrandName /> Tunnel, which can be managed automatically by the SDK.
 *   **CI/CD Integration**: The command-line nature of the SDK makes it trivial to integrate into any CI/CD pipeline (like Jenkins, GitHub Actions, CircleCI, etc.) for continuous testing.
 *   **Rich Test Artifacts**: All test runs are automatically reported to your <BrandName /> Dashboard, complete with video recordings, step-by-step screenshots, browser logs, and network logs for easy debugging.

--- a/docs/real-device-custom-date-and-time.md
+++ b/docs/real-device-custom-date-and-time.md
@@ -52,7 +52,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 ></script>
 
 
-Testing applications often requires validation across different date, time, and format scenarios. <BrandName /> now supports dynamic configuration of **date, time, 12/24-hour format**, and **automatic time toggle** on real **iOS (14+)** and **Android (10+)** devices — both in **manual** sessions and via **Appium automation hooks**.
+Testing applications often requires validation across different date, time, and format scenarios. <BrandName /> now supports dynamic configuration of **date, time, 12/24-hour format**, and **automatic time toggle** on real **iOS (14+)** and **Android (10+)** devices, both in **manual** sessions and via **Appium automation hooks**.
 
 This enables use cases like testing scheduled alerts, AM/PM behaviors, time-bound features, and regional formatting validations.
 
@@ -75,7 +75,7 @@ This enables use cases like testing scheduled alerts, AM/PM behaviors, time-boun
 <img loading="lazy" src={require('../assets/images/real-device-app-testing/set-date-and-time-pic-last.png').default} className="doc_img"/>
 
 :::note
-On Android devices, certain models — particularly those from **Motorola, Xiaomi, Oppo, and other Chinese OEMs** — do not support custom date and time configuration. On such devices, the modal will display a **Not Supported** message.
+On Android devices, certain models, particularly those from **Motorola, Xiaomi, Oppo, and other Chinese OEMs**, do not support custom date and time configuration. On such devices, the modal will display a **Not Supported** message.
 :::
 
 
@@ -125,7 +125,7 @@ The modal includes four options to simulate various datetime-related behaviors:
 | Android  | Manual + Appium Executor    | Android 10 and above  |
 
 :::warning
-Custom date and time configuration is not supported on certain Android device models — particularly those from **Motorola, Xiaomi, Oppo, and other Chinese OEMs**. On these devices, the modal will display a **Not Supported** message during manual sessions, and the Appium hook will return the following error during automation:
+Custom date and time configuration is not supported on certain Android device models, particularly those from **Motorola, Xiaomi, Oppo, and other Chinese OEMs**. On these devices, the modal will display a **Not Supported** message during manual sessions, and the Appium hook will return the following error during automation:
 
 `Custom date and time hook is not supported on this device. Please try on another device_id.`
 :::

--- a/docs/scim.md
+++ b/docs/scim.md
@@ -1,9 +1,9 @@
 ---
 id: scim
-title: SCIM Provisioning — Users & Groups
+title: "SCIM Provisioning: Users & Groups"
 hide_title: false
 sidebar_label: SCIM
-description: Automate user and group lifecycle management with SCIM 2.0. Provision users, sync groups, map to teams, concurrency groups, and sub-organizations — all from your Identity Provider.
+description: Automate user and group lifecycle management with SCIM 2.0. Provision users, sync groups, map to teams, concurrency groups, and sub-organizations, all from your Identity Provider.
 keywords:
     - TestMu AI SCIM
     - SCIM Provisioning
@@ -50,7 +50,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-SCIM (System for Cross-domain Identity Management) lets your Identity Provider (IDP) automatically manage users and groups within your <BrandName /> organization — no manual account setup required.
+SCIM (System for Cross-domain Identity Management) lets your Identity Provider (IDP) automatically manage users and groups within your <BrandName /> organization, no manual account setup required.
 
 | Capability | What it does |
 |---|---|
@@ -68,13 +68,13 @@ SCIM (System for Cross-domain Identity Management) lets your Identity Provider (
 
 **What you need:** Enterprise plan, SSO configured, Admin access, and an IDP that supports SCIM 2.0 (Okta, Azure AD, JumpCloud, etc.).
 
-### Step 1 — Copy SCIM Credentials
+### Step 1: Copy SCIM Credentials
 
 Go to **Settings** > **Organization Settings** > **Security** tab. Copy the **SCIM Base URL** and **Bearer Token**.
 
 <img loading="lazy" src={require('../assets/images/lambdatest-scim/scim-base-url.png').default} alt="SCIM Base URL and Bearer Token" width="404" height="206" className="doc_img img_center"/><br/>
 
-### Step 2 — Configure Your IDP
+### Step 2: Configure Your IDP
 
 Paste the SCIM Base URL and Bearer Token into your IDP's provisioning settings.
 
@@ -121,7 +121,7 @@ Full walkthrough: [PingOne SCIM Guide](/support/docs/pingone-scim/)
 
 1. In PingOne, go to **Integrations** > **Provisioning** > create a new **SCIM Outbound** connection
 2. Enter the **SCIM Base URL** and **Bearer Token** from <BrandName />
-3. Configure preferences — set **User Identifier** to `workEmail` and enable **Create**, **Update**, **Disable** users
+3. Configure preferences: set **User Identifier** to `workEmail` and enable **Create**, **Update**, **Disable** users
 4. Create a provisioning **Rule** to select which users and groups to sync
 
 </TabItem>
@@ -137,7 +137,7 @@ Any SCIM 2.0-compliant IDP works. Use these settings:
 | **Users Resource** | `/Users` |
 | **Groups Resource** | `/Groups` |
 
-**Custom Attribute Schema URNs** — add these to your IDP's SCIM custom attribute configuration to send role and group assignments:
+**Custom Attribute Schema URNs**: add these to your IDP's SCIM custom attribute configuration to send role and group assignments:
 
 | Purpose | Schema URN |
 |---|---|
@@ -145,7 +145,7 @@ Any SCIM 2.0-compliant IDP works. Use these settings:
 | **Group extension** | `urn:ietf:params:scim:schemas:extension:LambdaTest:2.0:Group` |
 
 - **User extension attributes:** `OrganizationRole` (Admin / User / Guest), `LambdatestGroup` (concurrency group name)
-- **Group extension attributes:** `LambdatestRoles` (array of Admin / User / Guest — applied to all group members)
+- **Group extension attributes:** `LambdatestRoles` (array of Admin / User / Guest, applied to all group members)
 
 </TabItem>
 </Tabs>
@@ -162,7 +162,7 @@ Any SCIM 2.0-compliant IDP works. Use these settings:
 |---|---|
 | New user (email doesn't exist) | Account created and added to your org |
 | Existing user (same org) | Attributes (role, active) updated |
-| Existing user (different org) | **Not** provisioned — invite via team invite first |
+| Existing user (different org) | **Not** provisioned, invite via team invite first |
 
 ### Schema & Attributes
 
@@ -324,7 +324,7 @@ Filter by email: `?filter=userName eq "jane@company.com"`
 }
 ```
 
-**Response:** `200 OK` — returns the full updated user object.
+**Response:** `200 OK`, returns the full updated user object.
 
 **Errors:** `404 Not Found` if user doesn't exist. `400 Bad Request` if user belongs to a different org.
 
@@ -352,7 +352,7 @@ Filter by email: `?filter=userName eq "jane@company.com"`
 | `urn:ietf:params:scim:schemas:extension:`<br/>`LambdaTest:2.0:User:OrganizationRole` | `Admin`, `User`, `Guest` |
 | `urn:ietf:params:scim:schemas:extension:`<br/>`LambdaTest:2.0:User:LambdatestGroup` | _(concurrency group name)_ |
 
-**Response:** `200 OK` — returns the full updated user object.
+**Response:** `200 OK`, returns the full updated user object.
 
 **Errors:** `404 Not Found` if user doesn't exist. `400 Bad Request` if user belongs to a different org.
 
@@ -370,7 +370,7 @@ Filter by email: `?filter=userName eq "jane@company.com"`
 }
 ```
 
-**Response:** `200 OK` — returns user object with `"active": false`.
+**Response:** `200 OK`, returns user object with `"active": false`.
 
 **Errors:** `404 Not Found` if user doesn't exist. `400 Bad Request` if user belongs to a different org.
 
@@ -382,7 +382,7 @@ Filter by email: `?filter=userName eq "jane@company.com"`
 **Response:** `204 No Content`
 
 :::warning
-DELETE only **deactivates** the account — it does not permanently delete it. For permanent deletion, the user must request it from <BrandName /> Account Settings.
+DELETE only **deactivates** the account. It does not permanently delete it. For permanent deletion, the user must request it from <BrandName /> Account Settings.
 :::
 
 **Errors:** `404 Not Found` if user doesn't exist. `400 Bad Request` if user belongs to a different org.
@@ -402,19 +402,19 @@ Push groups from your IDP → approve the mapping in the **SCIM Group Provisioni
 
 ### How It Works
 
-Groups and members are stored **as soon as your IDP pushes them** — even before any mapping is configured. Mapping only controls **where** members are assigned.
+Groups and members are stored **as soon as your IDP pushes them**, even before any mapping is configured. Mapping only controls **where** members are assigned.
 
 <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0', margin: '2rem 0'}}>
 
   <div style={{border: '1px solid #d1d5db', borderRadius: '10px', padding: '16px 28px', textAlign: 'center', width: '100%', maxWidth: '500px', background: '#f9fafb'}}>
-    <div style={{fontSize: '11px', textTransform: 'uppercase', letterSpacing: '1px', color: '#6b7280', marginBottom: '4px'}}>Step 1 — Your IDP (automatic)</div>
+    <div style={{fontSize: '11px', textTransform: 'uppercase', letterSpacing: '1px', color: '#6b7280', marginBottom: '4px'}}>Step 1: Your IDP (automatic)</div>
     <div style={{fontSize: '15px', fontWeight: 600, color: '#111827'}}>Groups & members pushed via SCIM</div>
   </div>
 
   <div style={{fontSize: '22px', lineHeight: '1', color: '#9ca3af', userSelect: 'none'}}>↓</div>
 
   <div style={{border: '1px solid #d1d5db', borderRadius: '10px', padding: '16px 28px', textAlign: 'center', width: '100%', maxWidth: '500px', background: '#f9fafb'}}>
-    <div style={{fontSize: '11px', textTransform: 'uppercase', letterSpacing: '1px', color: '#6b7280', marginBottom: '4px'}}>Step 2 — LambdaTest (automatic)</div>
+    <div style={{fontSize: '11px', textTransform: 'uppercase', letterSpacing: '1px', color: '#6b7280', marginBottom: '4px'}}>Step 2: LambdaTest (automatic)</div>
     <div style={{fontSize: '15px', fontWeight: 600, color: '#111827'}}>Group stored & roles applied to members</div>
     <div style={{fontSize: '12px', color: '#6b7280', marginTop: '4px'}}>Members get roles immediately, even without mapping</div>
   </div>
@@ -422,7 +422,7 @@ Groups and members are stored **as soon as your IDP pushes them** — even befor
   <div style={{fontSize: '22px', lineHeight: '1', color: '#9ca3af', userSelect: 'none'}}>↓</div>
 
   <div style={{border: '1px solid #d1d5db', borderRadius: '10px', padding: '16px 28px', textAlign: 'center', width: '100%', maxWidth: '500px', background: '#f9fafb'}}>
-    <div style={{fontSize: '11px', textTransform: 'uppercase', letterSpacing: '1px', color: '#6b7280', marginBottom: '4px'}}>Step 3 — Admin (manual) or Mapping Rules (automatic)</div>
+    <div style={{fontSize: '11px', textTransform: 'uppercase', letterSpacing: '1px', color: '#6b7280', marginBottom: '4px'}}>Step 3: Admin (manual) or Mapping Rules (automatic)</div>
     <div style={{fontSize: '15px', fontWeight: 600, color: '#111827'}}>Group mapped to a LambdaTest entity</div>
   </div>
 
@@ -462,7 +462,7 @@ Once activated, you can control it from **Settings** > **Organization Settings**
 
 <!-- <img loading="lazy" src={require('../assets/images/lambdatest-scim/group-provisioning-toggle.png').default} alt="SCIM Group Provisioning toggle" width="404" height="206" className="doc_img img_center"/><br/> -->
 
-> **When toggled OFF:** New IDP group operations (create/update/delete) are rejected with `403`. Existing groups, mappings, and assignments are preserved — nothing is deleted. Toggle back ON to resume syncing.
+> **When toggled OFF:** New IDP group operations (create/update/delete) are rejected with `403`. Existing groups, mappings, and assignments are preserved. Nothing is deleted. Toggle back ON to resume syncing.
 
 ### Group Schema & Attributes
 
@@ -509,40 +509,40 @@ Once a group is pushed, it needs to be **mapped** to tell <BrandName /> what to 
 <Tabs className="docs__val" groupId="entity-type" queryString="entity">
 <TabItem value="team" label="Team" default>
 
-**Teams are additive** — a user can belong to multiple teams at once, so there are no conflicts.
+**Teams are additive**: a user can belong to multiple teams at once, so there are no conflicts.
 
 | | |
 |---|---|
-| **Auto-create** | Yes — if the team doesn't exist, it's created automatically |
+| **Auto-create** | Yes, if the team doesn't exist, it's created automatically |
 | **On member removal** | Removed from team (unless another SCIM group also maps them there) |
 | **On group rename** | Team is **automatically renamed** to match the IDP group name |
-| **Conflicts** | None — teams are never exclusive |
+| **Conflicts** | None, teams are never exclusive |
 
 This is the simplest and most common mapping. If you're just starting out, **Team is the recommended choice**.
 
 </TabItem>
 <TabItem value="group" label="Concurrency Group">
 
-**Concurrency groups are exclusive** — a user can only belong to one at a time.
+**Concurrency groups are exclusive**: a user can only belong to one at a time.
 
 | | |
 |---|---|
-| **Auto-create** | Yes — if the group doesn't exist, it's created automatically |
+| **Auto-create** | Yes, if the group doesn't exist, it's created automatically |
 | **On member removal** | User moved back to the org's **default concurrency group** |
 | **On group rename** | Concurrency group is **automatically renamed** to match the IDP group name |
-| **Conflicts** | Yes — if the same user is in two SCIM groups mapped to **different** concurrency groups. See [Conflicts](#conflicts). |
+| **Conflicts** | Yes, if the same user is in two SCIM groups mapped to **different** concurrency groups. See [Conflicts](#conflicts). |
 
 </TabItem>
 <TabItem value="suborg" label="Sub-Organization">
 
-**Sub-organizations are exclusive** — a user can only belong to one at a time. Sub-orgs also **conflict with concurrency groups and teams** from other SCIM groups (cross-type conflict).
+**Sub-organizations are exclusive**: a user can only belong to one at a time. Sub-orgs also **conflict with concurrency groups and teams** from other SCIM groups (cross-type conflict).
 
 | | |
 |---|---|
-| **Auto-create** | No — sub-orgs must be created manually first (they have billing and setup requirements) |
+| **Auto-create** | No, sub-orgs must be created manually first (they have billing and setup requirements) |
 | **On member removal** | User moved back to the **root organization** |
 | **On group rename** | Sub-org is **not** renamed (sub-orgs have independent naming) |
-| **Conflicts** | Yes — two types: (1) same user in two groups mapped to **different** sub-orgs, or (2) same user in a sub-org group **and** a concurrency group/team group from a different SCIM group |
+| **Conflicts** | Yes, two types: (1) same user in two groups mapped to **different** sub-orgs, or (2) same user in a sub-org group **and** a concurrency group/team group from a different SCIM group |
 
 **Why cross-type conflicts?** Moving a user to a sub-org takes them out of the parent org's resource pool entirely. Team and concurrency group assignments in the parent org become invalid.
 
@@ -610,7 +610,7 @@ Matches **every group**. Use as a low-priority catch-all fallback.
 
 ### Role Assignment {#roles}
 
-Roles can be set per-user (User extension `OrganizationRole`) or per-group (Group extension `LambdatestRoles`). Roles work **independently of mappings** — even unmapped groups apply their roles to members immediately.
+Roles can be set per-user (User extension `OrganizationRole`) or per-group (Group extension `LambdatestRoles`). Roles work **independently of mappings**, even unmapped groups apply their roles to members immediately.
 
 When a user is in **multiple groups with different roles**, the highest-priority role wins: **Admin > User > Guest**
 
@@ -620,38 +620,38 @@ When a user is in **multiple groups with different roles**, the highest-priority
 | `org-admins` | Admin |
 | **Effective role** | **Admin** (highest wins) |
 
-**Roles can be upgraded and downgraded.** The effective role is always the **highest** across all current group memberships — removing a user from one group only downgrades their role if no other group provides it.
+**Roles can be upgraded and downgraded.** The effective role is always the **highest** across all current group memberships. Removing a user from one group only downgrades their role if no other group provides it.
 
 | Scenario | What happens |
 |---|---|
 | User added to a group with `Admin` role | Role upgraded to Admin (if currently lower) |
-| User removed from the `Admin` group | Role recomputed — drops to next highest (e.g., User) if no other group gives Admin |
+| User removed from the `Admin` group | Role recomputed, drops to next highest (e.g., User) if no other group gives Admin |
 | All groups removed, or no roles set | Role defaults to **User** |
-| Group's `LambdatestRoles` changed from `Admin` to `Guest` | All members' roles recomputed — may downgrade |
+| Group's `LambdatestRoles` changed from `Admin` to `Guest` | All members' roles recomputed, may downgrade |
 
 ### One Group per Entity
 
-Each <BrandName /> entity (team, concurrency group, or sub-org) can only be mapped from **one SCIM group at a time**. If you try to create a second mapping to the same entity, the request is rejected. This ensures a clear ownership model — one IDP group controls one <BrandName /> entity.
+Each <BrandName /> entity (team, concurrency group, or sub-org) can only be mapped from **one SCIM group at a time**. If you try to create a second mapping to the same entity, the request is rejected. This ensures a clear ownership model: one IDP group controls one <BrandName /> entity.
 
 ### Conflicts {#conflicts}
 
 :::note Teams don't have conflicts
-If you're only mapping to **Teams**, you can skip this section entirely. Teams are additive — no conflicts possible.
+If you're only mapping to **Teams**, you can skip this section entirely. Teams are additive: no conflicts possible.
 :::
 
-Conflicts happen when a user belongs to multiple SCIM groups that compete for the **same exclusive slot**. When a conflict occurs, the user **keeps their current assignment** until an admin resolves it — nothing changes automatically.
+Conflicts happen when a user belongs to multiple SCIM groups that compete for the **same exclusive slot**. When a conflict occurs, the user **keeps their current assignment** until an admin resolves it. Nothing changes automatically.
 
 **When do conflicts happen?**
 
 <Tabs className="docs__val" groupId="entity-type" queryString="entity">
 <TabItem value="group" label="Concurrency Group" default>
 
-When the same user is in two SCIM groups mapped to **different** concurrency groups. Example: Group A → "QA Pool" and Group B → "Dev Pool" — the user can only be in one.
+When the same user is in two SCIM groups mapped to **different** concurrency groups. Example: Group A → "QA Pool" and Group B → "Dev Pool". The user can only be in one.
 
 </TabItem>
 <TabItem value="suborg" label="Sub-Organization">
 
-When the same user is in two SCIM groups mapped to **different** sub-orgs. Example: Group X → "US Team" and Group Y → "EU Team" — the user can only be in one.
+When the same user is in two SCIM groups mapped to **different** sub-orgs. Example: Group X → "US Team" and Group Y → "EU Team". The user can only be in one.
 
 </TabItem>
 <TabItem value="crosstype" label="Cross-Type">
@@ -670,12 +670,12 @@ When a user is mapped to a **sub-organization** from one SCIM group and a **conc
 1. Go to **SCIM Group Provisioning** dashboard > **Conflicts** tab
 2. Each conflict card shows the **Current** group (where the user is now) and the **Incoming** group (the one trying to claim the user)
 3. Click **Keep Current** or **Use Incoming**
-4. <BrandName /> remembers this decision — the same combination won't create a new conflict
+4. <BrandName /> remembers this decision. The same combination won't create a new conflict
 
 <!-- <img loading="lazy" src={require('../assets/images/lambdatest-scim/conflict-resolution.png').default} alt="Resolving a SCIM group conflict" width="404" height="206" className="doc_img img_center"/><br/> -->
 
 :::tip To avoid conflicts
-Prefer **teams** when users need to be in multiple groups — teams never create conflicts. Only use concurrency groups and sub-orgs when you need exclusive assignment.
+Prefer **teams** when users need to be in multiple groups. Teams never create conflicts. Only use concurrency groups and sub-orgs when you need exclusive assignment.
 :::
 
 ### Deleted Target {#target-deleted}
@@ -683,7 +683,7 @@ Prefer **teams** when users need to be in multiple groups — teams never create
 If an admin deletes a team, concurrency group, or sub-org that has an active SCIM mapping, the mapping is flagged as `target_deleted` and the status changes to **Pending**.
 
 :::warning Manual re-mapping required
-When a target is deleted, the mapping **will not auto-create a replacement** — even if a matching mapping rule with auto-approve exists. This is intentional: auto-creating the same entity that was just deleted would cause a loop. An admin must manually update the mapping to point to a new (or recreated) target.
+When a target is deleted, the mapping **will not auto-create a replacement**, even if a matching mapping rule with auto-approve exists. This is intentional: auto-creating the same entity that was just deleted would cause a loop. An admin must manually update the mapping to point to a new (or recreated) target.
 :::
 
 **To fix a `target_deleted` mapping:**
@@ -691,7 +691,7 @@ When a target is deleted, the mapping **will not auto-create a replacement** —
 1. Go to **SCIM Group Provisioning** dashboard
 2. Find the group with `target_deleted` status
 3. Click the group and select a **new target entity**
-4. Click **Approve** — members will be synced to the new target
+4. Click **Approve**: members will be synced to the new target
 
 ### Group API Operations
 
@@ -787,7 +787,7 @@ Filter by name: `?filter=displayName eq "eng-backend"` | Paginate: `?startIndex=
 </TabItem>
 <TabItem value="update-group" label="Update">
 
-**PUT** (full replace) to `https://auth.lambdatest.com/api/scim/Groups/{id}` — replaces entire membership list. Members removed from the list are unassigned from all mapped entities.
+**PUT** (full replace) to `https://auth.lambdatest.com/api/scim/Groups/{id}`. Replaces entire membership list. Members removed from the list are unassigned from all mapped entities.
 
 **PATCH** (partial) to `https://auth.lambdatest.com/api/scim/Groups/{id}`:
 
@@ -858,7 +858,7 @@ Filter by name: `?filter=displayName eq "eng-backend"` | Paginate: `?startIndex=
 </TabItem>
 </Tabs>
 
-**Response:** `200 OK` — returns the updated group object with new membership and `meta.lastModified` timestamp.
+**Response:** `200 OK`, returns the updated group object with new membership and `meta.lastModified` timestamp.
 
 **Errors:** `404 Not Found` if group doesn't exist. `409 Conflict` if renamed to an existing `displayName`.
 
@@ -882,7 +882,7 @@ Filter by name: `?filter=displayName eq "eng-backend"` | Paginate: `?startIndex=
 
 ## What Happens When... {#sync-behavior}
 
-Quick reference for common scenarios. Everything below is handled automatically — no action needed unless noted.
+Quick reference for common scenarios. Everything below is handled automatically, no action needed unless noted.
 
 <Tabs className="docs__val" groupId="sync-source" queryString="sync">
 <TabItem value="idp-changes" label="Your IDP changes" default>
@@ -903,7 +903,7 @@ Quick reference for common scenarios. Everything below is handled automatically 
 |---|---|---|
 | **Rename a team / group / sub-org** | Works fine, but the next IDP group rename will overwrite it. | To control names, rename **in your IDP** |
 | **Delete a mapped entity** | Mapping flagged as `target_deleted`, reverts to Pending. Auto-create is blocked. | [Manually re-map](#target-deleted) to a new target |
-| **Manually remove a member from a team** | Removal is immediate but **temporary** — next IDP sync re-adds them. | Remove **in your IDP** instead |
+| **Manually remove a member from a team** | Removal is immediate but **temporary**. Next IDP sync re-adds them. | Remove **in your IDP** instead |
 | **Manually assign user to concurrency group / sub-org** | SCIM overrides non-SCIM assignments on next sync. | Use SCIM groups for exclusive assignments |
 | **Manually change a SCIM-managed user's role** | May be overwritten on next IDP sync. | Manage roles **in your IDP** |
 
@@ -932,7 +932,7 @@ Quick reference for common scenarios. Everything below is handled automatically 
 |---|---|
 | Members not appearing in teams or sub-orgs | Group mapping is still **Pending**. Approve it in the dashboard or create an auto-approve mapping rule. |
 | Members are in the SCIM group but not in the sub-org | Check for [conflicts](#conflicts). The user may belong to another group with a competing exclusive mapping. |
-| User has an unexpected role | Check **all** SCIM group memberships — roles follow highest-wins (Admin > User > Guest). The user may inherit Admin from another group. |
+| User has an unexpected role | Check **all** SCIM group memberships. Roles follow highest-wins (Admin > User > Guest). The user may inherit Admin from another group. |
 | User keeps getting re-added after manual removal | SCIM is the source of truth. Remove the user **in your IDP** instead. |
 | Group mapping reverted to Pending | The group was renamed (rules re-evaluated) or the target entity was deleted (`target_deleted`). If renamed, rules may auto-approve. If deleted, [manual re-mapping](#target-deleted) is required. |
 | Auto-approve didn't create my sub-organization | Sub-orgs are never auto-created (billing/setup required). Create the sub-org first, then approve manually. |
@@ -945,7 +945,7 @@ Quick reference for common scenarios. Everything below is handled automatically 
 | Can a group be mapped to multiple targets? | No. A single SCIM group can only map to **one** entity (team, concurrency group, or sub-org). To assign the same users to multiple entities, use separate IDP groups. |
 | Can two SCIM groups map to the same entity? | No. Each entity can only be owned by one SCIM group. This prevents conflicting membership lists. |
 | Can I disable group provisioning without losing data? | Yes. The toggle only blocks new IDP operations. Existing groups, mappings, and assignments are preserved. Toggle back ON to resume. |
-| Can I restore a deleted group? | Yes. Push a group with the same `displayName` from your IDP — the soft-deleted record is restored. Members need to be re-pushed. |
+| Can I restore a deleted group? | Yes. Push a group with the same `displayName` from your IDP. The soft-deleted record is restored. Members need to be re-pushed. |
 | Can roles be downgraded? | Yes. Roles are recomputed across all groups. If the highest role is removed, the effective role drops to the next highest. Defaults to **User** if none set. |
 | What happens to a conflict when one group is deleted? | The conflict is **auto-resolved** in favor of the remaining group. No admin action needed. |
 | What's the difference between Approved and Auto-Approved? | Both sync members identically. **Auto-Approved** = mapping rule matched automatically. **Approved** = admin approved manually. |

--- a/docs/screen-reader-on-real-devices-app.md
+++ b/docs/screen-reader-on-real-devices-app.md
@@ -54,7 +54,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 Manual accessibility testing is crucial to ensure that your mobile apps and websites are fully compliant with the Web Content Accessibility Guidelines (WCAG). This guarantees that your websites are usable by people with disabilities, regardless of their device or browsing capabilities.
 
-<BrandName />'s Live Screen Reader feature empowers you to perform manual accessibility testing on real Android devices, allowing you to navigate through app elements with spoken descriptions of the UI—similar to the [Google TalkBack](https://support.google.com/accessibility/android/topic/3529932?hl=en&ref_topic=9078845) functionality. This feature enables comprehensive accessibility testing to ensure compliance with WCAG standards.
+<BrandName />'s Live Screen Reader feature empowers you to perform manual accessibility testing on real Android devices, allowing you to navigate through app elements with spoken descriptions of the UI, similar to the [Google TalkBack](https://support.google.com/accessibility/android/topic/3529932?hl=en&ref_topic=9078845) functionality. This feature enables comprehensive accessibility testing to ensure compliance with WCAG standards.
 
 
 
@@ -64,7 +64,7 @@ Manual accessibility testing is crucial to ensure that your mobile apps and webs
 
 **Step 2:** Select the app you want to test and choose a device. Once selected, click on the **Start button** to launch the session.
 
-> Make sure the device supports accessibility features — look for the **Accessibility icon** next to the device name.
+> Make sure the device supports accessibility features, look for the **Accessibility icon** next to the device name.
 
 <img loading="lazy" src={require('../assets/images/real-device-app-testing/Acessiblity_Phone_selection.png').default} className="doc_img"/>
 

--- a/docs/screen-reader-on-real-devices-browser.md
+++ b/docs/screen-reader-on-real-devices-browser.md
@@ -54,7 +54,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 Manual accessibility testing is crucial to ensure that your mobile apps and websites are fully compliant with the Web Content Accessibility Guidelines (WCAG). This guarantees that your websites are usable by people with disabilities, regardless of their device or browsing capabilities.
 
-<BrandName />'s Live Screen Reader feature empowers you to perform manual accessibility testing on real Android devices, allowing you to navigate through app elements with spoken descriptions of the UI—similar to the [Google TalkBack](https://support.google.com/accessibility/android/topic/3529932?hl=en&ref_topic=9078845) functionality. This feature enables comprehensive accessibility testing to ensure compliance with WCAG standards.
+<BrandName />'s Live Screen Reader feature empowers you to perform manual accessibility testing on real Android devices, allowing you to navigate through app elements with spoken descriptions of the UI, similar to the [Google TalkBack](https://support.google.com/accessibility/android/topic/3529932?hl=en&ref_topic=9078845) functionality. This feature enables comprehensive accessibility testing to ensure compliance with WCAG standards.
 
 > This feature is currently in **Beta**
 

--- a/docs/screen-reader-voiceover-real-devices-app.md
+++ b/docs/screen-reader-voiceover-real-devices-app.md
@@ -87,7 +87,7 @@ The VoiceOver feature is currently supported on selected iOS devices, allowing a
 ---
 ## How to Navigate using Keyboard Shortcuts
 
-The navigation behavior on iOS—such as moving to the next or previous element, auto-reading from the start of the page, and interacting with UI elements—can be performed using keyboard shortcuts when **VoiceOver** is enabled.
+The navigation behavior on iOS, such as moving to the next or previous element, auto-reading from the start of the page, and interacting with UI elements, can be performed using keyboard shortcuts when **VoiceOver** is enabled.
 
 On a real iOS device, VoiceOver navigation can be executed via keyboard shortcuts and touch gestures as well . However, when performing  accessibility testing, using keyboard shortcuts is the most efficient way to validate VoiceOver interactions.
 

--- a/docs/screen-reader-voiceover-real-devices-browser.md
+++ b/docs/screen-reader-voiceover-real-devices-browser.md
@@ -85,7 +85,7 @@ The VoiceOver feature is currently supported on selected iOS devices, allowing a
 ---
 ## How to Navigate using Keyboard Shortcuts
 
-The navigation behavior on iOS—such as moving to the next or previous element, auto-reading from the start of the page, and interacting with UI elements—can be performed using keyboard shortcuts when **VoiceOver** is enabled.
+The navigation behavior on iOS, such as moving to the next or previous element, auto-reading from the start of the page, and interacting with UI elements, can be performed using keyboard shortcuts when **VoiceOver** is enabled.
 
 On a real iOS device, VoiceOver navigation can be executed via keyboard shortcuts and touch gestures as well. However, when performing accessibility testing, using keyboard shortcuts is the most efficient way to validate VoiceOver interactions.
 

--- a/docs/selenium-hyperexecute-accessibility-tests.md
+++ b/docs/selenium-hyperexecute-accessibility-tests.md
@@ -1,9 +1,9 @@
 ---
 id: selenium-hyperexecute-accessibility-tests
-title: HyperExecute integration — Selenium accessibility automation
+title: "HyperExecute integration: Selenium accessibility automation"
 hide_title: false
 sidebar_label: HyperExecute (Selenium)
-description: HyperExecute integration guide — run Selenium-based Accessibility Automation on the HyperExecute grid, align YAML with accessibility capabilities, and open reports after the job completes.
+description: "HyperExecute integration guide: run Selenium-based Accessibility Automation on the HyperExecute grid, align YAML with accessibility capabilities, and open reports after the job completes."
 keywords:
     - TestMu AI
     - Accessibility
@@ -40,19 +40,19 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
         },{
           "@type": "ListItem",
           "position": 3,
-          "name": "HyperExecute — Selenium accessibility automation",
+          "name": "HyperExecute: Selenium accessibility automation",
           "item": `${BRAND_URL}/support/docs/selenium-hyperexecute-accessibility-tests/`
         }]
       })
     }}
 ></script>
 
-# HyperExecute integration — Selenium accessibility automation
+# HyperExecute integration: Selenium accessibility automation
 
-This page is the **HyperExecute** integration guide for **Accessibility Automation** when your tests use **Selenium**. It assumes you already run Selenium jobs on HyperExecute (YAML + CLI) and need the same **accessibility** session capabilities and reporting behavior on the grid—not a generic Selenium-only tutorial. For framework setup on local or other grids, start with **[Accessibility Automation](/support/docs/accessibility-automation/)** and the **[Selenium](/support/docs/accessibility-automation-test/)** setup doc.
+This page is the **HyperExecute** integration guide for **Accessibility Automation** when your tests use **Selenium**. It assumes you already run Selenium jobs on HyperExecute (YAML + CLI) and need the same **accessibility** session capabilities and reporting behavior on the grid, not a generic Selenium-only tutorial. For framework setup on local or other grids, start with **[Accessibility Automation](/support/docs/accessibility-automation/)** and the **[Selenium](/support/docs/accessibility-automation-test/)** setup doc.
 
 :::note
-**Scope:** Selenium test code + `hyperexecute.yaml` orchestration on HyperExecute. If the Accessibility tab never appears on sessions, confirm `accessibility: true` (and related caps) in the process HyperExecute actually runs, and that Accessibility is enabled for your organization—contact support if needed.
+**Scope:** Selenium test code + `hyperexecute.yaml` orchestration on HyperExecute. If the Accessibility tab never appears on sessions, confirm `accessibility: true` (and related caps) in the process HyperExecute actually runs, and that Accessibility is enabled for your organization. Contact support if needed.
 :::
 
 ## Prerequisites
@@ -65,7 +65,7 @@ This page is the **HyperExecute** integration guide for **Accessibility Automati
 ## High-level flow (HyperExecute)
 
 1. Keep your Selenium suite configured for **HyperExecute** (YAML, discovery, `testRunnerCommand`).
-2. Enable **Accessibility** capabilities in the same session options you pass to `RemoteWebDriver` (or equivalent)—HyperExecute forwards them like any other capability.
+2. Enable **Accessibility** capabilities in the same session options you pass to `RemoteWebDriver` (or equivalent). HyperExecute forwards them like any other capability.
 3. Trigger the job with the **HyperExecute CLI** using your YAML.
 4. When the build finishes, open the session in the **Automation** dashboard and use the **Accessibility** tab for the report.
 
@@ -79,12 +79,12 @@ This page is the **HyperExecute** integration guide for **Accessibility Automati
 
 ## YAML and test code (integration point)
 
-HyperExecute does **not** replace Selenium capabilities—it **orchestrates** the same test JAR or Node project. The integration work is making sure the command HyperExecute runs is the profile that sets accessibility caps. Ensure:
+HyperExecute does **not** replace Selenium capabilities. It **orchestrates** the same test JAR or Node project. The integration work is making sure the command HyperExecute runs is the profile that sets accessibility caps. Ensure:
 
 - Your **test process** still loads the code path that sets `accessibility` on `RemoteWebDriver` / options.
 - **Discovery** in `hyperexecute.yaml` points at the same `mvn`/`gradle`/`npm` command you use locally for Accessibility runs.
 
-Example pattern (illustrative only—adapt to your repo’s actual `runson`, `pre`, and `testRunnerCommand`):
+Example pattern (illustrative only, adapt to your repo’s actual `runson`, `pre`, and `testRunnerCommand`):
 
 ```yaml
 version: 0.1
@@ -107,7 +107,7 @@ If your team keeps caps in **environment-specific property files**, inject those
 ## Related docs
 
 - [Accessibility Automation (Overview)](/support/docs/accessibility-automation/)
-- [Selenium — Accessibility Automation setup](/support/docs/accessibility-automation-test/)
+- [Selenium: Accessibility Automation setup](/support/docs/accessibility-automation-test/)
 - [Configure Accessibility Automation](/support/docs/accessibility-automation-settings/)
 - [HyperExecute CLI](/support/docs/hyperexecute-cli-run-tests-on-hyperexecute-grid/)
 - [HyperExecute YAML parameters](/support/docs/hyperexecute-yaml-parameters/)

--- a/docs/set-date-time-hour-format-real-devices-browser.md
+++ b/docs/set-date-time-hour-format-real-devices-browser.md
@@ -52,7 +52,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 ></script>
 
 
-Testing applications often requires validation across different date, time, and format scenarios. <BrandName /> now supports dynamic configuration of **date, time, 12/24-hour format**, and **automatic time toggle** on real **iOS (14+)** and **Android (10+)** devices — both in **manual** sessions and via **Appium automation hooks**.
+Testing applications often requires validation across different date, time, and format scenarios. <BrandName /> now supports dynamic configuration of **date, time, 12/24-hour format**, and **automatic time toggle** on real **iOS (14+)** and **Android (10+)** devices, both in **manual** sessions and via **Appium automation hooks**.
 
 This enables use cases like testing scheduled alerts, AM/PM behaviors, time-bound features, and regional formatting validations.
 
@@ -75,7 +75,7 @@ This enables use cases like testing scheduled alerts, AM/PM behaviors, time-boun
 <img loading="lazy" src={require('../assets/images/real-device-app-testing/set-date-and-time-pic-last.png').default} className="doc_img"/>
 
 :::note
-On Android devices, certain models — particularly those from **Motorola, Xiaomi, Oppo, and other Chinese OEMs** — do not support custom date and time configuration. On such devices, the modal will display a **Not Supported** message.
+On Android devices, certain models, particularly those from **Motorola, Xiaomi, Oppo, and other Chinese OEMs**, do not support custom date and time configuration. On such devices, the modal will display a **Not Supported** message.
 :::
 
 
@@ -125,7 +125,7 @@ The modal includes four options to simulate various datetime-related behaviors:
 | Android  | Manual + Appium Executor    | Android 10 and above  |
 
 :::warning
-Custom date and time configuration is not supported on certain Android device models — particularly those from **Motorola, Xiaomi, Oppo, and other Chinese OEMs**. On these devices, the modal will display a **Not Supported** message during manual sessions, and the Appium hook will return the following error during automation:
+Custom date and time configuration is not supported on certain Android device models, particularly those from **Motorola, Xiaomi, Oppo, and other Chinese OEMs**. On these devices, the modal will display a **Not Supported** message during manual sessions, and the Appium hook will return the following error during automation:
 
 `Custom date and time hook is not supported on this device. Please try on another device_id.`
 :::

--- a/docs/site-to-site-ipsec-vpn-setup.md
+++ b/docs/site-to-site-ipsec-vpn-setup.md
@@ -43,7 +43,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-<BrandName /> supports connectivity via IPsec Site-to-Site VPN (S2S VPN) for clients who need to test web applications hosted on internal/private networks that are not publicly accessible. This allows <BrandName /> cloud infrastructure to reach your privately hosted test environments directly over an encrypted, authenticated tunnel — just as if both networks are on the same LAN.
+<BrandName /> supports connectivity via IPsec Site-to-Site VPN (S2S VPN) for clients who need to test web applications hosted on internal/private networks that are not publicly accessible. This allows <BrandName /> cloud infrastructure to reach your privately hosted test environments directly over an encrypted, authenticated tunnel, just as if both networks are on the same LAN.
 
 :::info Executive Summary
 An IPsec Site-to-Site VPN creates a permanent, encrypted tunnel between your network gateway and <BrandName /> cloud, enabling secure access to internal staging environments, development servers, and private applications without exposing them to the public internet.

--- a/docs/slack-integration.md
+++ b/docs/slack-integration.md
@@ -40,7 +40,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
       })
     }}
 ></script>
-Slack is a cloud-based messaging platform designed for teams to collaborate in real time. It offers organized conversations through channels, instant messaging, file sharing, and powerful integrations with developer and productivity tools — making it ideal for DevOps and QA workflows.
+Slack is a cloud-based messaging platform designed for teams to collaborate in real time. It offers organized conversations through channels, instant messaging, file sharing, and powerful integrations with developer and productivity tools, making it ideal for DevOps and QA workflows.
 
 The <BrandName /> Slack Integration enables users to share or push bugs to their specified channel, capture screenshots, annotations, and issue information.
 

--- a/docs/smartui-hooks-region-ignore.md
+++ b/docs/smartui-hooks-region-ignore.md
@@ -61,7 +61,7 @@ Pass a `coordinates` entry (a list of `"x1,y1,x2,y2"` strings) under `ignoreDOM`
 
 <img loading="lazy" src={require('../assets/images/smartui-hooks-region-ignore/coordinate-rectangle.png').default} alt="A coordinate rectangle: x1,y1 is the top-left corner (left=50, top=50) and x2,y2 is the bottom-right corner (right=300, bottom=300), giving a 250 x 250 region." width="503" height="490" className="doc_img img_center"/>
 
-For example, `"50,50,300,300"` defines the region whose top-left corner is at `(left=50, top=50)` and whose bottom-right corner is at `(right=300, bottom=300)` — a 250 × 250 rectangle.
+For example, `"50,50,300,300"` defines the region whose top-left corner is at `(left=50, top=50)` and whose bottom-right corner is at `(right=300, bottom=300)`, a 250 × 250 rectangle.
 
 <Tabs className="docs__val" groupId="language">
 <TabItem value="java" label="Java" default>

--- a/docs/sync-test-instance.md
+++ b/docs/sync-test-instance.md
@@ -69,7 +69,7 @@ When you open a stale test instance, a banner appears at the top indicating how 
 
 ## Comparing Versions
 
-Before syncing, you can review exactly what changed. Click **View comparison** from the version banner to open a side-by-side diff view. This highlights all differences between the test case version currently linked to the test instance and the latest version of the same test case — including changes to descriptions, preconditions, and individual steps.
+Before syncing, you can review exactly what changed. Click **View comparison** from the version banner to open a side-by-side diff view. This highlights all differences between the test case version currently linked to the test instance and the latest version of the same test case, including changes to descriptions, preconditions, and individual steps.
 
 <img loading="lazy" src={require('../assets/images/test-manager/sync-test-instance/version-compare.png').default} alt="Version comparison view showing differences between versions" className="doc_img"/>
 
@@ -78,7 +78,7 @@ Before syncing, you can review exactly what changed. Click **View comparison** f
 When you click the sync action, a confirmation modal appears with the following details:
 
 - The instance will be updated to the latest version.
-- **All statuses will be reset to Not Started** — both the overall instance status and every individual step status.
+- **All statuses will be reset to Not Started**: both the overall instance status and every individual step status.
 - **Existing remarks and attachments will be preserved** for re-verification.
 
 <img loading="lazy" src={require('../assets/images/test-manager/sync-test-instance/update-version-modal.png').default} alt="Confirmation modal for updating test instance version" className="doc_img"/>
@@ -87,22 +87,22 @@ Click **Update to Version** to confirm, or **Cancel** to keep the current versio
 
 ### After Syncing
 
-Once synced, the test instance is updated with the latest master test case content — including any changes to the title, step descriptions, expected outcomes, and step structure (added, removed, or reordered steps). The instance and all step statuses are reset to **Not Started**, and a success notification confirms the update.
+Once synced, the test instance is updated with the latest master test case content, including any changes to the title, step descriptions, expected outcomes, and step structure (added, removed, or reordered steps). The instance and all step statuses are reset to **Not Started**, and a success notification confirms the update.
 
 <img loading="lazy" src={require('../assets/images/test-manager/sync-test-instance/instance-detail-updated.png').default} alt="Test instance updated to latest version with Not Started status" className="doc_img"/>
 
 ## Audit Log
 
-Every sync action is recorded in the test instance's [Audit Log](/support/docs/test-instance-audit-logs/). The log captures the version update (e.g., v1 → v2), the instance and step-level status resets, and any related changes — giving your team full traceability.
+Every sync action is recorded in the test instance's [Audit Log](/support/docs/test-instance-audit-logs/). The log captures the version update (e.g., v1 → v2), the instance and step-level status resets, and any related changes, giving your team full traceability.
 
 <img loading="lazy" src={require('../assets/images/test-manager/sync-test-instance/audit-logs.png').default} alt="Audit logs showing version sync and status reset events" className="doc_img"/>
 
 :::tip Duplicating a Test Run
-When you duplicate a test run, all test instances in the new run are automatically linked to the **latest version** of their master test cases — regardless of which version was used in the original run. All statuses are set to **Not Started**.
+When you duplicate a test run, all test instances in the new run are automatically linked to the **latest version** of their master test cases, regardless of which version was used in the original run. All statuses are set to **Not Started**.
 :::
 
 ## Limitations
 
-- **No auto-sync** — Syncing is a manual action. Test instances do not update automatically when the master test case changes.
-- **No partial status retention** — All statuses (instance and step level) are reset to **Not Started** upon sync. There is no option to selectively retain step statuses.
-- **KaneAI-generated versions** — If the latest version of a master test case was generated via **Automate with KaneAI**, the sync action is disabled for that instance. A tooltip indicates the reason when you hover over the disabled action.
+- **No auto-sync**: Syncing is a manual action. Test instances do not update automatically when the master test case changes.
+- **No partial status retention**: All statuses (instance and step level) are reset to **Not Started** upon sync. There is no option to selectively retain step statuses.
+- **KaneAI-generated versions**: If the latest version of a master test case was generated via **Automate with KaneAI**, the sync action is disabled for that instance. A tooltip indicates the reason when you hover over the disabled action.

--- a/docs/test-data-generation.md
+++ b/docs/test-data-generation.md
@@ -60,11 +60,11 @@ This page summarizes the three capabilities and points you to the deeper documen
 Author and manage datasets directly inside KaneAI Test Manager to drive the same test case with multiple inputs. Datasets remove the need to hand-craft fixtures or maintain external data files.
 
 **Capabilities:**
-- **Auto-generated default datasets** — every test case that uses parameters generates an immutable default dataset during authoring
-- **Custom datasets** — create copies of default datasets, add rows, and edit values to cover additional scenarios
-- **Autofill with AI** — populate dataset fields automatically based on parameter names (for example, generate realistic names, ages, and phone numbers)
-- **CSV import** — bring existing test data into KaneAI by uploading a CSV
-- **Version history** — track changes, revert, or restore previous dataset versions for audit and recovery
+- **Auto-generated default datasets**: every test case that uses parameters generates an immutable default dataset during authoring
+- **Custom datasets**: create copies of default datasets, add rows, and edit values to cover additional scenarios
+- **Autofill with AI**: populate dataset fields automatically based on parameter names (for example, generate realistic names, ages, and phone numbers)
+- **CSV import**: bring existing test data into KaneAI by uploading a CSV
+- **Version history**: track changes, revert, or restore previous dataset versions for audit and recovery
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/datasets/1.png').default} alt="KaneAI Test Manager Parameters table with Age, Phone number, and Name columns" className="doc_img img_center"/>
 
@@ -80,9 +80,9 @@ Author and manage datasets directly inside KaneAI Test Manager to drive the same
 Protect credentials, tokens, and other confidential values from showing up in network logs and test recordings. Masking is enforced at the platform level so sensitive data never lands in shared artifacts.
 
 **Capabilities:**
-- **Network payload masking (Selenium)** — set the `network.mask` capability to `true` to automatically mask values for sensitive keys (`key`, `password`, `token`, `auth`, `email`, `cipher`, `secret`, `nonce`, `salt`) across request headers, response headers, and cookies
-- **Lambda Masking for HyperExecute recordings** — automatically hide sensitive interactions captured in Playwright test recordings, including credentials, geolocation, and storage state
-- **Compliance-ready logs** — share test results, debug network traffic, and store CI/CD reports without exposing production secrets
+- **Network payload masking (Selenium)**: set the `network.mask` capability to `true` to automatically mask values for sensitive keys (`key`, `password`, `token`, `auth`, `email`, `cipher`, `secret`, `nonce`, `salt`) across request headers, response headers, and cookies
+- **Lambda Masking for HyperExecute recordings**: automatically hide sensitive interactions captured in Playwright test recordings, including credentials, geolocation, and storage state
+- **Compliance-ready logs**: share test results, debug network traffic, and store CI/CD reports without exposing production secrets
 
 **Documentation:**
 - [Network Data Masking for Selenium](/support/docs/network-data-masking/)
@@ -92,14 +92,14 @@ Protect credentials, tokens, and other confidential values from showing up in ne
 
 ## Parameterization
 
-Pass dynamic values into test cases at runtime so a single test runs across environments, accounts, and configurations. KaneAI provides a layered model — variables, secrets, smart variables, parameters, and datasets — so each piece of dynamic data is stored in the most appropriate way.
+Pass dynamic values into test cases at runtime so a single test runs across environments, accounts, and configurations. KaneAI provides a layered model (variables, secrets, smart variables, parameters, and datasets) so each piece of dynamic data is stored in the most appropriate way.
 
 **Capabilities:**
-- **Variables** — reusable placeholders for values that change between runs (URLs, user IDs, configuration flags)
-- **Secrets** — encrypted storage for credentials and other sensitive inputs that must never appear in plain text
-- **Smart variables** — context-aware values that resolve at runtime (for example, the current build's artifact URL)
-- **Parameters** — values supplied to a test case at execution time, including URL and data input fields, with the ability to convert any literal step value into a parameter on the fly
-- **Datasets** — combine parameters into rows for data-driven runs across multiple inputs
+- **Variables**: reusable placeholders for values that change between runs (URLs, user IDs, configuration flags)
+- **Secrets**: encrypted storage for credentials and other sensitive inputs that must never appear in plain text
+- **Smart variables**: context-aware values that resolve at runtime (for example, the current build's artifact URL)
+- **Parameters**: values supplied to a test case at execution time, including URL and data input fields, with the ability to convert any literal step value into a parameter on the fly
+- **Datasets**: combine parameters into rows for data-driven runs across multiple inputs
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/parameters/1.png').default} alt="Convert step value as Parameter, Variable, or Secret in KaneAI" className="doc_img img_center"/>
 

--- a/docs/test-run-creation-and-management.md
+++ b/docs/test-run-creation-and-management.md
@@ -87,7 +87,7 @@ Test instances are organized using a **Folders** sidebar on the left, reflecting
 
 - Select a folder to filter and view only its test instances. The status summary (Passed, Failed, Not Started, Skipped) is displayed in the top-right corner of the listing for the selected folder.
 - Collapse or expand folders for easier navigation.
-- Click the **three-dot menu** on the **Folders** header to toggle **Include Child Folders** — when enabled (default), selecting a parent folder also displays test instances from its child folders.
+- Click the **three-dot menu** on the **Folders** header to toggle **Include Child Folders**. When enabled (default), selecting a parent folder also displays test instances from its child folders.
 
 <img loading="lazy" src={require('../assets/images/test-run/6.png').default} alt="Real "  className="doc_img"/>
 
@@ -110,9 +110,9 @@ Test instances are organized using a **Folders** sidebar on the left, reflecting
 
 A filter bar above the test instance list lets you narrow down a test run by:
 
-- **Test instance attributes** — Status, Assignee, Platform, OS, Browser, Resolution, Device.
-- **Test case attributes** — Tags, Priority, Test Case Status.
-- **Test Case Custom Fields** — available under **More Filters**.
+- **Test instance attributes**: Status, Assignee, Platform, OS, Browser, Resolution, Device.
+- **Test case attributes**: Tags, Priority, Test Case Status.
+- **Test Case Custom Fields**: available under **More Filters**.
 
 Filters work on both Manual and Automation test runs, apply at the **All Test Instances** view as well as at any folder, and persist as you switch between folders. The active filter state is also reflected in the page URL, so you can bookmark or share a filtered view.
 
@@ -130,7 +130,7 @@ Custom Fields can be filtered only for types: **Single Select Dropdown**, **Mult
 <img loading="lazy" src={require('../assets/images/test-run/9.png').default} alt="Real "  className="doc_img"/>
 
 The Remark field supports **rich text formatting**, including:
-- Inline image embedding — paste images directly into the field.
+- Inline image embedding: paste images directly into the field.
 - Text styling such as bold, italic, bullet lists, and other standard rich text options.
 
 :::note
@@ -143,7 +143,7 @@ Remarks have a maximum limit of **5000 characters**.
 
 ## 6. Execute Test Runs on <BrandName /> Cloud
 
-Execute your manual test instances directly on <BrandName /> Cloud — no local setup or environment configuration required. This allows your team to run manual tests on real browsers and devices hosted on the cloud, making it one of the most efficient ways to validate your test cases.
+Execute your manual test instances directly on <BrandName /> Cloud, no local setup or environment configuration required. This allows your team to run manual tests on real browsers and devices hosted on the cloud, making it one of the most efficient ways to validate your test cases.
 
 **To execute a test run:**
 
@@ -156,7 +156,7 @@ Execute your manual test instances directly on <BrandName /> Cloud — no local 
 <img loading="lazy" src={require('../assets/images/test-run/14.png').default} alt="Real "  className="doc_img"/>
 
 :::tip Why execute on the Cloud?
-Running test instances on <BrandName /> Cloud gives you access to a wide range of real browsers, devices, and OS combinations — without maintaining local infrastructure. It ensures consistent, reliable test execution across environments.
+Running test instances on <BrandName /> Cloud gives you access to a wide range of real browsers, devices, and OS combinations, without maintaining local infrastructure. It ensures consistent, reliable test execution across environments.
 :::
 
 :::note Track bugs during execution

--- a/docs/test-settings-options.md
+++ b/docs/test-settings-options.md
@@ -33,12 +33,12 @@ We offer multiple options for comparing the **Baseline** and the **Test Output**
 
 Here are common **pixel-to-pixel** comparison options. The first group is **actively used** through `smartUI.options` (or your framework’s equivalent) in typical integrations:
 
-- `largeImageThreshold` — Pixel granularity for how comparison blocks are formed.
-- `errorType` — How differences are highlighted (`movement`, `flat`, etc.).
-- `ignore` — Reduces P2P false positives (`antialiasing`, `alpha`, `colors`, `nothing`).
-- `transparency` — Overlay transparency for the diff view.
+- `largeImageThreshold`: Pixel granularity for how comparison blocks are formed.
+- `errorType`: How differences are highlighted (`movement`, `flat`, etc.).
+- `ignore`: Reduces P2P false positives (`antialiasing`, `alpha`, `colors`, `nothing`).
+- `transparency`: Overlay transparency for the diff view.
 
-The sections **[Bounding Boxes](#bounding-boxes---compare-only-specific-area)**, **[Ignore Boxes](#ignore-boxes---ignore-only-specific-area)**, and **[Ignore Areas Colored](#ignore-areas-colored---removes-the-colored-content-from-the-comparison)** describe **region- and color-based** comparison. Examples nest keys under **`smartUI.options`** / **`smart_ui.options`** like the options above; **still validate** with your integration or support—see the warning before **Bounding Boxes**. For region-level control in the product UI, prefer **[Draw on UI / annotations](/support/docs/smartui-draw-on-ui/)**.
+The sections **[Bounding Boxes](#bounding-boxes---compare-only-specific-area)**, **[Ignore Boxes](#ignore-boxes---ignore-only-specific-area)**, and **[Ignore Areas Colored](#ignore-areas-colored---removes-the-colored-content-from-the-comparison)** describe **region- and color-based** comparison. Examples nest keys under **`smartUI.options`** / **`smart_ui.options`** like the options above; **still validate** with your integration or support, see the warning before **Bounding Boxes**. For region-level control in the product UI, prefer **[Draw on UI / annotations](/support/docs/smartui-draw-on-ui/)**.
 
 ## Examples with comparison settings
 
@@ -234,14 +234,14 @@ let capabilities = {
 ---
 
 :::warning `boundingBoxes`, `ignoredBoxes`, `ignoreAreasColoredWith`
-These three comparison modes exist in SmartUI’s **pixel-to-pixel** model. The examples below nest them under **`smartUI.options`** (Selenium) and **`smart_ui.options`** (Cypress)—the same shape as **Image Threshold** through **Transparency**—but **behavior can still vary by integration**; **do not copy into production** without validating against your session or with **[support](mailto:support@testmuai.com)**. For box/color-style ignores in the UI, use **[Draw on UI](/support/docs/smartui-draw-on-ui/)** or confirm the supported payload with support.
+These three comparison modes exist in SmartUI’s **pixel-to-pixel** model. The examples below nest them under **`smartUI.options`** (Selenium) and **`smart_ui.options`** (Cypress), the same shape as **Image Threshold** through **Transparency**, but **behavior can still vary by integration**; **do not copy into production** without validating against your session or with **[support](mailto:support@testmuai.com)**. For box/color-style ignores in the UI, use **[Draw on UI](/support/docs/smartui-draw-on-ui/)** or confirm the supported payload with support.
 :::
 
 ### Bounding Boxes - Compare only specific area {#bounding-boxes---compare-only-specific-area}
 
 The bounding boxes are the areas created on the screenshot which needs to be compared with the baseline ignoring other areas from the screenshot.
 
-**Reference only —** verify with support before relying on capability wiring.
+**Reference only:** verify with support before relying on capability wiring.
 
 This specific case is used to compare only a specific area of the screenshot from the **baseline**.
 
@@ -316,7 +316,7 @@ let capabilities = {
 
 ### Ignore Boxes - Ignore only specific area {#ignore-boxes---ignore-only-specific-area}
 
-**Reference only —** verify with support before relying on capability wiring.
+**Reference only:** verify with support before relying on capability wiring.
 
 The ignored boxes are the areas created on the screenshot which needs to be ignored with the baseline comparing the other areas from the screenshot.
 
@@ -393,7 +393,7 @@ let capabilities = {
 
 ### Ignore Areas Colored - Removes the colored content from the comparison {#ignore-areas-colored---removes-the-colored-content-from-the-comparison}
 
-**Reference only —** verify with support before relying on capability wiring.
+**Reference only:** verify with support before relying on capability wiring.
 
 You can exclude the pixels that match the specified color on a **baseline** image from the comparison view. This feature will ignore that specific regions with the color pixels and shows the comparison view.
 

--- a/docs/testing-your-first-ai-agent.md
+++ b/docs/testing-your-first-ai-agent.md
@@ -3,7 +3,7 @@ id: testing-your-first-ai-agent
 title: Testing Your First AI Agent
 hide_title: false
 sidebar_label: Test Your First AI Agent
-description: Step-by-step guide to setting up and running your first AI agent test on TestMu AI—configure inputs, run validations, and review results.
+description: "Step-by-step guide to setting up and running your first AI agent test on TestMu AI: configure inputs, run validations, and review results."
 keywords:
  - agent testing
  - agentic testing

--- a/docs/testmu-a2a-cli.md
+++ b/docs/testmu-a2a-cli.md
@@ -336,7 +336,7 @@ Note the project ID from the output.
 
 **Step 2: Set the agent prompt.** This is the most important step - the prompt drives scenario generation, evaluation criteria, and go-live assessments.
 
-From a YAML file (recommended — define everything in one place):
+From a YAML file (recommended, define everything in one place):
 
 ```bash
 testmu-a2a prompts set --project <project_id> --from-file prompt.yaml

--- a/docs/track-issues-in-test-runs.md
+++ b/docs/track-issues-in-test-runs.md
@@ -46,12 +46,12 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 ## Overview
 
-Test Manager connects the bugs found during testing to the test instances that exposed them. Every test instance in a Test Run carries its own issues, so the run becomes a traceable map of test results and the defects behind them — you can see which tests have known bugs and open any of them in one click.
+Test Manager connects the bugs found during testing to the test instances that exposed them. Every test instance in a Test Run carries its own issues, so the run becomes a traceable map of test results and the defects behind them. You can see which tests have known bugs and open any of them in one click.
 
 There are two ways to put a bug on a test instance:
 
-- **Link an existing issue** — connect a Jira or Azure DevOps ticket that already exists.
-- **Raise a new bug with Mark as Bug** — create a new ticket in your bug tracker while you execute the test.
+- **Link an existing issue**: connect a Jira or Azure DevOps ticket that already exists.
+- **Raise a new bug with Mark as Bug**: create a new ticket in your bug tracker while you execute the test.
 
 This works in Manual, KaneAI, and Automation Test Runs.
 
@@ -64,13 +64,13 @@ This works in Manual, KaneAI, and Automation Test Runs.
 
 ## How bug tracking works in a Test Run
 
-A bug is always associated with a **test instance** — one test case running with one configuration inside a Test Run. Whether you link an existing issue or raise a new one, the association is the same, and the bug becomes visible in three places:
+A bug is always associated with a **test instance**, one test case running with one configuration inside a Test Run. Whether you link an existing issue or raise a new one, the association is the same, and the bug becomes visible in three places:
 
 - On the test instance level.
 - In the Test Run's consolidated **Issues** tab, which lists every bug in the run.
 - Inside the Issues tab of the corresponding Test Case.
 
-You can add a bug from any of these points — from the run's instance list, from inside an instance, or from a specific step of an instance. A bug added at a step is listed with its parent instance, so you always see the complete picture at the instance level.
+You can add a bug from any of these points: from the run's instance list, from inside an instance, or from a specific step of an instance. A bug added at a step is listed with its parent instance, so you always see the complete picture at the instance level.
 
 ## Link an existing issue to a test instance
 
@@ -81,7 +81,7 @@ Use this when the defect is already tracked in Jira or Azure DevOps and you want
 
 <img loading="lazy" src={require('../assets/images/test-run-issues/test-instance-issue-menu.png').default} alt="Bug menu on a test instance row with Link Issue and View Issues options" className="doc_img"/>
 
-3. In the **Link Issues** dialog, choose the tracker — **Jira** or **Azure DevOps**. Only trackers you have integrated are available.
+3. In the **Link Issues** dialog, choose the tracker: **Jira** or **Azure DevOps**. Only trackers you have integrated are available.
 4. Enter the issue key or paste its URL.
 5. Click **Link Issue**.
 
@@ -93,7 +93,7 @@ The issue is now linked, and the test instance row shows a bug count. That count
 
 Use this when you find a defect while executing a test and no ticket exists yet.
 
-1. On a test instance — or a specific step within it — choose **Mark as Bug**.
+1. On a test instance, or a specific step within it, choose **Mark as Bug**.
 2. In the **Create an Issue** panel, confirm the bug tracker. Use **Switch App** to file the bug in a different connected tracker.
 3. Fill in the issue details, such as the project, issue type, and summary. Required fields are marked. The panel already carries the test instance's context.
 4. Click **Create Issue**.
@@ -110,10 +110,10 @@ Mark as Bug can file tickets in several bug trackers, but only Jira and Azure De
 
 You can review the bugs on a test instance in two ways:
 
-- **From the run list** — open the bug menu on the instance row and select **View Issues**. A side panel lists every issue associated with that instance.
-- **From the instance** — open the test instance and go to its **Issues** tab. The tab header shows how many issues the instance carries. This is only possible in Manual Test Runs.
+- **From the run list**: open the bug menu on the instance row and select **View Issues**. A side panel lists every issue associated with that instance.
+- **From the instance**: open the test instance and go to its **Issues** tab. The tab header shows how many issues the instance carries. This is only possible in Manual Test Runs.
 
-Each issue entry shows its title, key, type, status, priority, the project it belongs to, and who created it — enough to triage without opening the tracker. Use the search box and the **Status** and **Issue Type** filters to narrow a long list.
+Each issue entry shows its title, key, type, status, priority, the project it belongs to, and who created it, enough to triage without opening the tracker. Use the search box and the **Status** and **Issue Type** filters to narrow a long list.
 
 <img loading="lazy" src={require('../assets/images/test-run-issues/view-issues-panel.png').default} alt="View Issues panel listing the bugs associated with a test instance" className="doc_img"/>
 
@@ -121,28 +121,28 @@ Each issue entry shows its title, key, type, status, priority, the project it be
 
 You do not have to act from the run list. Inside a test instance you can link an existing issue or raise a new bug at two levels:
 
-- **At the instance** — for a defect that affects the test case as a whole.
-- **At a step** — open the **Test Steps** tab and use the bug action on the step where the failure occurred, so the defect is recorded against the exact point of failure.
+- **At the instance**: for a defect that affects the test case as a whole.
+- **At a step**: open the **Test Steps** tab and use the bug action on the step where the failure occurred, so the defect is recorded against the exact point of failure.
 
 A bug added at a step is listed on the instance's **Issues** tab along with every other issue for that instance, so the instance always reflects the full set of defects found.
 
 ## See every issue in the run
 
-The Test Run's **Issues** tab is the consolidated view of every bug raised or linked across all of its test instances — useful for a defect triage or a run sign-off.
+The Test Run's **Issues** tab is the consolidated view of every bug raised or linked across all of its test instances, useful for a defect triage or a run sign-off.
 
 1. Open the Test Run and go to the **Issues** tab.
 2. To add a bug that is not yet tied to a specific instance, use **Link Issue** on this tab.
-3. To focus the list, filter by **Test Case** — for example, to see only the bugs behind one failing test case. You can also filter by **Status** and **Issue Type**, or search by keyword.
+3. To focus the list, filter by **Test Case**, for example, to see only the bugs behind one failing test case. You can also filter by **Status** and **Issue Type**, or search by keyword.
 
 ## Unlink an issue
 
-If a bug no longer belongs on a test instance, open the instance's **Issues** tab (or the **View Issues** panel), find the issue, and use its unlink action. Unlinking removes the association in Test Manager only — the ticket itself stays in Jira or Azure DevOps.
+If a bug no longer belongs on a test instance, open the instance's **Issues** tab (or the **View Issues** panel), find the issue, and use its unlink action. Unlinking removes the association in Test Manager only. The ticket itself stays in Jira or Azure DevOps.
 
 ## Supported trackers and visibility
 
 Linking an existing issue is available for **Jira** and **Azure DevOps**.
 
-Mark as Bug can create tickets in several bug tracking tools, but only **Jira** and **Azure DevOps** tickets are associated with — and visible in — Test Runs, Test Cases, and test instances. A bug raised in any other tracker is created successfully but does not appear in these views.
+Mark as Bug can create tickets in several bug tracking tools, but only **Jira** and **Azure DevOps** tickets are associated with, and visible in, Test Runs, Test Cases, and test instances. A bug raised in any other tracker is created successfully but does not appear in these views.
 
 <nav aria-label="breadcrumbs">
   <ul className="breadcrumbs">

--- a/docs/troubleshooting-ios-app-testing.md
+++ b/docs/troubleshooting-ios-app-testing.md
@@ -53,7 +53,7 @@ For a complete step-by-step guide on building your iOS app for Simulator testing
 
 ### App crashes immediately with "App quit unexpectedly"
 
-**Cause:** Your `.app` is built for physical iOS devices (Mach-O Platform 2 — `iphoneos`) instead of the iOS Simulator (Platform 7 — `iphonesimulator`).
+**Cause:** Your `.app` is built for physical iOS devices (Mach-O Platform 2: `iphoneos`) instead of the iOS Simulator (Platform 7: `iphonesimulator`).
 
 **Solution:** Rebuild your app targeting the iOS Simulator SDK. In Xcode, select a **Simulator destination** (e.g., *iPhone 15 Pro*) instead of *Any iOS Device*, then build. For command line builds, use the `-sdk iphonesimulator` flag:
 

--- a/docs/web-scanner-accessibility-scan.md
+++ b/docs/web-scanner-accessibility-scan.md
@@ -45,7 +45,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 Web Scanner exposes Accessibility scanning as an integrated workflow for site-wide URL-based scans. It is separate from Accessibility DevTools and from Accessibility Test Scheduling, even though the configuration concepts can overlap.
 
-When you are already in Web Scanner, this page walks through configuring an Accessibility scan and interpreting the main options—WCAG target, review and best-practice toggles, local testing, and login settings—before you start the run. Use it to align scan settings with your environment and reporting goals on that product surface.
+When you are already in Web Scanner, this page walks through configuring an Accessibility scan and interpreting the main options (WCAG target, review and best-practice toggles, local testing, and login settings) before you start the run. Use it to align scan settings with your environment and reporting goals on that product surface.
 
 ## When to use this
 
@@ -57,7 +57,7 @@ Use this page when you are already in Web Scanner and want to run an Accessibili
 2. You have a **URL list** or plan to add URLs through the wizard, and permission to scan those hosts.
 3. For private environments, install or enable **TestMu AI Tunnel** per [Testing Locally Hosted Pages](/support/docs/testing-locally-hosted-pages/) **before** starting a scan that depends on local routing.
 4. For authenticated sites, collect **login steps** or credentials formats the wizard supports (see **Login Configurations** on this page).
-5. Decide the **WCAG target** and whether **best-practice** or **needs-review** items belong in the first run—narrower scopes make first triage faster.
+5. Decide the **WCAG target** and whether **best-practice** or **needs-review** items belong in the first run. Narrower scopes make first triage faster.
 
 ## Key configuration options
 

--- a/docs/web-scanner-visual-scan.md
+++ b/docs/web-scanner-visual-scan.md
@@ -137,7 +137,7 @@ After running your tests, the **Visual Build** becomes available in the dashboar
 <img loading="lazy" src={require('../assets/images/web-scanner/visual-build.png').default} alt="Visual Build" className="doc_img"/>
 
 ### Build Status
-Easily track the state of each screenshot — **Approved**, **Changes Found**, **New**, **Under Review**, and more.
+Easily track the state of each screenshot: **Approved**, **Changes Found**, **New**, **Under Review**, and more.
 
 <p align="center">
   <img loading="lazy" src={require('../assets/images/web-scanner/threedot-visual.png').default} alt="Build Status View" className="doc_img"/>


### PR DESCRIPTION
Removes every em dash (`—`) from the `docs/` tree, per the house style of no em dashes and no semicolons.

### What changed
- **194 files, 1,234 em dashes removed.**
- Context-aware replacements:
  - Colons for list/label intros and `- **Term** — desc` bullets.
  - Commas for parenthetical asides and mid-sentence continuations.
  - Periods where two independent clauses were joined.
  - Parentheses for asides that already contained commas.
  - Plain hyphen / "None" for bare em dashes used as table-cell placeholders.
- **No semicolons introduced** (net semicolon count actually went down by 4).
- En dashes (`–`), hyphens, non-breaking hyphens, and markdown table separator rows were left untouched.
- Frontmatter `title`/`description` values that picked up an internal colon are wrapped in double quotes to keep YAML valid.

### Verification
- Repo-wide `grep '—' docs/` returns **zero**.
- Production `docusaurus build`: Server and Client both **compiled successfully**, with no MDX, YAML, or broken-link errors across the changed pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)