### PR TITLE
fix(ci): never delete hashed JS/CSS bundles during S3 sync (prod/testmuai.com)

### DIFF
--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -59,15 +59,7 @@ jobs:
         run: |
           cp -R assets/ build/
           cd build/
-          # Upload/refresh everything except the content-hashed JS/CSS bundles first,
-          # deleting anything that no longer exists in this build (e.g. removed pages).
-          aws s3 sync . s3://lambdatest-prod-docs/support/ --exclude 'robots.txt' --exclude 'assets/js/*' --exclude 'assets/css/*' --delete
-          # Then add this build's hashed bundles without --delete, so previously
-          # deployed bundles stay in place. Old HTML still cached by browsers/CDN/
-          # crawlers references those old hashes, and deleting them causes 404s on
-          # the JS/CSS mid-deploy. These are cheap, immutable, content-hashed files,
-          # so leaving old ones around is safe.
-          aws s3 sync . s3://lambdatest-prod-docs/support/ --exclude '*' --include 'assets/js/*' --include 'assets/css/*'
+          aws s3 sync . s3://lambdatest-prod-docs/support/ --exclude 'robots.txt' --delete
 
       - name: Invalidate Cloudfront
         run : |

--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -59,7 +59,15 @@ jobs:
         run: |
           cp -R assets/ build/
           cd build/
-          aws s3 sync . s3://lambdatest-prod-docs/support/ --exclude 'robots.txt' --delete
+          # Upload/refresh everything except the content-hashed JS/CSS bundles first,
+          # deleting anything that no longer exists in this build (e.g. removed pages).
+          aws s3 sync . s3://lambdatest-prod-docs/support/ --exclude 'robots.txt' --exclude 'assets/js/*' --exclude 'assets/css/*' --delete
+          # Then add this build's hashed bundles without --delete, so previously
+          # deployed bundles stay in place. Old HTML still cached by browsers/CDN/
+          # crawlers references those old hashes, and deleting them causes 404s on
+          # the JS/CSS mid-deploy. These are cheap, immutable, content-hashed files,
+          # so leaving old ones around is safe.
+          aws s3 sync . s3://lambdatest-prod-docs/support/ --exclude '*' --include 'assets/js/*' --include 'assets/css/*'
 
       - name: Invalidate Cloudfront
         run : |

--- a/.github/workflows/testmucom-prod-deployment.yml
+++ b/.github/workflows/testmucom-prod-deployment.yml
@@ -47,7 +47,15 @@ jobs:
         run: |
           cp -R assets/ build/
           cd build/
-          aws s3 sync . s3://lambdatest-prod-support-docs-testmucom/support/ --exclude 'robots.txt' --delete
+          # Upload/refresh everything except the content-hashed JS/CSS bundles first,
+          # deleting anything that no longer exists in this build (e.g. removed pages).
+          aws s3 sync . s3://lambdatest-prod-support-docs-testmucom/support/ --exclude 'robots.txt' --exclude 'assets/js/*' --exclude 'assets/css/*' --delete
+          # Then add this build's hashed bundles without --delete, so previously
+          # deployed bundles stay in place. Old HTML still cached by browsers/CDN/
+          # crawlers references those old hashes, and deleting them causes 404s on
+          # the JS/CSS mid-deploy. These are cheap, immutable, content-hashed files,
+          # so leaving old ones around is safe.
+          aws s3 sync . s3://lambdatest-prod-support-docs-testmucom/support/ --exclude '*' --include 'assets/js/*' --include 'assets/css/*'
 
       - name: Invalidate CloudFront
         run: |


### PR DESCRIPTION
## Summary

Same fix as the stage PR, applied to the workflow that deploys to production (testmuai.com):

- `aws s3 sync --delete` in `testmucom-prod-deployment.yml` was deleting the previous build's content-hashed JS/CSS bundles the instant a new build synced, before CloudFront/Cloudflare invalidation even ran.
- Any HTML still cached by a CDN edge, browser, or a crawler (e.g. Ahrefs re-visiting an already-indexed URL — this is how it was originally spotted, via a site audit showing 404s on `/support/assets/js/main.[hash].js`) that referenced the old bundle hashes got a 404 on those JS/CSS files.
- When the 404'd file is `runtime~main.[hash].js` or `main.[hash].js` specifically, the app never hydrates — page renders as static HTML but every click, the sidebar, search, etc. silently stop working until the user hard-refreshes into HTML referencing the current (still-present) bundle hash.
- Fix: split the S3 sync into two passes. The first still deletes stale files everywhere except `assets/js/*` and `assets/css/*` (so removed pages etc. still get cleaned up). The second uploads the new build's bundles into those dirs without `--delete`, so previously deployed bundles are never removed.

Scoped to `testmucom-prod-deployment.yml` only — `prod-deployment.yml` is intentionally left untouched (out of scope).

Stage counterpart: #3218

## Test plan

- [ ] Trigger a prod deploy (testmuCom push), confirm new bundle files show up in `assets/js/`/`assets/css/` in S3 (`lambdatest-prod-support-docs-testmucom`) alongside prior ones, not replacing them
- [ ] Confirm testmuai.com still loads/functions correctly post-deploy
- [ ] Spot check that an old page open in a browser tab from before the deploy doesn't 404 on its JS bundle / lose interactivity after this deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)