### PR TITLE
Tunnel Release Notes | Add 3.2.29 Windows proxy auto-detect and CVE fixes

### DIFF
--- a/docs/tunel-release-notes.md
+++ b/docs/tunel-release-notes.md
@@ -44,6 +44,10 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 ## Version 3.2.29 (14th June 2026)
 - **gRPC / HTTP/2 Tunnel Fix**
   - Fixed gRPC-over-HTTP/2 traffic hanging through the tunnel for strict HTTP/1.1 CONNECT clients (e.g. Flutter / grpc-dart apps on real devices). The tunnel now replies `HTTP/1.1 200` on the passthrough CONNECT path, so these clients establish the tunnel instead of timing out.
+- **Windows System Proxy Auto-Detection**
+  - Auto-detect the Windows system PAC (`Use setup script`) and manual proxy when no proxy flags or `--pacfile` are provided.
+- **Security Updates and Stability Fixes**
+  - Updated `golang.org/x/net` and `golang.org/x/crypto` dependencies to address reported CVEs.
 
 ## Version 3.2.28 (24th May 2026)
 - **Security Updates and Stability Fixes**


### PR DESCRIPTION
Documents the remaining changes shipping in **tunnel client 3.2.29** (burrow [#641](https://github.com/LambdatestIncPrivate/burrow/pull/641), Stage → Prod), added to the existing 3.2.29 entry in `docs/tunel-release-notes.md`:

- **Windows System Proxy Auto-Detection** — auto-detect the Windows system PAC (`Use setup script`) and manual proxy when no proxy flags or `--pacfile` are given (TE-18784).
- **Security Updates and Stability Fixes** — bumped `golang.org/x/net` (0.55.0) and `golang.org/x/crypto` (0.52.0) to clear reported CVEs (TE-19165).

The gRPC/HTTP2 passthrough-CONNECT fix (TE-17124) was already documented under 3.2.29; all three ship under binary version 3.2.29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)