### PR TITLE
Tunnel Release Notes | Add 3.2.31 TCP readiness gating and bounded auto-update retries

### DIFF
--- a/docs/tunel-release-notes.md
+++ b/docs/tunel-release-notes.md
@@ -41,7 +41,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
       })
     }}
 ></script>
-## Version 3.2.30 (19th July 2026)
+## Version 3.2.31 (19th July 2026)
 - **TCP Tunnel Reliability**
   - The tunnel now waits for a healthy data-path heartbeat before marking itself ready, and automatically falls back to WebSocket/SSH when the TCP data path is unhealthy. This prevents intermittent HTTP 502 errors caused by egress proxies that accept the initial connection upgrade but drop the multiplexed traffic.
 - **Auto-Update Stability**

--- a/docs/tunel-release-notes.md
+++ b/docs/tunel-release-notes.md
@@ -41,6 +41,12 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
       })
     }}
 ></script>
+## Version 3.2.30 (19th July 2026)
+- **TCP Tunnel Reliability**
+  - The tunnel now waits for a healthy data-path heartbeat before marking itself ready, and automatically falls back to WebSocket/SSH when the TCP data path is unhealthy. This prevents intermittent HTTP 502 errors caused by egress proxies that accept the initial connection upgrade but drop the multiplexed traffic.
+- **Auto-Update Stability**
+  - Bounded the client auto-update retries to prevent restart loops when an update cannot be applied (e.g. a read-only binary path or an unpublished version). The client now retries a limited number of times and keeps running the current binary instead of restarting indefinitely.
+
 ## Version 3.2.29 (14th June 2026)
 - **gRPC / HTTP/2 Tunnel Fix**
   - Fixed gRPC-over-HTTP/2 traffic hanging through the tunnel for strict HTTP/1.1 CONNECT clients (e.g. Flutter / grpc-dart apps on real devices). The tunnel now replies `HTTP/1.1 200` on the passthrough CONNECT path, so these clients establish the tunnel instead of timing out.


### PR DESCRIPTION
Adds release notes for **Tunnel Client 3.2.31**, shipped in [LambdatestIncPrivate/burrow#645](https://github.com/LambdatestIncPrivate/burrow/pull/645).

### What's new in 3.2.31
- **TCP Tunnel Reliability** — the tunnel gates readiness on a healthy data-path heartbeat and falls back to WebSocket/SSH when the TCP data path is unhealthy, preventing intermittent HTTP 502s from egress proxies that drop multiplexed traffic after the connection upgrade (TE-19570).
- **Auto-Update Stability** — bounded auto-update retries to prevent restart loops when an update can't be applied (read-only binary path or unpublished version); the client keeps running the current binary instead of restarting indefinitely.

Base branch: `stage`.