### PR TITLE
docs(smartui): document webElement element-scoped screenshot capture (TE-19999)

### DIFF
--- a/docs/smartui-hooks-element-screenshot.md
+++ b/docs/smartui-hooks-element-screenshot.md
@@ -51,7 +51,7 @@ Make sure you have:
 
 - A LambdaTest account with Web Automation access, such as Selenium on the LambdaTest Grid.
 - SmartUI enabled for the session. Your SmartUI project and build must be configured on the test session.
-- A locator for the target element, such as a CSS selector, XPath, or HTML `id`.
+- A locator for the target element, such as a CSS selector, XPath, or HTML `id`. You can also pass an already-resolved element handle, see [Capture by Resolved Element Handle](#capture-by-resolved-element-handle-webelement).
 
 :::note
 Do not store usernames or access keys in your source repository. Use environment variables or your CI secret manager instead.
@@ -84,8 +84,8 @@ The JSON must include at least these fields:
 | Field | Purpose |
 |---|---|
 | `screenshotName` | Stable name for the screenshot in SmartUI. Used for baselines and comparisons. |
-| `elementType` | Locator type. Supported values: `css_selector`, `xpath`, `id`, `class` |
-| `element` | Locator value for the target element |
+| `elementType` | Locator type. Supported values: `css_selector`, `xpath`, `id`, `class`, `webElement` |
+| `element` | Locator value for the target element. When `elementType` is `webElement`, this is a resolved element handle instead of a locator string. See [Capture by Resolved Element Handle](#capture-by-resolved-element-handle-webelement). |
 | `fullPage` | Set to `false` to capture only the target element |
 
 Example JSON:
@@ -107,6 +107,40 @@ Update `elementType` and `element` to match the locator used in your test.
 If you want to capture more than one component, call the hook again with a different `screenshotName` for each one.
 
 Keep screenshot names stable across runs so SmartUI compares against the correct baseline.
+
+## Capture by Resolved Element Handle (webElement)
+
+The locator-based flow above re-resolves your selector at the moment the screenshot runs. On pages where the DOM is rewritten after you locate the element, for example a workspace that rebuilds its layout every time a new tab is added, the selector can go stale before capture and the element screenshot fails.
+
+To avoid this, set `elementType` to `webElement` and pass an already-resolved element reference as `element`. SmartUI uses that live handle directly and skips locator re-resolution, so the capture stays reliable even when the surrounding DOM changes after the element was located.
+
+:::note
+When `elementType` is `webElement`, you pass a real element object, not a string. Call the hook with the command name and a config object as two separate arguments so your automation framework serializes the element handle correctly. Do not use the `smartui.takeScreenshot,<JSON>` string form for `webElement`, because a serialized string cannot carry a live element reference.
+:::
+
+First resolve the element in your test, then pass it to the hook:
+
+```javascript
+const el = await driver.findElement(By.className('hero-heading'));
+
+const config = {
+  screenshotName: 'region-screenshot',
+  elementType: 'webElement',
+  element: el
+};
+
+await driver.executeScript('smartui.takeScreenshot', config);
+```
+
+| Field | Purpose |
+|---|---|
+| `screenshotName` | Stable name for the captured screenshot in SmartUI. |
+| `elementType` | Set to `webElement` to pass a resolved element handle instead of a locator. |
+| `element` | The resolved element reference to scope the capture to, for example the return value of `driver.findElement(...)`. |
+
+:::tip
+Use `webElement` when the element is present and stable when you locate it, but the page mutates the DOM before the screenshot runs. If your locator stays valid through capture, the locator-based flow in Step 3 is simpler.
+:::
 
 ## Optional: Capture Many Elements Automatically
 
@@ -231,6 +265,7 @@ for (const item of elements) {
 | CSS selector | `css_selector` | `main article:first-of-type` |
 | XPath | `xpath` | `//div[@data-testid='invoice-panel']` |
 | HTML `id` | `id` | `sidebar` |
+| Resolved element handle | `webElement` | `await driver.findElement(By.className('hero-heading'))` |
 
 ## Related Docs
 


### PR DESCRIPTION
## What

Documents the new `webElement` support in the SmartUI Hooks element-screenshot flow, shipped under [TE-19999](https://lambdatest.atlassian.net/browse/TE-19999) (Salesforce: CheckRegion/SelectRegion based on element handles instead of locators). Feature is deployed on prod and QA-verified.

Updates the existing **Element Screenshot** page (`smartui-hooks-element-screenshot.md`) rather than adding a new one, per the request to modify the existing doc with webElement support.

## Changes

- Added `webElement` to the `elementType` field table and the Quick Reference table.
- New section **Capture by Resolved Element Handle (webElement)** covering:
  - Why: on pages where the DOM is rewritten after the element is located (e.g. a workspace that rebuilds on every tab add), a locator can go stale before capture. Passing a resolved handle skips locator re-resolution and stays reliable.
  - The `driver.findElement(...)` → config object → `driver.executeScript('smartui.takeScreenshot', config)` flow.
  - A `:::note` that `webElement` must use the object form (two args), not the `smartui.takeScreenshot,<JSON>` string form, since a serialized string cannot carry a live element reference.
- Mentioned the resolved-handle alternative in **Before You Start**.

## Validated API surface (from the ticket, confirmed on prod)

```javascript
const el = await driver.findElement(By.className('hero-heading'));
const config = {
  screenshotName: 'region-screenshot',
  elementType: 'webElement',
  element: el
};
await driver.executeScript('smartui.takeScreenshot', config);
```

## Verification

- Dev server compiles clean, route present in `.docusaurus/routes.js`, in-page anchor links resolve, page renders in the SmartUI > Lambda Hooks > Element Screenshot sidebar slot.
- No new page/sidebar entry needed (edits an existing page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TE-19999]: https://lambdatest.atlassian.net/browse/TE-19999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ