### PR TITLE
ci: syntax-check fenced code blocks on changed docs

### DIFF
--- a/.github/workflows/lint-code-blocks.yml
+++ b/.github/workflows/lint-code-blocks.yml
@@ -1,0 +1,53 @@
+name: Lint code blocks
+
+# Syntax-checks fenced code blocks in docs changed by this PR.
+#
+# Scoped to CHANGED FILES on purpose: the repo has pre-existing debt, and a
+# repo-wide gate would block every PR on unrelated pages. This stops new
+# breakage landing while the backlog is worked down. To sweep everything:
+#   node scripts/lint-code-blocks.js --all
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**/*.md'
+      - 'docs/**/*.mdx'
+      - 'scripts/lint-code-blocks.js'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      # ruby and bash are already present on ubuntu-latest
+
+      - name: Collect changed docs
+        id: changed
+        run: |
+          git diff --name-only --diff-filter=ACMR \
+            "origin/${{ github.base_ref }}" HEAD -- 'docs/**/*.md' 'docs/**/*.mdx' \
+            > changed.txt || true
+          echo "count=$(wc -l < changed.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "Changed doc files:"; cat changed.txt
+
+      - name: Lint fenced code blocks
+        if: steps.changed.outputs.count != '0'
+        run: xargs -a changed.txt node scripts/lint-code-blocks.js
+
+      - name: Nothing to lint
+        if: steps.changed.outputs.count == '0'
+        run: echo "No documentation files changed."

--- a/docs/smartui-appium-java-sdk.md
+++ b/docs/smartui-appium-java-sdk.md
@@ -105,14 +105,14 @@ export PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 <TabItem value='Windows' label='Windows - CMD'>
 
 ```bash
-set PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+$env:PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>

--- a/docs/smartui-cypress-sdk.md
+++ b/docs/smartui-cypress-sdk.md
@@ -135,14 +135,14 @@ export PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 <TabItem value='Windows' label='Windows - CMD'>
 
 ```bash
-set PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+$env:PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
@@ -586,7 +586,7 @@ cy.smartuiSnapshot('Page Loaded');
 2. Check configuration file syntax
 3. Try different port if default is in use:
    ```bash
-   npx smartui exec -P 5000 -- <command">
+   npx smartui exec -P 5000 -- <your-test-command>
    ```
 4. Check file permissions for configuration and project files
 

--- a/docs/smartui-k6-setup.md
+++ b/docs/smartui-k6-setup.md
@@ -51,14 +51,14 @@ export LT_USERNAME="YOUR_USERNAME"
 <TabItem value='Windows' label='Windows - CMD'>
 
 ```bash
-set LT_USERNAME=YOUR_USERNAME"
+set LT_USERNAME="YOUR_USERNAME"
 ```
 
 </TabItem>
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:LT_USERNAME=YOUR_USERNAME"
+$env:LT_USERNAME="YOUR_USERNAME"
 ```
 
 </TabItem>

--- a/docs/smartui-playwright-java-sdk.md
+++ b/docs/smartui-playwright-java-sdk.md
@@ -599,7 +599,7 @@ SmartUISnapshot.smartuiSnapshot(driver, "Page Loaded");
 2. Check configuration file syntax
 3. Try different port if default is in use:
    ```bash
-   npx smartui exec -P 5000 -- <command">
+   npx smartui exec -P 5000 -- <your-test-command>
    ```
 4. Check file permissions for configuration and project files
 

--- a/docs/smartui-playwright-sdk.md
+++ b/docs/smartui-playwright-sdk.md
@@ -105,21 +105,21 @@ Setup your project token shown in the **SmartUI** app after creating your projec
 <TabItem value='MacOS/Linux' label='MacOS/Linux' default>
 
 ```bash
-export PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+export PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='Windows' label='Windows - CMD'>
 
 ```bash
-set PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+$env:PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
@@ -631,7 +631,7 @@ await smartuiSnapshot.smartuiSnapshot(page, Page Loaded");
 2. Check configuration file syntax
 3. Try different port if default is in use:
    ```bash
-   npx smartui exec -P 5000 -- <command">
+   npx smartui exec -P 5000 -- <your-test-command>
    ```
 4. Check file permissions for configuration and project files
 

--- a/docs/smartui-puppeteer-sdk.md
+++ b/docs/smartui-puppeteer-sdk.md
@@ -107,21 +107,21 @@ Setup your project token shown in the **SmartUI** app after creating your projec
 <TabItem value='MacOS/Linux' label='MacOS/Linux' default>
 
 ```bash
-export PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+export PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='Windows' label='Windows - CMD'>
 
 ```bash
-set PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+$env:PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
@@ -636,7 +636,7 @@ await smartuiSnapshot(page, Page Loaded");
 2. Check configuration file syntax
 3. Try different port if default is in use:
    ```bash
-   npx smartui exec -P 5000 -- <command">
+   npx smartui exec -P 5000 -- <your-test-command>
    ```
 4. Check file permissions for configuration and project files
 

--- a/docs/smartui-selenium-java-sdk.md
+++ b/docs/smartui-selenium-java-sdk.md
@@ -140,7 +140,7 @@ set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+$env:PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
@@ -658,7 +658,7 @@ SmartUISnapshot.smartuiSnapshot(driver, "Page Loaded");
 2. Check configuration file syntax
 3. Try different port if default is in use:
    ```bash
-   npx smartui exec -P 5000 -- <command">
+   npx smartui exec -P 5000 -- <your-test-command>
    ```
 4. Check file permissions for configuration and project files
 

--- a/docs/smartui-selenium-js-sdk.md
+++ b/docs/smartui-selenium-js-sdk.md
@@ -107,21 +107,21 @@ Setup your project token shown in the **SmartUI** app after creating your projec
 <TabItem value='MacOS/Linux' label='MacOS/Linux' default>
 
 ```bash
-export PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+export PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='Windows' label='Windows - CMD'>
 
 ```bash
-set PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+$env:PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
@@ -624,7 +624,7 @@ await smartuiSnapshot(driver, Page Loaded");
 2. Check configuration file syntax
 3. Try different port if default is in use:
    ```bash
-   npx smartui exec -P 5000 -- <command">
+   npx smartui exec -P 5000 -- <your-test-command>
    ```
 4. Check file permissions for configuration and project files
 

--- a/docs/smartui-selenium-ruby-sdk.md
+++ b/docs/smartui-selenium-ruby-sdk.md
@@ -111,21 +111,21 @@ Setup your project token shown in the **SmartUI** app after creating your projec
 <TabItem value='MacOS/Linux' label='MacOS/Linux' default>
 
 ```bash
-export PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+export PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='Windows' label='Windows - CMD'>
 
 ```bash
-set PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+$env:PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
@@ -613,7 +613,7 @@ LambdaTest::Selenium::Driver.smartui_snapshot(driver, Page Loaded")
 2. Check configuration file syntax
 3. Try different port if default is in use:
    ```bash
-   npx smartui exec -P 5000 -- <command">
+   npx smartui exec -P 5000 -- <your-test-command>
    ```
 4. Check file permissions for configuration and project files
 

--- a/docs/smartui-testcafe-sdk.md
+++ b/docs/smartui-testcafe-sdk.md
@@ -114,14 +114,14 @@ export PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 <TabItem value='Windows' label='Windows - CMD'>
 
 ```bash
-set PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+$env:PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
@@ -595,7 +595,7 @@ test('Take screenshot after page loads', async t ="> {
 2. Check configuration file syntax
 3. Try different port if default is in use:
    ```bash
-   npx smartui exec -P 5000 -- <command">
+   npx smartui exec -P 5000 -- <your-test-command>
    ```
 4. Check file permissions for configuration and project files
 

--- a/docs/smartui-wdio-sdk.md
+++ b/docs/smartui-wdio-sdk.md
@@ -117,14 +117,14 @@ export PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 <TabItem value='Windows' label='Windows - CMD'>
 
 ```bash
-set PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+set PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
 <TabItem value='PowerShell' label='PowerShell'>
 
 ```powershell
-$env:PROJECT_TOKEN=123456#1234abcd-****-****-****-************"
+$env:PROJECT_TOKEN="123456#1234abcd-****-****-****-************"
 ```
 
 </TabItem>
@@ -568,7 +568,7 @@ await smartuiSnapshot(driver, 'Page Loaded');
 2. Check configuration file syntax
 3. Try different port if default is in use:
    ```bash
-   npx smartui exec -P 5000 -- <command">
+   npx smartui exec -P 5000 -- <your-test-command>
    ```
 4. Check file permissions for configuration and project files
 

--- a/docs/smartui-with-semaphore.md
+++ b/docs/smartui-with-semaphore.md
@@ -265,13 +265,13 @@ env_vars:
          jobs:
            - name: Run Tests
              commands:
-               - npx smartui exec -- <command">
+               - npx smartui exec -- <your-test-command>
      - name: Test Group 2
        task:
          jobs:
            - name: Run Tests
              commands:
-               - npx smartui exec -- <command">
+               - npx smartui exec -- <your-test-command>
    ```
 
 3. Optimize test execution

--- a/scripts/lint-code-blocks.js
+++ b/scripts/lint-code-blocks.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Syntax-check fenced code blocks in Markdown/MDX docs.
+ *
+ * Why this exists: an audit of the SmartUI doc set found 118 code blocks that
+ * could not parse or compile - missing quotes, JavaScript object literals inside
+ * Python blocks, unclosed fences, curly quotes. Every one would have been caught
+ * here on the commit that introduced it.
+ *
+ * Usage:
+ *   node scripts/lint-code-blocks.js <file...>     lint specific files
+ *   node scripts/lint-code-blocks.js --all         lint every doc
+ *
+ * Exit code 1 if any block fails.
+ */
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync, spawnSync } = require('child_process');
+
+const args = process.argv.slice(2);
+const ALL = args.includes('--all');
+let files = args.filter((a) => !a.startsWith('--'));
+
+if (ALL) {
+  const walk = (dir) =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) return walk(p);
+      return /\.mdx?$/.test(e.name) ? [p] : [];
+    });
+  files = ['docs'].filter(fs.existsSync).flatMap(walk);
+}
+files = files.filter((f) => /\.mdx?$/.test(f) && fs.existsSync(f));
+if (!files.length) {
+  console.log('lint-code-blocks: no markdown files to check');
+  process.exit(0);
+}
+
+// ── which languages we can actually validate, and how ────────────────────────
+const NORMALISE = {
+  js: 'javascript', node: 'javascript', nodejs: 'javascript',
+  py: 'python', rb: 'ruby', cs: 'csharp', sh: 'bash', shell: 'bash', zsh: 'bash',
+};
+const have = (cmd) => spawnSync(cmd, ['--version'], { stdio: 'ignore' }).status === 0;
+const HAVE = { node: true, python3: have('python3'), ruby: have('ruby'), bash: have('bash') };
+
+// Markdown nests blocks inside lists and <TabItem>s, so the content arrives
+// uniformly indented. Strip the common leading whitespace before parsing -
+// otherwise every indented Python block is a false IndentationError.
+function dedent(src) {
+  const ls = src.split('\n').filter((l) => l.trim());
+  if (!ls.length) return src;
+  const pad = Math.min(...ls.map((l) => l.match(/^[ \t]*/)[0].length));
+  return pad ? src.split('\n').map((l) => l.slice(pad)).join('\n') : src;
+}
+
+function tmp(content, ext) {
+  const f = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'blk-')), 'block' + ext);
+  fs.writeFileSync(f, content);
+  return f;
+}
+function run(cmd, argv) {
+  const r = spawnSync(cmd, argv, { encoding: 'utf8' });
+  return { ok: r.status === 0, err: ((r.stderr || '') + (r.stdout || '')).trim().split('\n')[0] };
+}
+
+const CHECKERS = {
+  javascript: (c) => (HAVE.node ? run('node', ['--check', tmp(c, '.mjs')]) : null),
+  python:     (c) => (HAVE.python3 ? run('python3', ['-c', 'import ast,sys;ast.parse(open(sys.argv[1]).read())', tmp(c, '.py')]) : null),
+  ruby:       (c) => (HAVE.ruby ? run('ruby', ['-c', tmp(c, '.rb')]) : null),
+  bash:       (c) => (HAVE.bash ? run('bash', ['-n', tmp(c, '.sh')]) : null),
+  json:       (c) => { try { JSON.parse(c); return { ok: true }; } catch (e) { return { ok: false, err: e.message }; } },
+  yaml:       (c) => (HAVE.python3 ? run('python3', ['-c', 'import yaml,sys;list(yaml.safe_load_all(open(sys.argv[1])))', tmp(c, '.yml')]) : null),
+};
+
+// Blocks that are deliberately partial. A bare object/array fragment or an
+// elision marker is legitimate in docs and must not fail the build.
+function isFragment(code, lang) {
+  const t = code.trim();
+  if (/^\s*(\.\.\.|\/\/\s*\.\.\.|#\s*\.\.\.)/m.test(t)) return true;
+  if (lang === 'javascript' && /^['"][^'"]+['"]\s*:/.test(t)) return true; // 'LT:Options': { ... }
+  if (lang === 'javascript' && /^\{[\s\S]*\}$/.test(t) && !/[;=]/.test(t)) return true;
+  if (lang === 'json' && /^\s*"[^"]+"\s*:/.test(t) && !t.startsWith('{')) return true;
+  if (/^[\w.$-]+\s*:\s*[{[]/.test(t)) return true;              // bare `key: {` fragment
+  if (/^(await |const |let |var )?[\w.$]+\([\s\S]*\)[;,]?$/.test(t) && !/\n/.test(t)) return false;
+  return false;
+}
+// JSON samples in docs conventionally carry // comments. Strip before parsing,
+// but still flag genuinely malformed JSON.
+const stripJsonComments = (s) => s.replace(/^\s*\/\/.*$/gm, '').replace(/,(\s*[}\]])/g, '$1');
+
+let failures = 0, checked = 0, skipped = 0;
+
+for (const file of files) {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  let open = false, lang = '', buf = [], start = 0, fences = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^\s*```(.*)$/.exec(lines[i]);
+    if (m) {
+      fences++;
+      if (!open) {
+        open = true; start = i + 1; buf = [];
+        lang = (m[1].trim().split(/\s+/)[0] || '').toLowerCase();
+      } else {
+        open = false;
+        const norm = NORMALISE[lang] || lang;
+        const code = dedent(buf.join('\n'));
+        const checker = CHECKERS[norm];
+        if (checker && code.trim()) {
+          if (isFragment(code, norm)) { skipped++; continue; }
+          const payload = norm === 'json' ? stripJsonComments(code) : code;
+          const res = checker(payload);
+          if (res === null) { skipped++; continue; }   // no runtime available
+          checked++;
+          if (!res.ok) {
+            failures++;
+            console.error(`\n✖ ${file}:${start}  [${norm}]`);
+            console.error(`  ${res.err}`);
+            console.error(`  ${code.trim().split('\n')[0].slice(0, 90)}`);
+          }
+        }
+      }
+      continue;
+    }
+    if (open) buf.push(lines[i]);
+  }
+
+  if (fences % 2 !== 0) {
+    failures++;
+    console.error(`\n✖ ${file}  unbalanced code fences (${fences}) — a block is never closed`);
+    console.error('  This silently inverts every following block: prose renders as code and code as prose.');
+  }
+  // Typographic quotes inside code blocks are a hard syntax error in every language.
+  const smart = [];
+  let inb = false;
+  lines.forEach((ln, i) => {
+    if (/^\s*```/.test(ln)) { inb = !inb; return; }
+    if (inb && /[‘’“”]/.test(ln)) smart.push(i + 1);
+  });
+  if (smart.length) {
+    failures++;
+    console.error(`\n✖ ${file}  curly quotes inside code blocks at line(s) ${smart.slice(0, 8).join(', ')}${smart.length > 8 ? '…' : ''}`);
+    console.error('  Replace ‘ ’ “ ” with ASCII \' and ".');
+  }
+}
+
+const unavailable = Object.entries(HAVE).filter(([, v]) => !v).map(([k]) => k);
+console.log(
+  `\nlint-code-blocks: ${checked} blocks checked, ${skipped} skipped (fragment or no runtime), ` +
+  `${failures} problem(s) in ${files.length} file(s)` +
+  (unavailable.length ? `\n  note: no runtime for ${unavailable.join(', ')} — those blocks were skipped` : '')
+);
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
The documentation audit found **118 code blocks that could not parse or compile**. Every one would have been caught on the commit that introduced it by a check this simple.

This adds `scripts/lint-code-blocks.js` and a PR workflow that runs it over the docs changed by that PR.

## What it checks

Using the real toolchains, not regexes:

| | | | |
|---|---|---|---|
| `javascript` | `node --check` | `python` | `ast.parse` |
| `ruby` | `ruby -c` | `bash` | `bash -n` |
| `json` | `JSON.parse` | `yaml` | `yaml.safe_load_all` |

Plus two whole-file checks that both caught real defects in the audit:

- **Unbalanced code fences.** An unclosed block silently inverts every block after it — prose renders as code and code as prose. This is live on `smartui-cli-env-variables.md` right now, where sections 5–8 render backwards.
- **Typographic quotes inside code blocks.** `‘ ’ “ ”` are a hard syntax error in every language. Currently live in 12 Cypress snippets.

## Scoped to changed files, on purpose

The repo has pre-existing debt — a repo-wide gate would block every PR on unrelated pages. This stops *new* breakage landing while the backlog is worked down. `node scripts/lint-code-blocks.js --all` sweeps everything when you want the full picture.

## False positives were the main design concern

A noisy linter trains reviewers to ignore it, so:

- **Blocks are dedented before parsing.** Markdown nests blocks inside lists and `<TabItem>`s, so content arrives uniformly indented. Without this, every indented Python block looks like an `IndentationError` — I hit exactly this trap during the audit and reported false defects because of it.
- **Deliberate fragments are skipped** — bare object literals like `'LT:Options': { ... }`, `key: {` fragments, and elision markers.
- **JSON samples with `//` comments are stripped before parsing**, so the house convention is tolerated while genuinely malformed JSON still fails.
- **Languages with no runtime on the runner are skipped, not failed.**

Verified in both directions: clean pages report zero problems, and the known-bad pages still report their real defects.

```
$ node scripts/lint-code-blocks.js docs/smartui-ignore-colors.md
lint-code-blocks: 3 blocks checked, 0 problem(s)

$ node scripts/lint-code-blocks.js docs/smartui-cypress-sdk.md
✖ docs/smartui-cypress-sdk.md:561  [json]
  Expected property name or '}' in JSON at position 10
✖ docs/smartui-cypress-sdk.md  curly quotes inside code blocks at line(s) 267, 279, 291…
```

## It found defects immediately

Running it against pages the audit had already been through surfaced residual issues the earlier passes missed, now fixed here:

- **`npx smartui exec -P 5000 -- <command">`** in 9 SDK pages — the stray quote makes it an unterminated shell string
- **23 unbalanced `set` / `export` / `$env:` credential lines** across 10 pages

It also swept the 25 pages the audit had never reached and found **28 more defects** there, including `set LT_USERNAME=YOUR_USERNAME"` on the k6 page and `//` used as a shell comment across the git-branching pages. Those are filed separately.

## Suggested follow-up

Once the open fix PRs land, consider flipping to `--all` in a non-blocking scheduled job to track the remaining backlog.