### PR TITLE
docs(smartui): fix takeScreenshot hook syntax on element screenshot page

### DIFF
--- a/docs/smartui-hooks-element-screenshot.md
+++ b/docs/smartui-hooks-element-screenshot.md
@@ -73,13 +73,18 @@ This helps ensure the correct region is ready for capture. Use your framework's 
 
 Run a JavaScript string in the browser context, for example using Selenium `executeScript()`.
 
-Use the following format:
+Call the hook with your screenshot options:
 
-```text
-smartui.takeScreenshot,<JSON>
+```js
+smartui.takeScreenshot({
+  screenshotName: "Checkout_Summary_Block",
+  elementType: "css_selector",
+  element: "section.checkout-summary",
+  fullPage: false
+});
 ```
 
-The JSON must include at least these fields:
+Include at least these fields:
 
 | Field | Purpose |
 |---|---|
@@ -87,12 +92,6 @@ The JSON must include at least these fields:
 | `elementType` | Locator type. Supported values: `css_selector`, `xpath`, `id`, `class` |
 | `element` | Locator value for the target element |
 | `fullPage` | Set to `false` to capture only the target element |
-
-Example, with the JSON in place of `<JSON>`. This is the full script string passed to `executeScript()`:
-
-```text
-smartui.takeScreenshot,{"screenshotName":"Checkout_Summary_Block","elementType":"css_selector","element":"section.checkout-summary","fullPage":false}
-```
 
 Update `elementType` and `element` to match the locator used in your test.
 
@@ -184,12 +183,12 @@ for (const item of elements) {
   const screenshotName = `element_${label}`.replace(/[^a-zA-Z0-9_-]+/g, '_').slice(0, 80);
 
   await driver.executeScript(
-    `smartui.takeScreenshot,${JSON.stringify({
+    `smartui.takeScreenshot(${JSON.stringify({
       screenshotName,
       elementType: 'xpath',
       element: item.xpath,
       fullPage: false
-    })}`
+    })})`
   );
 }
 ```

--- a/docs/smartui-hooks-element-screenshot.md
+++ b/docs/smartui-hooks-element-screenshot.md
@@ -71,20 +71,20 @@ This helps ensure the correct region is ready for capture. Use your framework's 
 
 ## Step 3: Call the SmartUI Element Screenshot Hook
 
-Run a JavaScript string in the browser context, for example using Selenium `executeScript()`.
-
-Call the hook with your screenshot options:
+Call the SmartUI hook through your driver's script executor, passing `"smartui.takeScreenshot"` as the command and a config object with your screenshot options:
 
 ```js
-smartui.takeScreenshot({
+const config = {
   screenshotName: "Checkout_Summary_Block",
   elementType: "css_selector",
   element: "section.checkout-summary",
   fullPage: false
-});
+};
+
+await driver.executeScript("smartui.takeScreenshot", config);
 ```
 
-Include at least these fields:
+The config object must include at least these fields:
 
 | Field | Purpose |
 |---|---|
@@ -182,14 +182,12 @@ for (const item of elements) {
 
   const screenshotName = `element_${label}`.replace(/[^a-zA-Z0-9_-]+/g, '_').slice(0, 80);
 
-  await driver.executeScript(
-    `smartui.takeScreenshot(${JSON.stringify({
-      screenshotName,
-      elementType: 'xpath',
-      element: item.xpath,
-      fullPage: false
-    })})`
-  );
+  await driver.executeScript("smartui.takeScreenshot", {
+    screenshotName,
+    elementType: 'xpath',
+    element: item.xpath,
+    fullPage: false
+  });
 }
 ```
 

--- a/docs/smartui-hooks-element-screenshot.md
+++ b/docs/smartui-hooks-element-screenshot.md
@@ -88,13 +88,7 @@ The JSON must include at least these fields:
 | `element` | Locator value for the target element |
 | `fullPage` | Set to `false` to capture only the target element |
 
-Example JSON:
-
-```json
-{"screenshotName":"Checkout_Summary_Block","elementType":"css_selector","element":"section.checkout-summary","fullPage":false}
-```
-
-Full script string passed to `executeScript()`:
+Example, with the JSON in place of `<JSON>`. This is the full script string passed to `executeScript()`:
 
 ```text
 smartui.takeScreenshot,{"screenshotName":"Checkout_Summary_Block","elementType":"css_selector","element":"section.checkout-summary","fullPage":false}


### PR DESCRIPTION
## What

The [Element Screenshot Hook](https://www.testmuai.com/support/docs/smartui-hooks-element-screenshot/) page used a `smartui.takeScreenshot,<JSON>` comma-string format that **appears nowhere else in the docs**. Every other SmartUI hook page (group-by-test-cases, appium-sdk, gitlab-pr-checks, layout-comparison, ...) uses the canonical two-argument form: the command string plus a config object.

## Change

Aligned this page with the standard syntax:

```js
const config = {
  screenshotName: "Checkout_Summary_Block",
  elementType: "css_selector",
  element: "section.checkout-summary",
  fullPage: false
};

await driver.executeScript("smartui.takeScreenshot", config);
```

- Removed the `smartui.takeScreenshot,<JSON>` placeholder line and the separate bare-JSON example.
- Main example and the batch-loop example both now pass a config object as the second arg to `executeScript`, matching `executeScript("smartui.takeScreenshot", config)` used across the other hook docs.
- Fields table retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)