### PR TITLE
docs(kaneai): correct conditional logic paused state claims

### DIFF
--- a/docs/kaneai-conditional-logic.md
+++ b/docs/kaneai-conditional-logic.md
@@ -51,18 +51,22 @@ Each branch can contain multiple steps, including regular actions, **modules**, 
 
 ## How It Works
 
-1. Insert a conditional block from the **/** slash command menu during authoring or from the **+ Add step** option during a paused state.
+1. Insert a conditional block from the **/** slash command menu while your authoring session is running.
 2. Define a condition using variables and comparison operators.
 3. Optionally add **Else‑If** branches for additional conditions.
 4. Add steps, including modules, JS, API, and DB steps, inside each branch.
 5. During authoring, only the branch whose condition is true gets executed. Steps in the remaining branches are queued.
 6. In automation, KaneAI evaluates the conditions top‑to‑bottom at runtime and executes the first matching branch automatically.
 
+:::note Conditional blocks require a running session
+A conditional block can only be inserted while the authoring session is running, because KaneAI needs a running session to analyze the condition. Adding a conditional block from the **+ Add step** option while a test is paused is not currently supported. Conditional blocks that already exist in the test can still be extended while paused, for example by adding an Else‑If branch.
+:::
+
 <img loading="lazy" src={require('../assets/images/kane-ai/features/if-else/slash-if-else.png').default} alt="If / Else-If / Else block in the KaneAI authoring panel" className="doc\_img"/>
 
 ## Prerequisites
 
-- An active KaneAI authoring session.
+- A KaneAI authoring session that is running. Conditional blocks cannot be inserted while the session is paused.
 - Variables or element states available to build your conditions (e.g., smart variables, global variables, or extracted values).
 
 ## Step‑by‑step Guide
@@ -175,12 +179,13 @@ To add a module inside a branch:
 ## Limitations
 
 - **Nested conditions are not supported.** You cannot place an If / Else‑If / Else block inside another conditional block.
+- **New conditional blocks cannot be created while a test is paused.** The **/** slash command menu and the **+ Add step** option do not offer **Add If-Else** in the Draft state. Conditional blocks that already exist in the test can still be extended while paused.
 
 ## FAQ
 
 ### Can I add an Else‑If branch after I have already authored the test?
 
-Yes. When you pause the test or revisit it in the playground, you can edit the conditional block and add new Else‑If branches.
+Yes. On a conditional block that already exists in your test, you can add Else‑If branches, including while the test is paused. What you cannot do while paused is create a new conditional block, because **Add If-Else** is not offered in the **/** slash command menu or the **+ Add step** option in that state.
 
 ### How many Else‑If branches can I add?
 

--- a/docs/kaneai-while-loops.md
+++ b/docs/kaneai-while-loops.md
@@ -277,6 +277,7 @@ The following nesting patterns are **not supported**:
 - **While Loops cannot live inside conditional branches.** A While Loop cannot be placed inside an If / Else branch.
 - **No Break / Continue commands.** There is no way to exit a loop early or skip to the next iteration; structure your condition to terminate naturally.
 - **Natural language cannot create a loop.** Phrases like "repeat this 10 times" or "while the spinner is visible, do X" will not create a loop. You must use the slash command and select **While Loop**. KaneAI surfaces this as the `WHILE_NOT_SUPPORTED_VIA_NL` error.
+- **New While Loops cannot be created while a test is paused.** The **/** slash command menu and the **+ Add step** option do not offer **Add While Loop** in the Draft state. A While Loop that already exists in the test can still be edited while paused.
 - **Both operands in a condition cannot be parameters at the same time.** At least one side must be a runtime‑updated value. See `BOTH_OPERANDS_AS_PARAMETERS` in [Error Messages and Troubleshooting](#error-messages-and-troubleshooting).
 - **Local variables must be defined inside the block.** If a local variable referenced inside a While block was created outside the block, KaneAI shows an error when you click **End While**.
 

--- a/static/docs/kaneai-conditional-logic.md
+++ b/static/docs/kaneai-conditional-logic.md
@@ -10,16 +10,18 @@ Each branch can contain multiple steps, including regular actions, **modules**, 
 
 ## How It Works
 
-1. Insert a conditional block from the **/** slash command menu during authoring or from the **+ Add step** option during a paused state.
+1. Insert a conditional block from the **/** slash command menu while your authoring session is running.
 2. Define a condition using variables and comparison operators.
 3. Optionally add **Else‑If** branches for additional conditions.
 4. Add steps, including modules, JS, API, and DB steps, inside each branch.
 5. During authoring, only the branch whose condition is true gets executed. Steps in the remaining branches are queued.
 6. In automation, KaneAI evaluates the conditions top‑to‑bottom at runtime and executes the first matching branch automatically.
 
+**Conditional blocks require a running session.** A conditional block can only be inserted while the authoring session is running, because KaneAI needs a running session to analyze the condition. Adding a conditional block from the **+ Add step** option while a test is paused is not currently supported. Conditional blocks that already exist in the test can still be extended while paused, for example by adding an Else‑If branch.
+
 ## Prerequisites
 
-- An active KaneAI authoring session.
+- A KaneAI authoring session that is running. Conditional blocks cannot be inserted while the session is paused.
 - Variables or element states available to build your conditions (e.g., smart variables, global variables, or extracted values).
 
 ## Step‑by‑step Guide
@@ -122,12 +124,13 @@ To add a module inside a branch:
 ## Limitations
 
 - **Nested conditions are not supported.** You cannot place an If / Else‑If / Else block inside another conditional block.
+- **New conditional blocks cannot be created while a test is paused.** The **/** slash command menu and the **+ Add step** option do not offer **Add If-Else** in the Draft state. Conditional blocks that already exist in the test can still be extended while paused.
 
 ## FAQ
 
 ### Can I add an Else‑If branch after I have already authored the test?
 
-Yes. When you pause the test or revisit it in the playground, you can edit the conditional block and add new Else‑If branches.
+Yes. On a conditional block that already exists in your test, you can add Else‑If branches, including while the test is paused. What you cannot do while paused is create a new conditional block, because **Add If-Else** is not offered in the **/** slash command menu or the **+ Add step** option in that state.
 
 ### How many Else‑If branches can I add?
 

--- a/static/docs/kaneai-while-loops.md
+++ b/static/docs/kaneai-while-loops.md
@@ -212,6 +212,7 @@ The following nesting patterns are **not supported**:
 - **While Loops cannot live inside conditional branches.** A While Loop cannot be placed inside an If / Else branch.
 - **No Break / Continue commands.** There is no way to exit a loop early or skip to the next iteration; structure your condition to terminate naturally.
 - **Natural language cannot create a loop.** Phrases like "repeat this 10 times" or "while the spinner is visible, do X" will not create a loop. You must use the slash command and select **While Loop**. KaneAI surfaces this as the `WHILE_NOT_SUPPORTED_VIA_NL` error.
+- **New While Loops cannot be created while a test is paused.** The **/** slash command menu and the **+ Add step** option do not offer **Add While Loop** in the Draft state. A While Loop that already exists in the test can still be edited while paused.
 - **Both operands in a condition cannot be parameters at the same time.** At least one side must be a runtime‑updated value. See `BOTH_OPERANDS_AS_PARAMETERS` in [Error Messages and Troubleshooting](#error-messages-and-troubleshooting).
 - **Local variables must be defined inside the block.** If a local variable referenced inside a While block was created outside the block, KaneAI shows an error when you click **End While**.
 


### PR DESCRIPTION
## Problem

The Conditional Logic page told users they could insert an If / Else-If / Else block from the **+ Add step** option during a paused state:

> 1. Insert a conditional block from the **/** slash command menu during authoring or from the **+ Add step** option during a paused state.

That is not supported. Creating a new conditional block needs a running session so KaneAI can analyze the condition, and the restriction is intended rather than a defect.

Reported by Devansh Singh in [this thread](https://lambdatestteam.slack.com/archives/CCD3FMGGG/p1778597247546589), confirmed by Shantanu Wali ("If-else conditions need session in running state for analysis"). The future enhancement is tracked as LTPM-3753.

## Verified on KaneAI Classic before writing

Rather than only removing the false line, the behaviour was checked in the product. The real boundary is **creating** versus **editing**:

| Operation | Running (System Idle) | Paused (Draft) |
|---|---|---|
| Create a new If / Else block | Yes | No, not offered in either menu |
| Add an Else-If to an existing block | Yes | Yes |
| Create a new While Loop | Yes | No, not offered in either menu |
| Edit an existing While Loop | Yes | Yes |

So a blanket "conditionals do not work while paused" would have been wrong in the other direction. Both pages now state the actual line.

## Changes

**docs/kaneai-conditional-logic.md** and its static mirror
- How It Works step 1 drops the + Add step paused state path
- new note explaining why a running session is needed, and that existing blocks can still be extended while paused
- Prerequisites asks for a running session instead of an active one
- new Limitations entry, scoped to creating new conditional blocks
- the FAQ on adding an Else-If later now states the real boundary

**docs/kaneai-while-loops.md** and its static mirror
- one matching Limitations entry for creating a new While Loop while a test is paused. This page carried no false claim, the entry closes the gap Devansh raised for loops

The `static/docs/` mirrors are included because they are what AI assistants and crawlers read. Fixing only the rendered pages would leave those answers wrong.

## Scope

Only claims with direct evidence were changed. Left untouched on purpose: the "up to 5 Else-If branches" FAQ, the 30 iteration cap, `WHILE_NOT_SUPPORTED_VIA_NL`, and the nesting rules. Some of those have open questions, but none are what was reported and none are confirmed enough to edit here.

Rendered and checked locally on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
