### PR TITLE
docs: add Appium Hooks page to SmartUI sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -3606,6 +3606,11 @@ module.exports = {
               },
               {
                 type: "doc",
+                label: "Appium Hooks",
+                id: "smartui-appium-hooks",
+              },
+              {
+                type: "doc",
                 label: "Puppeteer Hooks",
                 id: "puppeteer-visual-regression",
               },


### PR DESCRIPTION
## Summary
The `smartui-appium-hooks` doc (https://www.testmuai.com/support/docs/smartui-appium-hooks/) exists in `docs/` but was never added to `VisualRegressionTestingSidebar`, so it is unreachable from the SmartUI navigation.

This PR adds it under **Testing Frameworks > Lambda Hooks** as "Appium Hooks", next to the other framework hook pages (Playwright, Cypress, Puppeteer).

## Changes
- `sidebars.js`: add `smartui-appium-hooks` doc entry to the Lambda Hooks category.

## Verification
- `node -e` parse of `sidebars.js` confirms the entry renders in the Lambda Hooks item list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)