### PR TITLE
fix(ci): upload hashed bundles before HTML to close 404 race window

### DIFF
--- a/.github/workflows/testmucom-prod-deployment.yml
+++ b/.github/workflows/testmucom-prod-deployment.yml
@@ -47,15 +47,17 @@ jobs:
         run: |
           cp -R assets/ build/
           cd build/
-          # Upload/refresh everything except the content-hashed JS/CSS bundles first,
-          # deleting anything that no longer exists in this build (e.g. removed pages).
-          aws s3 sync . s3://lambdatest-prod-support-docs-testmucom/support/ --exclude 'robots.txt' --exclude 'assets/js/*' --exclude 'assets/css/*' --delete
-          # Then add this build's hashed bundles without --delete, so previously
-          # deployed bundles stay in place. Old HTML still cached by browsers/CDN/
-          # crawlers references those old hashes, and deleting them causes 404s on
-          # the JS/CSS mid-deploy. These are cheap, immutable, content-hashed files,
-          # so leaving old ones around is safe.
+          # Upload this build's hashed bundles FIRST, without --delete, so old
+          # bundles stay in place (old HTML still referencing them keeps working)
+          # and this build's new hashes exist in S3 before any HTML that
+          # references them can possibly go live. Doing this second would open a
+          # window where new HTML is already live but its bundle isn't uploaded
+          # yet, causing a 404 that CDNs/browsers can then cache for hours.
           aws s3 sync . s3://lambdatest-prod-support-docs-testmucom/support/ --exclude '*' --include 'assets/js/*' --include 'assets/css/*'
+          # Then sync everything else (HTML etc.), deleting anything that no
+          # longer exists in this build, but never touching the hashed asset
+          # dirs so previously deployed bundles are never removed.
+          aws s3 sync . s3://lambdatest-prod-support-docs-testmucom/support/ --exclude 'robots.txt' --exclude 'assets/js/*' --exclude 'assets/css/*' --delete
 
       - name: Invalidate CloudFront
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #3219. That PR stopped old bundles from being deleted, but I got this from you after it deployed:

> still after deployment when i come on page then runtime and main chunk file is 404 but after clearing its working fine 200

Root cause: the two sync passes ran in the wrong order — HTML (with `--delete`) synced first, then the hashed JS/CSS bundles synced second. That leaves a window, between those two `aws s3 sync` calls, where the new build's HTML (referencing the new hash) is already live in S3, but the matching bundle file hasn't been uploaded yet. A request landing in that window gets a 404 on `main.[hash].js`/`runtime~main.[hash].js`.

Confirmed via your screenshot: `Cf-Cache-Status: HIT`, `Age: 262`s, `Cache-Control: public, max-age=43200` — Cloudflare cached that 404 response for its full 12h TTL, which is why it kept failing on repeat visits until you cleared cache (bypassing Cloudflare's cached copy and hitting origin fresh, where the file was already fine by then).

Fix: swap the order. Upload this build's hashed bundles first (still without `--delete`), then sync/delete everything else. No HTML can go live referencing a bundle hash that isn't already in S3.

## Test plan

- [ ] Trigger a prod deploy, watch network tab for `main.[hash].js`/`runtime~main.[hash].js` on first load post-deploy — should be 200, not 404
- [ ] Confirm old bundles are still preserved (not deleted) as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)