### PR TITLE
docs(smartui): flat tables on Hooks Layout/Full-Page/Smart Ignore page

### DIFF
--- a/docs/smartui-hooks-layout-fullpage-smartignore.md
+++ b/docs/smartui-hooks-layout-fullpage-smartignore.md
@@ -52,12 +52,16 @@ Use this page when you run **SmartUI Hooks** on LambdaTest (for example, Seleniu
 
 SmartUI Hooks split configuration between the session capabilities (`LT:Options`) and the per-screenshot hook:
 
+<div className="flat-table">
+
 | Goal | Where to configure | How |
 |------|--------------------|-----|
 | **Layout** comparison | `smartui.takeScreenshot` hook options | Pass `ignoreType: ["layout"]` in the options map for that screenshot. |
 | **Full-page** capture | `smartui.takeScreenshot` hook options | Pass `fullPage: true` in the options map for that screenshot. |
 | **Smart Ignore** | `LT:Options` | Set `smartUI.smartIgnore: true` on the session, for both baseline and comparison runs. |
 | **Project** | `LT:Options` | Set `smartUI.project` (with `visual` and credentials). |
+
+</div>
 
 Layout and full page are enabled per screenshot through the hook options, not through `LT:Options` capabilities. When you use Smart Ignore, choose either **Ignore DOM** or **Select DOM** in the dashboard for a given flow, not both.
 
@@ -249,6 +253,8 @@ These patterns do not turn on Smart Ignore:
 Set `smartUI.smartIgnore: true` instead.
 :::
 
+<div className="flat-table">
+
 | Problem | What to do |
 |---------|------------|
 | Layout never activates; only set in `LT:Options` | Move `ignoreType: ["layout"]` into the `smartui.takeScreenshot` options (see §2). |
@@ -256,6 +262,8 @@ Set `smartUI.smartIgnore: true` instead.
 | Tried `smartUI.layout` or nested `smartUI.options` layout blocks | These are not the Hooks switch for layout; use the hook options instead. |
 | Strict (pixel) comparison still applies | Align the dashboard comparison mode with the session capabilities. |
 | Relying on dashboard toggles only | Hooks still need the correct hook option and capability split shown above. |
+
+</div>
 
 ## Related Docs
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1733,6 +1733,10 @@ table th, table td{border: none;}
 table th{background-color: #fff;}
 table th:not(:last-child), table td:not(:last-child){border-right: 1px solid #d4d4d4;}
 
+/* Flat tables: header and cells match the page background instead of a filled header */
+.flat-table table th,
+.flat-table table td{background-color: var(--ifm-background-color);}
+
 .desired-capabilities-page table {
   table-layout: fixed;
 }
@@ -1855,6 +1859,11 @@ html[data-theme='dark'] .feedback__form__submit__btn {
 
 html[data-theme='dark'] table th {
   background-color: #0D1117;
+}
+
+html[data-theme='dark'] .flat-table table th,
+html[data-theme='dark'] .flat-table table td {
+  background-color: var(--ifm-background-color);
 }
 
 html[data-theme='dark'] table, html[data-theme='dark'] table th:not(:last-child), html[data-theme='dark'] table td:not(:last-child), html[data-theme='dark'] table tr {


### PR DESCRIPTION
## What

On the [Hooks Layout / Full-Page / Smart Ignore](https://www.testmuai.com/support/docs/smartui-hooks-layout-fullpage-smartignore/) page, both tables now use the page background instead of a filled header. In dark mode the table header was hardcoded to `#0D1117`, which read as a distinct blue-black block against the `#1b1b1d` page background.

## Change
- Added a scoped `.flat-table` class in `src/css/custom.css` (light + a dark override with enough specificity to beat the global `#0D1117` header rule). Header and cells resolve to `var(--ifm-background-color)`.
- Wrapped both tables (the capability/hook split table and the troubleshooting table) in `<div className="flat-table">`.

Verified in dark mode via a scripted render: the header background now computes to `rgb(27,27,29)` = `#1b1b1d`, matching the page. Markdown tables still parse correctly inside the wrapper.

## Note on the other asks
The `takeFullPageScreenshot` syntax fix, the "reliably" wording removal, and the blue-note removal are **already on `stage`** from the merged #3175 — verified present. The live site still shows the old versions only because it deploys from `testmuCom`; those need the normal `stage` → `testmuCom` promotion, not another `stage` PR. This PR adds the one genuinely new item (table background), which #3175 did not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)