### PR TITLE
docs(kane-cli): assurance lifecycle guide (Mintlify)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -65,6 +65,17 @@
                 ]
               },
               {
+                "group": "Assurance",
+                "pages": [
+                  "docs/kane-cli-assurance",
+                  "docs/kane-cli-assurance-context",
+                  "docs/kane-cli-assurance-design",
+                  "docs/kane-cli-assurance-coverage",
+                  "docs/kane-cli-assurance-maintain",
+                  "docs/kane-cli-assurance-automation"
+                ]
+              },
+              {
                 "group": "Integrations & Automation",
                 "pages": [
                   "docs/kane-cli-tms-integration",

--- a/docs/kane-cli-assurance-automation.mdx
+++ b/docs/kane-cli-assurance-automation.mdx
@@ -1,0 +1,180 @@
+---
+title: "Assurance in CI and from Agents"
+sidebarTitle: "Agents & CI"
+description: "The headless contract for kane-cli assurance — the --mode agent|ci|override ask policy, exit codes, the NDJSON event streams for extract, design, and reconcile, and the pause → answer → resume loop."
+keywords: ['kane cli assurance ci', 'headless test design', 'ndjson event stream', 'ai agent automation', 'kaneai', 'testmu ai']
+"og:description": "The headless contract for kane-cli assurance — the --mode ask policy, exit codes, NDJSON event streams, and the pause → answer → resume loop."
+---
+
+---
+
+The conversational assurance commands — `context extract`, `design tests`, and `maintain reconcile` — are interactive by default. This page is the contract for running them **headless**: from CI, from a script, or from an AI agent driving kane-cli.
+
+## The ask policy: `--mode`
+
+On a terminal, extract and design open a chat. Headless is an explicit opt-in — a bare non-TTY invocation **exits `2`** and mutates nothing:
+
+```
+extract: no TTY — pass an explicit --mode agent|ci|override to run headless
+```
+
+`--mode` decides both what happens when the agent has a question, and what the command writes to stdout:
+
+| Mode | Questions | stdout |
+|---|---|---|
+| `interactive` | asked in the chat (TTY default) | the Ink chat UI |
+| `agent` | low/medium-risk defaults are auto-taken (each reported); a **high-risk** question pauses the session — exit `3`, resumable | **NDJSON events** (one JSON object per line); prose diagnostics go to stderr |
+| `ci` | any high-risk question **fails closed** — exit `1`, error code `HIGH_RISK_CI` | prose transcript |
+| `override` | every default is auto-taken, including high-risk (each flagged in the commit record) | prose transcript |
+
+Rule of thumb: `agent` when something can read the pause and answer (an AI agent, a human on the next shift); `ci` when a pipeline must never guess; `override` when you accept the recommended defaults wholesale and want one unattended pass.
+
+The same matrix drives `maintain reconcile`, with two reconcile-specific rules: no headless mode ever archives anything — ARCHIVE decisions wait for an interactive session — and a `ci`-mode run that hits a decision needing a human **stores the plan and exits `2`** (the work isn't lost; walk the stored plan interactively or apply it in `agent` mode).
+
+## Exit codes
+
+Consistent across extract, design, and the maintain commands that embed them:
+
+| Code | Meaning |
+|---|---|
+| `0` | Complete. |
+| `1` | Runtime failure. For extract and design, a `ci`-mode fail-close on a high-risk question also exits `1`; reconcile's `ci` fail-close stores the plan and exits `2` instead. |
+| `2` | Usage / auth / refusal — bad flags, failed input validation, no store, bare non-TTY without `--mode`, missing `--yes` on a destructive command. Nothing was mutated. |
+| `3` | **Paused and resumable** — the only meaning of 3. A session is saved; resume it within 24 hours. |
+
+## The NDJSON stream (`--mode agent`)
+
+With `--mode agent`, stdout speaks a versioned NDJSON vocabulary — envelope `{"type": "<name>", "v": 1, "verb": "extract"|"design", ...}`, one object per line. The vocabulary is open: new event types may appear, so **tolerate unknown types**.
+
+| type | payload highlights |
+|---|---|
+| `run_start` | `mode`, `trace` (the per-run log path); design adds `use_case` |
+| `corpus` | extract: the `sources[]` this run covers + already-extracted `skipped[]` |
+| `source_start` / `source_skipped` | `source_id`, `index`/`total`, `resumed` / `reason` |
+| `plan` | the `--plan` transcription payload |
+| `assumed_default` | a question auto-answered with its recommended default: `id`, `selected_index`, `risk` |
+| `agent_activity` | progress: `kind` (`tool` / `decision` / `progress` / `thinking_done`) + a display `label` |
+| `usage` | per agent turn: `credits` + running `total_credits` |
+| `validate_failed` | a proposal failed kane-side validation: `codes[]`, `repairing` (the agent self-repairs) |
+| `commit` | what landed: counts + `minted[]` (`cid` + `logical_id`); extract adds `proposal_id` |
+| `receipt` | design: per-phase commit receipt — `commit_n`, `phase`, `committed[]`, `warnings[]`, `parity`, and a human-readable `next` hint |
+| `message_sent` | your `--message` was delivered: `sid`, `chars` |
+| `session_paused` | `sid`, the verbatim `resume` command, `expires_at`, and **`pending_questions[]`** in full |
+| `session_complete` | `sid` |
+| `gate_refused` | a design gate refused the run (may be the first event) |
+| `error` | `message` + a stable `code` where one exists (`NO_STORE`, `PREFLIGHT`, `SOURCE_MISSING`, `BLOB_MISSING`, `HIGH_RISK_CI`, `STALE_BASIS`) |
+| `done` | **always the last event**: `status` (`complete`/`paused`/`error`/`refused`/`interrupted`/`aborted`) + `exit_code` |
+
+**The `done` guarantee:** every `--mode agent` invocation ends its stream with exactly one `done` event — including refusals and graceful interrupts. The one exception is operator force: a second Ctrl+C can hard-kill the process (exit `130`) without a `done`. Any other stream that ends without `done` should be treated as a crash. One more parsing note: the agent may also repair a draft mid-turn on its own — that surfaces only as `agent_activity` lines (labels like `validation failed`, `refining the draft`); treat activity labels as display text, never script against them.
+
+### Reconcile's stream
+
+`maintain reconcile --mode agent` speaks the same envelope with `verb: "reconcile"` and its own event set:
+
+| type | payload highlights |
+|---|---|
+| `reconcile_plan` | the triage ahead: `source_id`, `plan_path`, `rows[]` (`kind`, `ref`, `why`), `archive[]` (proposed archivals with their evidence-decay reasons) |
+| `reconcile_row_start` | per row: `kind`, `ref`, plus the impact counts where they apply (`stale`, `direct`) |
+| `reconcile_row_end` | the row's `outcome` (`applied` \| `failed` \| `skipped` \| `plan-only` \| `paused`) + `exit_code`, and an additive `detail` carrying a failure's reason and hint. A row's embedded design run is folded in here, so the stream stays single-writer with exactly one `done` |
+| `reconcile_paused` | `plan_path` + `pending[]` (`ref`, `why`) — resume with the same reconcile command (or `--apply`) |
+| `reconcile_summary` | the honest totals, always the same field set: `applied`, `skipped`, `deferred`, `plan_only`, `failed`, `paused`, `stale_created` |
+| `done` | always last — same guarantee as above |
+
+Validation failures (bad inputs, unknown source, the fork guard) ride the stream as `error` + `done` with exit `2` — never stderr alone.
+
+## The pause → answer → resume loop
+
+This is the heart of driving assurance from an agent. A real exchange (events abridged, payloads shortened):
+
+```bash
+$ kane-cli context extract --mode agent
+{"type":"run_start","v":1,"verb":"extract","mode":"agent","trace":".context/logs/extract-….log"}
+{"type":"corpus","v":1,"verb":"extract","sources":[{"source_id":"prd-online-store","cid":"sha256:0661…"}],"skipped":[]}
+{"type":"agent_activity","v":1,"verb":"extract","kind":"decision","label":"asking to resolve an ambiguity"}
+{"type":"session_paused","v":1,"verb":"extract","sid":"ext-20260716T140742-prd-online-store",
+  "resume":"kane-cli context extract --resume ext-20260716T140742-prd-online-store --mode agent",
+  "expires_at":"2026-07-17T14:07:53Z",
+  "pending_questions":[{"id":"q1",
+    "text":"The PRD conflicts on guest checkout; should I treat checkout as account-required or guest-allowed?",
+    "risk":"high",
+    "rationale":"Lines L20-L21 say all customers must create an account, but L35 says guest checkout is allowed.",
+    "options":[{"label":"Account required","detail":"…"},{"label":"Guest allowed","detail":"…"}],
+    "recommended_index":0,"allow_free_text":true}]}
+{"type":"done","v":1,"verb":"extract","status":"paused","exit_code":3}
+```
+
+The pause event carries everything needed to decide: the question, why it matters, the options, and the recommendation. Answer **in plain words** — no question ids, no option indexes. After the resumed run's usual `run_start`, `corpus`, and `source_start` (with `"resumed": true`) events, the stream continues:
+
+```bash
+$ kane-cli context extract --resume ext-20260716T140742-prd-online-store --mode agent \
+    --message "Account required — treat the update section as superseding: no guest checkout"
+{"type":"message_sent","v":1,"verb":"extract","sid":"ext-…","chars":115}
+{"type":"usage","v":1,"verb":"extract","credits":2.45,"total_credits":2.45}
+{"type":"commit","v":1,"verb":"extract","derived":5,"minted":[{"cid":"sha256:6d68…","logical_id":"uc-create-an-account-to-order"}, …]}
+{"type":"session_complete","v":1,"verb":"extract","sid":"ext-…"}
+{"type":"done","v":1,"verb":"extract","status":"complete","exit_code":0}
+```
+
+The agent maps your statement to its own pending questions. A statement that answers nothing pending is treated as steering ("also cover the coupon path"); if it leaves a high-risk ambiguity standing, the run pauses again with refreshed questions.
+
+Between the pause and the resume, everything is inspectable without contending the session:
+
+```bash
+kane-cli context sessions --json                 # one row per resumable session, with its resume command
+kane-cli context sessions show <sid> --json      # the pending questions in wire shape + any assumed defaults
+```
+
+Abandoned sessions expire after 24 hours; `kane-cli context sessions clean` garbage-collects them.
+
+## Headless review
+
+Trust promotion deliberately has **no auto-approve** — but it does have a non-interactive path. Prepare verdicts as JSON and land them atomically:
+
+```bash
+cat > verdicts.json <<'EOF'
+[
+  {"ref": "uc-create-an-account-to-order", "resolution": "approved"},
+  {"ref": "uc-manage-the-cart",            "resolution": "approved"}
+]
+EOF
+kane-cli context review --verdicts verdicts.json --json
+```
+
+`resolution` is one of `approved | edited | rejected | skipped | supersede` (optional `reason`, `edit`, `supersede_target`). One unresolvable ref fails the whole file (exit `2`, nothing committed). With `--json`, each landed verdict echoes as one NDJSON row.
+
+## Machine-readable reads
+
+These read commands have structured forms: `context list --json` and `context sessions --json` (one JSON object per line), `context explain --json`, `context view --json` (the full computed graph payload), `context view --no-open --out graph.html` (render without a browser), and `cover --json`.
+
+## Headless maintain
+
+- `maintain reconcile --from <file> --source-id <id> --plan` — safe preview: records the source change, stages every proposed row into a stored plan, touches nothing else. Exit `0`; when the source actually changed, the plan path is the last stdout line (an unchanged source is a no-op that stores nothing).
+- `maintain reconcile … --mode override` (or `--mode ci`) — unattended application: ADD and MODIFY rows apply, archiving never happens headless, and `ci` fail-closes the moment human judgement is needed (the plan is stored; exit `2`).
+- Re-running the same reconcile command is idempotent — it resumes a pending plan, reports an applied one, and recomputes a superseded one ([details](/docs/kane-cli-assurance-maintain/#running-again)).
+- Bare headless runs without an explicit `--mode` refuse with exit `2` — by design.
+
+## A CI shape that works
+
+```bash
+# fail the pipeline on unresolved high-risk ambiguity, never guess:
+kane-cli context extract --mode ci
+
+# or: let it pause, surface the questions as a build artifact, resume in a follow-up job:
+kane-cli context extract --mode agent > extract.ndjson; code=$?
+if [ "$code" -eq 3 ]; then
+  kane-cli context sessions --json > pending-sessions.ndjson   # hand to a human or an agent
+fi
+
+# design a specific use-case unattended, bounded:
+kane-cli design tests --use-case uc-checkout --max 8 --mode ci
+
+# keep the suite honest on requirement changes:
+kane-cli maintain reconcile --from ./docs/prd.md --source-id prd --plan
+```
+
+Author and batch the resulting tests with the same CI patterns as any other test — see the [CI/CD recipes](/docs/kane-cli-cicd/).
+
+## Next steps
+
+- [The assurance overview](/docs/kane-cli-assurance/) — where each command sits.
+- [Building the context graph](/docs/kane-cli-assurance-context/) · [Designing tests](/docs/kane-cli-assurance-design/) · [Maintaining the suite](/docs/kane-cli-assurance-maintain/).

--- a/docs/kane-cli-assurance-context.mdx
+++ b/docs/kane-cli-assurance-context.mdx
@@ -1,0 +1,251 @@
+---
+title: "Building the Context Graph"
+sidebarTitle: "Context Graph"
+description: "Snapshot requirement documents into a local, content-addressed store and extract use-cases with an AI agent using kane-cli context — ingest, extract, review, sessions, inspection, and housekeeping."
+keywords: ['kane cli context', 'context ingest', 'use-case extraction', 'requirements ingestion', 'context graph', 'kaneai', 'testmu ai']
+"og:description": "Snapshot requirement documents into a local, content-addressed store and extract use-cases with an AI agent using kane-cli context."
+---
+
+---
+
+`kane-cli context` builds a local, content-addressed knowledge store (`.context/` in your project directory) from your requirement documents, and extracts **use-cases** from them with an AI agent. It is the first stage of the [assurance lifecycle](/docs/kane-cli-assurance/): Source → Use-case → Scenario → AC → Test.
+
+```bash
+kane-cli context ingest ./prd-online-store.md   # snapshot a source
+kane-cli context extract                        # extract use-cases (interactive chat)
+kane-cli context review                         # promote proposals to trusted
+kane-cli context list                           # see what you have
+```
+
+<a id="ingest" />
+## `context ingest` — snapshot your sources
+
+```bash
+kane-cli context ingest <src...> [--as <id>]
+```
+
+Snapshots one or more files into `.context/` (the store is created on first use). Each source gets a stable id — by default the filename slug (`prd-online-store.md` → `prd-online-store`), or pass `--as <id>` to name it yourself.
+
+Ingest is deterministic about identity:
+
+| You ingest… | Result |
+|---|---|
+| same id, same bytes | `unchanged` — nothing written |
+| same id, new bytes | `versioned` — the source's head moves; everything extracted from the old snapshot goes **stale** |
+| a new id | `created` |
+| identical bytes already ingested under a different id | interactive relocate offer (default yes); non-TTY mints the new id and prints a hint |
+
+```
+$ kane-cli context ingest ./prd-online-store.md
+created  prd-online-store  source sha256:0661…  blob sha256:3db8…
+```
+
+Accepted media: text (`.txt`) and markdown (`.md`, `.markdown`) up to 2 MB — cited verbatim by line; PNG/JPEG/WebP images up to 5 MB — cited whole-image. Anything else is rejected with `UNSUPPORTED_MEDIA`; oversized files with `FILE_TOO_LARGE`.
+
+When the new bytes are a **changed version of a source you already extracted from**, prefer [`kane-cli maintain reconcile`](/docs/kane-cli-assurance-maintain/) over a bare re-ingest — it records the same head move *and* triages what the change means for your suite, in one step.
+
+<a id="extract" />
+## `context extract` — propose use-cases
+
+```bash
+kane-cli context extract [--plan] [--force] [--source <id>] [--mode <mode>] [--resume <sid> [--message "<text>"]]
+```
+
+Runs the extraction agent over every ingested source whose current snapshot has no committed extraction yet (already-extracted snapshots are skipped — re-run with `--force` to redo one).
+
+On a terminal the default is an **interactive chat**. Headless use is an explicit opt-in: a bare non-TTY invocation exits `2` and asks you to pass `--mode agent|ci|override` — see [Automation](/docs/kane-cli-assurance-automation/) for the headless contract.
+
+What the agent does:
+
+- Reads each source and proposes use-cases with **verbose descriptions** (flows, inputs, states, boundaries) and **`criteria[]`** — short, cited sketches of the acceptance-relevant promises the source states. Criteria are hints for [`kane-cli design`](/docs/kane-cli-assurance-design/), never test oracles.
+- **Cites everything.** Every proposal must quote an exact line from the source; fabricated evidence is rejected before anything is written. (Image sources cite the whole image — there is no text to quote.)
+- **Asks when the source is ambiguous.** Conflicting requirements become clarifying questions with options, a recommended default, and a risk level — low/medium-risk questions can be defaulted, high-risk ones want a real answer.
+- **Grounds itself in what you already have.** The agent explores the existing graph read-only before proposing, so a use-case you already committed becomes new evidence on the existing node (shown as `≈ matches`) instead of a duplicate.
+
+Extraction stops at the use-case. Scenarios, ACs, and tests are minted by the [design engine](/docs/kane-cli-assurance-design/) — each stage can only create its own kinds.
+
+Flags:
+
+| Flag | Meaning |
+|---|---|
+| `--plan` | Stop after the proposal: print it (with `≈ matches` dedup flags) and commit nothing |
+| `--force` | Re-extract sources even if their current snapshot was already extracted |
+| `--source <id>` | Extract exactly this ingested source instead of the whole corpus |
+| `--mode <mode>` | Ask policy for headless runs: `agent` \| `ci` \| `override` — see [Automation](/docs/kane-cli-assurance-automation/) |
+| `--resume <sid>` | Resume a paused session ([sessions](#sessions)) |
+| `--message "<text>"` | With `--resume`: answer the pending questions in plain words |
+
+### The interactive chat
+
+The chat has two zones. The scrollback is the complete session journey — your words, the agent's narrative, its reasoning segments and tool lines, each proposal list as it arrived, answer receipts, commit receipts, and per-turn credit costs. The live region below shows only what is happening now: the current thinking line (**ctrl+t** expands it), the question panel, and the composer.
+
+**Answering questions** happens right in the composer:
+
+- Bare input answers the active question (marked `›`), and the cursor advances: `1` picks option 1, typing an option's name matches it, anything else is free text where allowed.
+- `N:` targets question N explicitly (`2: yes`). Without the colon, `2 business days` stays free text.
+- **Empty Enter** accepts the recommended defaults for **low/medium-risk questions only** — each is echoed back as `↳ assumed … (flagged)`. High-risk questions are never bulk-defaulted: answer them, or type `defer` to leave the rest with the agent.
+- The batch submits when every question is answered, assumed, or deferred — never silently partial.
+
+**Ctrl+C asks for a pause, not a crash.** The first press asks the agent to save the session; on success you get a pause card with the exact resume command (including the `--message` form) and the run exits `3`. If the save can't complete within a few seconds you get an honest `interrupted — session not saved` (exit `130`, not resumable), and a second Ctrl+C at any point is an immediate hard exit. `/pause` does the same from the composer; `/done` ends the session cleanly.
+
+Slash commands (everything else you type is conversation for the agent):
+
+| Command | Action |
+|---|---|
+| `/view [N \| acs\|scenarios\|tests]` | browse this session's proposals in a view-only explorer |
+| `/explain <ref>` | why a committed item exists — replayed from the record, no agent turn |
+| `/pause` | save + exit, resumable |
+| `/done` | finish the session cleanly |
+
+### The review checklist
+
+After the agent proposes, the same session walks you through a review checklist: space cycles **approve / edit / reject / skip** per item, `e` opens an edit form, and Enter commits the whole batch as one record:
+
+- **approve / edit** → committed as `trusted`
+- **reject** → committed + archived (kept on record, not deleted)
+- **skip** → committed as `derived` — queued for later review
+
+### Pausing and resuming
+
+When the agent needs an answer you're not there to give (or you Ctrl+C), the session is saved and the run exits `3`. Resume it any time within 24 hours:
+
+```bash
+kane-cli context sessions                       # list resumable sessions + their resume commands
+kane-cli context extract --resume <sid>         # re-presents the pending questions
+kane-cli context extract --resume <sid> --message "Account required — the update supersedes the old section"
+```
+
+`--message` answers **in plain words** — no question ids, no option indexes. The agent maps your statement to its own pending questions. A statement that answers nothing pending is treated as steering ("also cover the coupon path"). If your answer leaves a high-risk ambiguity standing, the run pauses again with refreshed questions.
+
+<a id="review" />
+## `context review` — review outside the extract session
+
+```bash
+kane-cli context review [--queue derived|skipped|archived|drift] [--verdicts <file>] [--json]
+```
+
+Walks existing nodes through the same review checklist, landing every verdict as one batched record:
+
+- `derived` (default) — everything unreviewed
+- `skipped` — strictly the items you skipped during an extract review
+- `archived` — resurrection candidates: an explicit approve restores trust
+- `drift` — a **listing only** (works without a TTY): nodes whose evidence is stale or orphaned, with their pinned sources — the re-extract worklist
+
+In any queue: approve promotes, reject archives (a trusted node *can* be demoted), and edit mints a new version that supersedes the old one — nodes are immutable, so edits never rewrite history and existing references never break.
+
+**Headless verdicts** — `--verdicts <file.json>` is the one non-TTY write path: a JSON array of
+
+```json
+[{ "ref": "uc-manage-the-cart", "resolution": "approved" }]
+```
+
+with `resolution` one of `approved | edited | rejected | skipped | supersede` (plus optional `reason`, `edit`, `supersede_target`). It is atomic: every ref must resolve and sit in a verdict queue, or nothing commits (exit `2`). With `--json`, each landed verdict echoes as one NDJSON row. There is deliberately no auto-approve mode for review — trust requires a human decision.
+
+<a id="inspect" />
+## Inspecting the graph
+
+### `context list`
+
+```bash
+kane-cli context list [--type source|usecase] [--inferred] [--stale] [--all] [--json]
+```
+
+Lists nodes with their trust and freshness. `--inferred` shows only unreviewed (`derived`) nodes, `--stale` only stale or orphaned nodes (evidence pinned to an outdated snapshot, or no live source at all), `--all` includes superseded versions (hidden by default). `--json` emits one JSON object per line.
+
+### `context view`
+
+```bash
+kane-cli context view [--out <path>] [--open|--no-open] [--json]
+```
+
+Renders the whole graph as a **single self-contained HTML page** — swimlanes per use-case, provenance edges back to the source, trust and staleness at a glance, a commit rail along the bottom, and click-through detail panels with each node's lineage. It is a snapshot (no server; works offline); re-run to refresh. Piped runs write the file and print its path instead of opening a browser; `--json` prints the computed payload for scripting.
+
+### `context explain`
+
+```bash
+kane-cli context explain <ref> [--json]
+```
+
+Replays a node's recorded history straight from the store — **no model call, ever**: when it was minted and why, every review verdict, edits and supersessions, name assignments. `<ref>` is a logical id (`uc-manage-the-cart`) or a cid.
+
+<a id="sessions" />
+### `context sessions`
+
+```bash
+kane-cli context sessions [list|show|clean] [<sid>] [--all] [--json]
+```
+
+Paused extract *and* design sessions live under `.context/sessions/` for 24 hours. `list` shows each with its pending-question count, expiry, and ready-to-paste resume command. `show <sid>` prints everything the paused agent is waiting on — the questions in full, any defaults it assumed in your absence, and both resume forms. `clean` garbage-collects expired sessions (`clean <sid>` removes one; `--all` removes everything).
+
+## Housekeeping
+
+### `context retire`
+
+```bash
+kane-cli context retire <source_id> [--reason <text>] [--yes]
+```
+
+Retires a source. Its use-cases are **not** deleted — they read `orphaned` once no live source evidences them. Fully reversible via `revert`.
+
+### `context name`
+
+```bash
+kane-cli context name <ref> <slug>          # name one node
+kane-cli context name --backfill [--yes]    # assign ids to every unnamed node
+```
+
+Assigns a stable kebab-case name. Names are never part of a node's identity — renaming never re-addresses — and names follow edits, so a name assigned to version 1 keeps resolving to the current version.
+
+### `context revert`
+
+```bash
+kane-cli context revert <seq> [--reason <text>] [--yes]
+```
+
+Inverts a record's effects by appending a compensation record — mints are tombstoned, heads move back, trust states are restored. History is never rewritten: the store keeps both the mistake and its correction. Reverting a revert restores the original effects.
+
+### `context fsck` / `context rebuild`
+
+`fsck` verifies the full record chain and checks the read caches for drift (exit `1` on any issue) — run it whenever hands touched `.context/` directly. `rebuild` wipes the derived caches and regenerates them from the verified records; it is always safe.
+
+**Destructive-verb rule:** `retire`, `revert`, `name --backfill`, and `rebuild` prompt for confirmation on a terminal (default No) and require an explicit `--yes` headless. Read commands never create a `.context/` store in a directory that has none — only `ingest` and `extract` do.
+
+## Trust and freshness
+
+| Trust | Meaning | How you get there |
+|---|---|---|
+| `derived` | machine-proposed, unreviewed | extraction commit (or a skip verdict) |
+| `trusted` | human-confirmed | approve or edit in review |
+| `archived` | human-rejected | reject in review |
+
+Freshness is orthogonal: `fresh` / `stale` (the source snapshot moved) / `orphaned` (no live source evidences it) / `superseded` (this version was replaced). A stale use-case is still trusted — it just needs re-verification against the new snapshot, which is exactly what [`kane-cli maintain reconcile`](/docs/kane-cli-assurance-maintain/#reconcile) is for.
+
+## The store on disk
+
+```
+.context/
+├── meta.json            # store identity + format version
+├── commits/             # append-only records — the truth
+├── blobs/               # write-once source snapshots
+├── derived/             # regenerable read caches (delete any time; rebuild restores)
+├── proposals/<ts>/      # proposal + review artifacts per extract run
+├── sessions/<sid>/      # resumable paused sessions (expire after 24h)
+├── logs/                # per-run trace files
+├── design/              # design rationale sidecars + technique overrides
+├── reconcile/plans/     # stored reconcile plans
+└── signals.ndjson       # internal review bookkeeping (appears once recorded)
+```
+
+Two rules worth repeating from the [overview](/docs/kane-cli-assurance/#store): the store is **single-writer**, and it is **not git-mergeable** — gitignore it and share by re-ingesting sources.
+
+Every extract run also writes a per-run trace to `.context/logs/extract-<ts>.log` (the path is printed at the start of the run) — the first place to look when a run surprises you.
+
+## For agents and CI
+
+Headless extraction (`--mode agent|ci|override`), the NDJSON event stream, exit codes, and the pause/resume contract are documented in [Automation](/docs/kane-cli-assurance-automation/).
+
+## Next steps
+
+- [Designing tests](/docs/kane-cli-assurance-design/) — turn a trusted use-case into ACs, scenarios, and runnable tests.
+- [Maintaining the suite](/docs/kane-cli-assurance-maintain/) — what to do when a source changes.
+- [Automation](/docs/kane-cli-assurance-automation/) — the headless contract.

--- a/docs/kane-cli-assurance-coverage.mdx
+++ b/docs/kane-cli-assurance-coverage.mdx
@@ -1,0 +1,82 @@
+---
+title: "Coverage: Proven vs Owed"
+sidebarTitle: "Coverage"
+description: "Measure coverage on two axes with kane-cli cover — what a sealed evidence pack proved in execution, and what the design still owes — plus a ranked gaps worklist with ready-to-paste commands."
+keywords: ['kane cli cover', 'test coverage', 'coverage gaps', 'evidence pack', 'requirements coverage', 'kaneai', 'testmu ai']
+"og:description": "Measure coverage on two axes with kane-cli cover — what a sealed evidence pack proved in execution, and what the design still owes."
+---
+
+---
+
+`kane-cli cover` measures coverage on two independent axes over the same store:
+
+- **Depth** — what a real execution **proved**, read from an evidence pack's coverage records. Facts only: the pack was sealed with these verdicts inside it; `cover` never recomputes them.
+- **Completeness** — what the design still **owes**, computed live from the `.context/` graph. A perfect pack can still ship with an unverified criterion or a happy-path-only use-case; this axis never reads packs.
+
+A run can look green and still owe you coverage — that's exactly the situation the two axes make visible.
+
+```bash
+kane-cli cover [--from <pack>] [--json]                     # the two-axis panel
+kane-cli cover gaps [--stage design|cover|all] [--top <n>] [--from <pack>]  # the ranked worklist
+```
+
+## The panel
+
+```
+coverage — 8f0e…f2.evidence
+
+depth (proven by the pack):
+  ◐ ███░░░░░░░  38%  uc-buy-as-a-guest — partial (1/4 ACs proven, 1 failed, 1 blocked)
+  ✔ ██████████ 100%  uc-mobile-sign-in — covered (1/1 ACs proven)  · 1 stale
+
+completeness (live graph):
+  [high] create ac-payment-declined-message — no test verifies this AC
+         → kane-cli design tests --use-case uc-buy-as-a-guest
+```
+
+- The default pack is the newest in `<cwd>/.testmuai/evidence`; `--from` takes a pack directory, a sealed `.evidence` file, or an execution id.
+- Depth is **risk-weighted and lenient**: a high-risk criterion weighs more, and a passed-but-stale criterion still counts as proven — staleness is surfaced (`· N stale`), never silently demoted. Per-use-case status is `covered` (every AC proved) · `blocked` (something couldn't run, nothing failed) · `partial` · `uncovered`.
+- Coverage reflects **this run**: sealed packs cover only what the run touched. Project-wide coverage lives in the graph axis, unaffected by any single pack.
+- `--json` emits the full panel as structured data.
+
+## `cover gaps` — the worklist
+
+One ranked list (risk first) of what to do next, each row with a ready-to-paste command:
+
+```
+gaps — stage design (5)
+   1. [high] create uc-checkout-while-signed-in — use-case has no scenarios
+      → kane-cli design tests --use-case uc-checkout-while-signed-in
+   2. [med] create ac-the-cart-displays-an-order-subtotal — no live test verifies this acceptance criterion
+      → kane-cli design tests --use-case uc-manage-the-cart
+```
+
+- `--stage design` (default, no pack needed) — criteria no test verifies, use-cases with no or only-happy scenarios, recorded gap nodes from design runs, stale designed entities.
+- `--stage cover` (needs a pack) — a covered criterion whose **execution** disappointed: `failed` → re-design that slice; `blocked` or never-run → the test exists, run it.
+- `--stage all` — both, one ranking. `--top <n>` trims the list.
+
+## The join: how a pack knows your graph
+
+Every per-test result in an evidence pack carries a `definition_id` — a hash of the resolved test definition, identical to the one design stamps on each test it emits. The pack↔graph join is this hash equality and nothing else: no ids to sync, no registry to maintain. A hand-edited test hashes differently and simply stops joining — honest, not broken (a redesign — [`design tests --force`](/docs/kane-cli-assurance-design/#re-runs) or [`maintain evolve`](/docs/kane-cli-assurance-maintain/#evolve) — re-stamps the link).
+
+Coverage records land in packs automatically whenever the project has a `.context/` store — the inline `run`/`testmd` path and `testrun` both write them before sealing. A project without a store gets byte-identical packs to before; a coverage-write failure never costs the seal.
+
+## The authoring bridge
+
+A freshly designed test has never been executed, and the tooling is honest about that:
+
+1. `kane-cli design tests` writes `t-…_test.md` files — runnable, but with no recording yet.
+2. `kane-cli testrun` preflight refuses never-authored members (`missing_meta`).
+3. So the first run of each designed test is `kane-cli testmd run <file>` — the agent authors it in a real browser and commits the recording.
+4. From then on the test replays like any other: batch it with `testrun`, and its verdicts join the pack via `definition_id`.
+
+Until step 3 happens, `cover` reads the test's criteria as *covered on paper, unproven in execution* (`covered_by` present, execution `not-run`). That is a deliberate reading, not a bug — a designed test is a claim until a run proves it.
+
+## Inside the pack: `coverage/usecases.yaml`
+
+The pack's coverage record is one YAML file you can read, diff, and archive — one row per live use-case: identity and risk, sources and provenance, scenarios, and each acceptance criterion with its verdict join (`covered_by`, `execution: passed|failed|blocked|not-run`, `fresh`, the expected answer, and what satisfied it). Diff two packs' `usecases.yaml` to see exactly what a release changed in proven coverage.
+
+## Next steps
+
+- [The authoring bridge in practice](/docs/kane-cli-assurance-design/#from-design-to-execution) — design → author → batch.
+- [Maintaining the suite](/docs/kane-cli-assurance-maintain/) — act on what the gaps list tells you.

--- a/docs/kane-cli-assurance-design.mdx
+++ b/docs/kane-cli-assurance-design.mdx
@@ -1,0 +1,133 @@
+---
+title: "Designing Tests from Use-Cases"
+sidebarTitle: "Designing Tests"
+description: "Turn one committed use-case into acceptance criteria, scenarios, and exactly one runnable test per scenario with kane-cli design tests — reviewed, cited, and permanently linked to requirements via @verifies tags."
+keywords: ['kane cli design tests', 'ai test design', 'acceptance criteria', 'test scenarios', 'covering array', 'kaneai', 'testmu ai']
+"og:description": "Turn one committed use-case into acceptance criteria, scenarios, and exactly one runnable test per scenario with kane-cli design tests."
+---
+
+---
+
+`kane-cli design tests` turns **one committed use-case** into everything that proves it: acceptance criteria (ACs), scenarios, and exactly one runnable test per scenario — conversationally, on the same chat surface [`kane-cli context extract`](/docs/kane-cli-assurance-context/#extract) uses. Everything the engine emits is **derived** knowledge you review; approvals promote it, nothing is silently trusted.
+
+```bash
+kane-cli design tests --use-case uc-manage-the-cart      # design one use-case (chat)
+kane-cli design explain t-add-first-item                 # replay WHY — zero fresh AI
+```
+
+`<ref>` is a short logical id (`uc-manage-the-cart`, `t-login-smoke`) or a full cid.
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--use-case <ref>` | The use-case to design (optional with `--resume` — the session remembers it) |
+| `--max <n>` | Budget ceiling: max scenario+test pairs kept. **No ceiling when omitted** — the agent estimates the right size and asks you to confirm. Every eviction becomes a named `budget-evicted` gap |
+| `--strength pairwise\|3-wise` | Manual covering-array strength override; absent = risk-judged (3-wise when money, auth, or data loss is involved) |
+| `--mode <mode>` | Ask policy for headless runs: `agent` \| `ci` \| `override` — bare non-TTY exits `2`. See [Automation](/docs/kane-cli-assurance-automation/) |
+| `--force` | Redesign a use-case that already has a live design (supersedes its scenario+test pairs; equivalent ACs are reused) |
+| `--resume <sid>` | Resume a paused session ([sessions](/docs/kane-cli-assurance-context/#sessions)) |
+| `--message "<text>"` | With `--resume`: answer the pending questions (or steer) in plain words |
+| `--plan` | Transcription only — print each finalize payload, commit nothing |
+
+## The session — five phases
+
+Interactive runs are a chat. The engine works phase by phase and parks between phases for your approval; you steer in plain words.
+
+0. **Grounding** — reads the use-case and its cited criteria, follows the cites into the actual source text, and surveys what already exists for reuse.
+1. **Invariant ACs** — promises that hold across every path, each with a complete, machine-checkable oracle. A promise whose expected result the source never states becomes a `missing-expected-result` gap with a recommended default rather than an invented answer.
+2. **Scenarios** — technique-driven path expansion: happy, negative, boundary, edge, and — where the use-case warrants them — security, accessibility, performance, and i18n paths. Existing scenarios are linked, never duplicated; preconditions become dependencies.
+3. **Path ACs + wiring** — per-scenario criteria, plus the record of which scenario exercises which invariant. An invariant nothing exercises becomes an `invariant-unexercised` gap.
+4. **Tests** — exactly **one test per scenario** (strict 1:1). Pairs are scored and cut at the budget; each kept test carries a runnable body, a baseline-capture step where a check needs a before/after delta, and a written check whose expected value comes from its AC — a check that disagrees with its criterion is rejected, so a test can't quietly assert something weaker than the requirement.
+
+Between phases you steer in plain words: `looks good` (approve) · rename or correct an item (edit) · `drop 3` (reject) · `show 2` / `hide` (drill in) — plus the local slash commands `/explain <ref>` (why an item exists — free, replayed from the record), `/done` (end the session), and `/pause` (save + exit `3`). The chat shell — the question panel, the composer grammar, ctrl+t, ctrl+c-to-pause — is exactly the one [extract uses](/docs/kane-cli-assurance-context/#the-interactive-chat).
+
+Headless modes run all phases without parking and emit one combined result; a high-risk question pauses an `agent`-mode run (resumable) and fails a `ci`-mode run closed. See [Automation](/docs/kane-cli-assurance-automation/).
+
+## What you get
+
+A design run commits to the graph **and writes files**. Each kept test lands as a normal, runnable `*_test.md` under `<cwd>/.testmuai/tests/`:
+
+```markdown
+---
+assurance:
+  id: t-add-one-in-stock-product-and-verify-minimum-valid-cart
+  base: sha256:00f8…
+---
+# Add one in-stock product and verify minimum valid cart pricing
+
+> Prove the customer can create the minimum valid cart and see a line total and subtotal.
+
+## Step 1
+
+Open {{store_url}} in a fresh browser session and navigate to the product listing…
+
+## Step 4 — assert @verifies ac-a-valid-cart-contains-at-least-1-item, ac-the-cart-displays-an-order-subtotal
+
+Confirm count check: 1 (equals) — the stated promise: after adding one in-stock product, the cart contains exactly 1 item.
+```
+
+Three things to notice:
+
+- **`@verifies` tags** bind each assert step to the acceptance criteria it proves. This is the link [`kane-cli cover`](/docs/kane-cli-assurance-coverage/) measures against — captured at authoring time, permanent, auditable.
+- **`{{variables}}`** appear wherever the requirements didn't pin a value (the store URL, a known in-stock product). Each unknown is also recorded as a gap so it can't be forgotten. Supply values the normal way — see [Variables & context](/docs/kane-cli-variables-and-context/).
+- The `assurance:` frontmatter links the file to its design entry in the graph, so coverage lookups are exact even after the file moves.
+
+Alongside the tests, the run records the ACs and scenarios themselves, the wiring between them, **gap nodes** with full context for everything it could not resolve, and a rationale sidecar per test (under `.context/design/rationale/`) that `design explain` replays. You'll also see **warnings** at commit time — for example when a test's `@verifies` list claims more criteria than its written check actually asserts.
+
+Design output is derived like everything else — review it with [`kane-cli context review`](/docs/kane-cli-assurance-context/#review), or browse it with [`kane-cli context view`](/docs/kane-cli-assurance-context/#inspect).
+
+### From design to execution
+
+A designed test is a normal test file — but it is still `derived`, and it has never been *run*. First review the design output like anything else the engine emits (approve, edit, or reject the generated ACs, scenarios, and tests with [`kane-cli context review`](/docs/kane-cli-assurance-context/#review) — the commit-time warnings resurface there). Then author each kept test once, and it batches like any other test:
+
+```bash
+kane-cli testmd run .testmuai/tests/t-add-one-…_test.md   # author it (first run, agent works it out)
+kane-cli testrun run --match 't-'                          # from then on: batch replay
+```
+
+Until a test has been authored, `kane-cli testrun` preflight reports it as `missing_meta` and [`kane-cli cover`](/docs/kane-cli-assurance-coverage/) reads its criteria as covered-on-paper but unproven. That reading is deliberate — see [Coverage](/docs/kane-cli-assurance-coverage/#the-authoring-bridge).
+
+<a id="re-runs" />
+## Re-runs and `--force`
+
+A use-case with a live design refuses a re-run, staleness-aware:
+
+```
+'uc-manage-the-cart' is already designed @ v1 — current; use --force to redesign
+'uc-manage-the-cart' was designed @ v1 — the use-case is now @ v2 (STALE); use --force to redesign
+```
+
+`--force` regenerates the scenario+test pairs (superseding the old ones); ACs are dedup-first — an equivalent AC re-emitted by the engine reuses the existing node instead of piling up copies. When the staleness comes from a source document you just changed, [`kane-cli maintain reconcile`](/docs/kane-cli-assurance-maintain/) surfaces the same re-design as part of its changed-source triage; for staleness from older changes, [`kane-cli maintain evolve`](/docs/kane-cli-assurance-maintain/#evolve) re-designs the use-case with the blast radius stated first.
+
+## `design explain` — replay the why
+
+```bash
+kane-cli design explain <ref>
+```
+
+Replays the recorded rationale — never a model call:
+
+- a **test** → the technique that produced it, the boundary values considered, the covering-array strength and why, the criteria it verifies and the scenario it automates;
+- a **scenario / AC / gap** → its content plus every recorded judgement and review verdict.
+
+Ask it "why does this test exist?" six months later and the answer is the one recorded at design time, not a reconstruction.
+
+## Extending the technique catalog
+
+The design engine ships with an embedded catalog of test-design techniques and surface profiles. Drop replacement or additional YAML under `.context/design/` (same id overrides, new ids append) to extend it per store — no upgrade needed.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Design complete (or `--plan` transcription complete). |
+| `1` | Runtime failure. |
+| `2` | Usage / refusal — unknown use-case, already-designed without `--force`, bare non-TTY without `--mode`. |
+| `3` | Session paused and resumable — see [sessions](/docs/kane-cli-assurance-context/#sessions). |
+
+## Next steps
+
+- [Coverage](/docs/kane-cli-assurance-coverage/) — measure what the designed tests prove.
+- [Maintaining the suite](/docs/kane-cli-assurance-maintain/) — reconcile the suite when requirements change.
+- [Automation](/docs/kane-cli-assurance-automation/) — headless design in CI or from an agent.

--- a/docs/kane-cli-assurance-maintain.mdx
+++ b/docs/kane-cli-assurance-maintain.mdx
@@ -1,0 +1,146 @@
+---
+title: "Maintaining the Suite as Sources Change"
+sidebarTitle: "Maintaining the Suite"
+description: "Keep tests aligned with changing requirements — kane-cli maintain reconcile triages one changed source into an ADD/MODIFY/ARCHIVE plan you approve card by card, and maintain evolve re-designs stale use-cases."
+keywords: ['kane cli maintain', 'maintain reconcile', 'test suite maintenance', 'requirements change', 'stale tests', 'kaneai', 'testmu ai']
+"og:description": "Keep tests aligned with changing requirements — kane-cli maintain reconcile triages one changed source into an ADD/MODIFY/ARCHIVE plan you approve card by card."
+---
+
+---
+
+Products change; tests shouldn't rot. `kane-cli maintain` closes the [assurance loop](/docs/kane-cli-assurance/): when a requirement document changes, `maintain reconcile` turns that one changed source into an honest, row-by-row update plan for your suite, and `maintain evolve` re-designs a use-case whose design went stale. Everything works over the same `.context/` store — maintain adds no new knowledge kinds, it moves the existing ones.
+
+```bash
+kane-cli maintain reconcile --from <file> --source-id <id>          # the interactive session (TTY default)
+kane-cli maintain reconcile --from <file> --source-id <id> --plan   # preview: stage + store the plan
+kane-cli maintain reconcile --apply [path]                          # continue a stored plan
+kane-cli maintain reconcile --from <file> --source-id <id> --mode agent   # headless — see Automation
+kane-cli maintain evolve <ref> [--because "<reason>"]               # re-design one stale use-case (interactive)
+kane-cli maintain evolve --from-stale                               # …or every use-case with stale designs
+```
+
+<a id="reconcile" />
+## `maintain reconcile` — one changed source, one triage
+
+Reconcile is the on-change front door: a requirement document changed — what should the suite do about it? It re-ingests the source, re-extracts use-cases over the new snapshot, leads with a changeset (what the change did to your knowledge), and then triages the resulting rows with you.
+
+It takes **two explicit inputs** — reconcile never guesses which source a file belongs to:
+
+- `--from <file>` — the **new** version of the document (a file path).
+- `--source-id <id>` — the **existing** source this file succeeds; its head moves. Find ids with `kane-cli context list --type source`.
+
+Both are required on a fresh run. `--apply <path>` alone is enough to continue a stored plan — the plan remembers its source.
+
+<Tip>
+Hand reconcile the changed file directly — don't `context ingest` the new version first. Reconcile does the re-ingest itself, and [re-running the same command](#running-again) is always safe.
+</Tip>
+
+### Fail-fast validations
+
+Before anything runs — no questions asked, nothing written, identical in every mode — reconcile validates its inputs, in order:
+
+1. both `--from` and `--source-id` are present;
+2. the file exists and is a regular file;
+3. it is an ingestable document type;
+4. the source id names a known source;
+5. that source isn't retired (restore it first with [`kane-cli context revert`](/docs/kane-cli-assurance-context/#housekeeping));
+6. the file doesn't already back a **different** live source — the fork guard: the error suggests the `--source-id` you probably meant, so one document's history never silently forks into another's.
+
+Any failure exits `2` with a message naming the next command to run. In `--mode agent`, validation failures ride the NDJSON stream (`error` + `done`), never stderr alone.
+
+### The changeset — what the change did
+
+Rendered first, before any actions:
+
+```
+changeset: 3 item(s)
+  [MODIFY] uc-manage-the-cart — updated: title, criteria
+  [ADD] uc-save-cart-for-later
+  [ARCHIVE] uc-legacy-flow — evidence decayed: no quote from the source relocates into the new text, no other live source, no fresh evidence this run
+```
+
+- **MODIFY** — the re-extract matched an existing use-case whose content moved. Each MODIFY knows *why*: a content change in the source, or a structural break the change caused.
+- **ADD** — a use-case newly extracted from the changed source.
+- **ARCHIVE** — a strict, three-part evidence decay: every quote fails to relocate into the new text, *and* no other live source evidences the node, *and* this run attached no fresh evidence. All three, or it isn't proposed for archiving.
+
+### The session (the default in a terminal)
+
+Interactive reconcile is a **card walk**: one ADD / MODIFY / ARCHIVE card at a time, each with its why — ARCHIVE cards carry the full evidence-decay reasoning, and MODIFY and ARCHIVE cards state their honest downstream cost up front (`impact: approving marks 14 item(s) stale`). While a card is up, every keystroke belongs to the card:
+
+- **Arrow keys** move through the options, **Enter** takes the highlighted one, and **digits** jump straight to an option.
+- **Typing anything else opens an inline editor** seeded with your words — they become the steering the re-design sees, and approving applies both in one gesture.
+
+The verdicts per card:
+
+- **ADD / MODIFY** — **approve** (an ADD runs a design session for the new use-case right there; a MODIFY commits the update, or re-designs via [`maintain evolve`](#evolve) when the break is structural, blast radius stated first) · **reject** (drop the staged proposal) · **defer** (park it — the stored plan keeps it and a later run re-offers it) · or type to **steer** the re-design in your own words.
+- **ARCHIVE** — **retire** (the explicit verdict; reversible any time with [`kane-cli context revert`](/docs/kane-cli-assurance-context/#housekeeping) — nothing is ever deleted) · **skip** · **defer**.
+
+After the last card the composer wakes: type `<uc-ref> <what to change>` to route one more re-design through the same session. **Nothing lands unapproved** — beyond recording the source change itself, everything a reconcile proposes is staged until you decide. Ctrl+C pauses cleanly (pending work lives in the stored plan, and the same reconcile command picks it back up), and the session ends with an honest summary of what was applied, rejected, deferred, and retired.
+
+### `--plan` — a preview that doesn't touch the suite
+
+`--plan` records the source change and **stages everything downstream**: the proposed rows are held in a stored plan (`plan stored: <path>`, under `.context/reconcile/plans/`), and no tests or designs are touched. Two things do land, disclosed in the output: the head move (the change fact is true regardless of what you decide), and a matched use-case whose source content moved is updated as part of the re-extract itself. Every MODIFY and ARCHIVE row in the plan carries its impact line (`impact: approving marks N item(s) stale`), and a `skipped arms` line names every analysis this release does not run.
+
+Walk the plan later with `--apply <path>` — or bare `--apply`, which picks the latest plan behind an approval prompt (headless modes accept it silently). `--apply --from <file> --source-id <id>` recomputes live instead. `--plan` and `--apply` together is a usage error (exit `2`). A repeated `--plan` re-renders the stored plan; an unchanged source is a truthful no-op (`nothing to reconcile`).
+
+<a id="running-again" />
+### Running again — reconcile converges
+
+The same command is safe to repeat; it picks up where things stand:
+
+| State on a re-run | What happens |
+|---|---|
+| the file's bytes changed again | a fresh reconcile of the new change |
+| unchanged, and the stored plan has pending rows | the plan is **resumed** in your chosen mode |
+| unchanged, and the plan was fully applied | `already reconciled` — clean exit |
+| unchanged, no stored plan | `nothing to reconcile` |
+| the graph moved since the plan was stored | `graph moved since this plan — recomputing` (pending work is re-staged, not re-billed) |
+
+A plan stored by an earlier kane-cli version is refused with a hint to recompute — plans don't survive format changes silently.
+
+### Headless modes
+
+`--mode agent|ci|override` is the same ask-policy matrix extract and design use — see [Automation](/docs/kane-cli-assurance-automation/) for the full contract and reconcile's NDJSON stream. Two things are specific to reconcile:
+
+- Headless runs don't stage: the re-extract commits as it goes, and rows apply per mode — `override` and `ci` auto-apply ADD and MODIFY rows; `ci` fail-closes when a run needs human judgement; `agent` streams typed events and pauses.
+- **Archiving is never automatic.** No headless mode archives anything; ARCHIVE decisions wait for an interactive session.
+
+A bare non-TTY run refuses (exit `2`) and asks for an explicit `--mode` — or `--plan` for a preview.
+
+### The rows
+
+| Kind | Fact behind it | Action on approve |
+|---|---|---|
+| `ADD` | a use-case newly extracted from the changed source, or an uncovered criterion of a touched use-case | a design run for that use-case (`kane-cli design tests --use-case <id>`) |
+| `MODIFY` | matched-but-changed content, or an entity whose pins this change broke | commit the update, or re-design via `kane-cli maintain evolve <id>` when the break is structural |
+| `REMOVE` | a use-case now orphaned — no live source evidences it | plan-only — never executed in this release |
+
+<a id="evolve" />
+## `maintain evolve` — re-design a stale use-case
+
+```bash
+kane-cli maintain evolve <ref> [--because "<reason>"]   # any designed entity → its parent use-case
+kane-cli maintain evolve --from-stale                   # every use-case with stale designed entities
+```
+
+Evolve re-designs the **parent use-case** of whatever you point it at — a test, scenario, criterion, or the use-case itself. It is interactive-only, and the blast radius is always stated before anything runs; declining is a clean exit.
+
+- **Staleness-gated:** a fresh target refuses. `--because "<reason>"` is the sanctioned override — your reason becomes the change context the re-design sees, on the record.
+- `--from-stale` collects every use-case with stale designed entities and walks them one confirm at a time.
+- After a clean run, evolve reports the diff between the two design generations — what was superseded, what was minted, what was **retained** unchanged, and which criteria's verifying tests moved. A re-design doesn't break what it didn't change.
+- Reconcile's MODIFY rows route here automatically — reach for evolve directly when staleness arrived outside a reconcile (an older change, a retired source). [`kane-cli cover gaps`](/docs/kane-cli-assurance-coverage/) lists stale designed entities in its ranked worklist.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Session, plan, or resume complete — or a friendly no-op (unchanged source). |
+| `1` | The reconcile chain failed, or another live reconcile holds the lock (a dead run's lock clears itself — never delete it by hand). |
+| `2` | Usage or validation failure — nothing was mutated. |
+| `3` | Paused — pending work is in the stored plan; the same command (or `--apply`) continues it. |
+
+## Next steps
+
+- [Coverage](/docs/kane-cli-assurance-coverage/) — `cover gaps --stage design` is the standing worklist between reconciles.
+- [Designing tests](/docs/kane-cli-assurance-design/) — what an approved ADD row actually runs.
+- [Automation](/docs/kane-cli-assurance-automation/) — reconcile in CI, and its NDJSON stream.

--- a/docs/kane-cli-assurance.mdx
+++ b/docs/kane-cli-assurance.mdx
@@ -1,0 +1,92 @@
+---
+title: "The Assurance Lifecycle"
+sidebarTitle: "Overview"
+description: "Go from requirement documents to designed, runnable tests with the kane-cli assurance commands — every test permanently linked to the requirement it verifies, coverage measured from sealed evidence, and the suite reconciled as your product changes."
+keywords: ['kane cli assurance', 'requirements to tests', 'test coverage lifecycle', 'context graph', 'ai test design', 'kaneai', 'testmu ai']
+"og:description": "Go from requirement documents to designed, runnable tests with the kane-cli assurance commands — every test permanently linked to the requirement it verifies."
+---
+
+---
+
+kane-cli began as a way to author and replay browser tests. The **assurance** commands take on the step before and after: describe what your product must do, and kane-cli designs the tests that prove it — each one permanently linked to the requirement it verifies. Run them, and coverage stops being a guess: every run reports exactly what it proved and what it still owes. And as your product changes, the suite is reconciled instead of quietly rotting.
+
+<Note>
+Requires kane-cli **0.6.1 or later** (`kane-cli --version`). On 0.6.0 these commands fail after a fresh install — upgrade.
+</Note>
+
+## The loop
+
+```
+  requirement docs                          product changes
+        │                                          │
+        ▼                                          ▼
+  context ingest ──► context extract ──► context review ──► design tests
+  (snapshot the      (agent proposes       (promote to       (ACs, scenarios,
+   sources)           use-cases, cites      trusted)          one test per
+                      every claim)                            scenario — written
+                                                              as *_test.md files)
+                                                                     │
+                                                                     ▼
+  maintain ◄── cover ◄── evidence pack ◄── testrun run ◄── testmd run ◄── context review
+  (reconcile   (proven     (sealed proof)   (batch replay)   (author each    (approve the
+   a changed    vs owed)                                      test once)      design output)
+   source)
+```
+
+Every stage is a separate command, so you can stop, review, and resume at any point — nothing downstream happens without the upstream commit.
+
+| Stage | Command | What it does |
+|---|---|---|
+| Capture | [`kane-cli context ingest`](/docs/kane-cli-assurance-context/#ingest) | Snapshot requirement documents into a local, content-addressed store (`.context/`) |
+| Extract | [`kane-cli context extract`](/docs/kane-cli-assurance-context/#extract) | An agent reads the sources and proposes **use-cases**, citing the exact lines it read |
+| Review | [`kane-cli context review`](/docs/kane-cli-assurance-context/#review) | You promote proposals to **trusted**, edit them, or reject them |
+| Design | [`kane-cli design tests`](/docs/kane-cli-assurance-design/) | Turn one use-case into acceptance criteria, scenarios, and runnable tests — each test tagged with the criteria it verifies |
+| Review the design | [`kane-cli context review`](/docs/kane-cli-assurance-context/#review) | Design output is `derived` too — approve, edit, or reject the generated ACs, scenarios, and tests |
+| Execute | `kane-cli testmd run`, `kane-cli testrun run` | Author and replay the designed tests; every run seals an evidence pack |
+| Measure | [`kane-cli cover`](/docs/kane-cli-assurance-coverage/) | Two axes: what a pack **proved** vs what the design still **owes** |
+| Maintain | [`kane-cli maintain`](/docs/kane-cli-assurance-maintain/) | Reconcile the suite when a source document changes |
+
+## The vocabulary
+
+| Term | Meaning |
+|---|---|
+| **Source** | A requirement document you ingested — a PRD, a spec, a policy page. Content-addressed: editing the file and re-ingesting creates a new version. |
+| **Use-case** | One thing a user needs to accomplish, extracted from sources with cited evidence. |
+| **Acceptance criterion (AC)** | A single verifiable promise ("the cart holds at most 10 items"), with a machine-checkable oracle. |
+| **Scenario** | One path through a use-case — happy, negative, boundary, edge. |
+| **Test** | Exactly one runnable test per scenario (strict 1:1), written as a normal `*_test.md` file. |
+| **derived / trusted / archived** | Trust states. Everything an agent proposes starts `derived` (unreviewed); your review promotes it to `trusted` or rejects it to `archived`. Nothing is silently trusted. |
+| **fresh / stale / orphaned** | Freshness. When a source document changes, everything extracted from the old snapshot reads `stale` until re-verified; a node whose sources are all retired reads `orphaned`. |
+| **Gap** | A recorded, ranked piece of missing coverage — a criterion no test verifies, a question nobody answered, a scenario cut by budget. Gaps are first-class output, not silence. |
+| **Evidence pack** | The sealed `.evidence` file every run produces — the proof coverage is measured from. |
+
+## Assurance vs `generate`
+
+kane-cli has two ways to author tests, for two different jobs:
+
+- **`kane-cli generate`** — quick test cases from a plain-language description. One prompt in, scenarios and cases out. Great for exploring coverage of a feature you can describe in a sentence.
+- **The assurance lifecycle** — tests derived from your actual requirement documents, with every claim cited, every proposal reviewed, and a permanent, auditable link from each test back to the criteria it verifies. Use it when you need to answer "what exactly is covered, and how do we know?"
+
+If you have a PRD and care about coverage accounting, start with assurance. If you want ten good test ideas in a minute, start with `generate`.
+
+<a id="store" />
+## The store: `.context/`
+
+The assurance commands work over a local store in your project directory, created on first `ingest`:
+
+- It is **append-only**: nothing is ever deleted or rewritten. Edits create new versions; mistakes are reverted with compensation records. `kane-cli context explain` can replay the full history of any node.
+- It is **yours and local**: sources, use-cases, designs, and review verdicts live in your project, not on a server. The extract and design agents run against the KaneAI service using your login, but the store they commit to is on your disk.
+- **Keep `.context/` out of git merges.** The store is single-writer and not git-mergeable — two branches appending records will corrupt it on the next read. Gitignore it; share by re-ingesting sources.
+- `kane-cli context fsck` verifies the whole store; `kane-cli context rebuild` regenerates the read caches from the verified records.
+
+## What costs credits
+
+`context extract`, `design tests`, and `maintain reconcile` (which embeds them) call the KaneAI agent and consume credits (`kane-cli balance` to check; each agent turn's cost is reported as it happens). Everything else — list, view, review, explain, cover, fsck — is local and free.
+
+## Next steps
+
+- [Building the context graph](/docs/kane-cli-assurance-context/) — ingest, extract, review.
+- [Designing tests](/docs/kane-cli-assurance-design/) — from a use-case to runnable `*_test.md` files.
+- [Coverage](/docs/kane-cli-assurance-coverage/) — proven vs owed, and how designed tests join execution.
+- [Maintaining the suite](/docs/kane-cli-assurance-maintain/) — reconcile a changed source.
+- [Automation](/docs/kane-cli-assurance-automation/) — running all of this headless in CI or from an agent.


### PR DESCRIPTION
## What

Mintlify port of the Kane CLI **assurance** user guide (LambdaTest/kane-cli#137, merged; Docusaurus counterpart: #3255): six new `.mdx` pages plus a new **Assurance** nav group in `docs.json`, placed after *Core Concepts*.

| Page | Covers |
|---|---|
| `docs/kane-cli-assurance` | The requirements-to-coverage loop, stage-by-stage command map, vocabulary, assurance vs `generate`, the `.context/` store contract, credit costs |
| `docs/kane-cli-assurance-context` | `context` — ingest, extract (interactive chat, questions, pause/resume), review (incl. headless `--verdicts`), sessions, list/view/explain, retire/name/revert/fsck/rebuild, trust & freshness |
| `docs/kane-cli-assurance-design` | `design tests` — the five-phase session, budget & covering-array strength, the emitted `*_test.md` files with `@verifies` links, `design explain` |
| `docs/kane-cli-assurance-coverage` | `cover` — depth (proven by a pack) vs completeness (owed by the graph), the definition-id join, the authoring bridge |
| `docs/kane-cli-assurance-maintain` | `maintain reconcile` — two-input lineage, fail-fast validations, the ADD/MODIFY/ARCHIVE changeset, the card-walk session, staged `--plan`, idempotent re-runs — plus `maintain evolve` |
| `docs/kane-cli-assurance-automation` | Headless/CI contract — the `--mode agent|ci|override` matrix, exit codes, NDJSON event streams, the pause → answer → resume loop, CI shapes |

## Adaptation notes

- Front matter (`title`/`sidebarTitle`/`description`/`keywords`/`og:description`) and page shape follow the existing `kane-cli-*.mdx` pages; blockquote callouts became `<Note>`/`<Tip>`.
- Internal links rewritten to `/docs/kane-cli-assurance-*` slugs; explicit `<a id>` anchors added for cross-page section links whose headings contain code/em-dashes.
- References to pages this branch doesn't carry (`testmd`, `generate`, `testrun`, `evidence`) degrade to plain text.
- `docs.json` parses and every new page path is registered; pages contain no raw `{`/`<` outside code spans.

## Source

Content verified against the released CLI in the upstream PR (LambdaTest/kane-cli#137). Same timing caveat as upstream: the **maintain** page documents the revised reconcile contract shipping in the next kane-cli release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)