### PR TITLE
docs(kane-cli): rename Chat Mode section to TUI Mode

### DIFF
--- a/docs/kane-cli-modes.md
+++ b/docs/kane-cli-modes.md
@@ -77,9 +77,9 @@ On launch, Kane CLI runs a short boot sequence (auth check, environment resoluti
 
 Use the arrow keys to navigate, Enter to select, and Esc to back out of a submenu.
 
-### Chat Mode
+### TUI Mode
 
-Selecting **Run > Start Run** switches the TUI into chat mode. Type your objective at the prompt and press Enter. The agent begins streaming steps into the scrollback: each step shows the action taken, a short rationale, and a status icon. When the run finishes, a result summary block appears.
+In your terminal, type `kane-cli --tui` and this switches to TUI mode. Type your objective at the prompt and press Enter. The agent begins streaming steps into the scrollback: each step shows the action taken, a short rationale, and a status icon. When the run finishes, a result summary block appears.
 
 Subsequent runs in the same TUI session reuse the same browser, so you can iterate on objectives without re-logging in or re-navigating.
 


### PR DESCRIPTION
## What

On the Kane CLI **Modes of Operation** page (`/support/docs/kane-cli-modes/`), under **Interactive TUI**:

- Renamed the `### Chat Mode` heading to `### TUI Mode`.
- Updated the opening sentence from "Selecting **Run > Start Run** switches the TUI into chat mode." to "In your terminal, type `kane-cli --tui` and this switches to TUI mode."

Everything else on the page is unchanged.

## Why

The section described entering the interactive surface via a menu path (`Run > Start Run`). The actual entry point is running `kane-cli --tui` in the terminal, so the heading and instruction now match how users really launch it.

## Note

The section anchor changes from `#chat-mode` to `#tui-mode` as a result of the heading rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)