### PR TITLE
fix(ci): never delete hashed JS/CSS bundles during S3 sync (stage)

### DIFF
--- a/.github/workflows/testmucom-stage-deployment.yml
+++ b/.github/workflows/testmucom-stage-deployment.yml
@@ -47,7 +47,15 @@ jobs:
         run: |
           cp -R assets/ build/
           cd build/
-          aws s3 sync . s3://lambdatest-stage-support-docs-testmu/support/ --exclude 'robots.txt' --delete
+          # Upload/refresh everything except the content-hashed JS/CSS bundles first,
+          # deleting anything that no longer exists in this build (e.g. removed pages).
+          aws s3 sync . s3://lambdatest-stage-support-docs-testmu/support/ --exclude 'robots.txt' --exclude 'assets/js/*' --exclude 'assets/css/*' --delete
+          # Then add this build's hashed bundles without --delete, so previously
+          # deployed bundles stay in place. Old HTML still cached by browsers/CDN/
+          # crawlers references those old hashes, and deleting them causes 404s on
+          # the JS/CSS mid-deploy. These are cheap, immutable, content-hashed files,
+          # so leaving old ones around is safe.
+          aws s3 sync . s3://lambdatest-stage-support-docs-testmu/support/ --exclude '*' --include 'assets/js/*' --include 'assets/css/*'
 
       - name: Invalidate CloudFront
         run: |


### PR DESCRIPTION
## Summary

- `aws s3 sync --delete` in the stage deploy workflow was deleting the previous build's content-hashed JS/CSS bundles the instant a new build synced, before CloudFront/Cloudflare invalidation ran.
- Any HTML still cached by a CDN edge, browser, or a crawler (e.g. Ahrefs re-visiting an already-indexed URL) that referenced the old bundle hashes got a 404 on those JS/CSS files until it reloaded fresh HTML.
- Worse, if the 404'd file is `runtime~main.[hash].js` or `main.[hash].js`, the whole app fails to hydrate — page looks fine but clicks, sidebar, search etc. silently stop working since no JS ever ran.
- Fix: split the S3 sync into two passes. The first still deletes stale files everywhere except `assets/js/*` and `assets/css/*` (so removed pages etc. still get cleaned up). The second uploads the new build's bundles into those dirs without `--delete`, so previously deployed bundles are never removed.

## Test plan

- [ ] Trigger a stage deploy, confirm new bundle files show up in `assets/js/`/`assets/css/` in S3 alongside prior ones (not replacing them)
- [ ] Confirm the site still loads/functions correctly post-deploy
- [ ] Spot check that an old page still open in a browser tab from before the deploy doesn't 404 on its JS bundle after this deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)