### PR TITLE
docs(kane-cli): bring Mintlify Kane CLI docs to parity with testmuCom

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -59,9 +59,20 @@
                 "group": "Core Concepts",
                 "pages": [
                   "docs/kane-cli-modes",
-                  "docs/kane-cli-configuration",
                   "docs/kane-cli-writing-objectives",
-                  "docs/kane-cli-variables-and-context"
+                  "docs/kane-cli-api-calls",
+                  "docs/kane-cli-browser-state",
+                  "docs/kane-cli-variables-and-context",
+                  "docs/kane-cli-configuration",
+                  "docs/kane-cli-tms-integration",
+                  "docs/kane-cli-testmd"
+                ]
+              },
+              {
+                "group": "Generate Test Cases",
+                "pages": [
+                  "docs/kane-cli-generate",
+                  "docs/kane-cli-generate-workflow"
                 ]
               },
               {
@@ -76,17 +87,38 @@
                 ]
               },
               {
-                "group": "Integrations & Automation",
+                "group": "Checkpoints",
                 "pages": [
-                  "docs/kane-cli-tms-integration",
-                  "docs/kane-cli-cicd",
-                  "docs/kane-cli-parallel-execution"
+                  "docs/kane-cli-checkpoints",
+                  "docs/kane-cli-checkpoint-visual",
+                  "docs/kane-cli-checkpoint-textual",
+                  "docs/kane-cli-checkpoint-url",
+                  "docs/kane-cli-checkpoint-title",
+                  {
+                    "group": "DevTools",
+                    "pages": [
+                      "docs/kane-cli-checkpoint-devtools",
+                      "docs/kane-cli-checkpoint-devtools-network",
+                      "docs/kane-cli-checkpoint-devtools-console",
+                      "docs/kane-cli-checkpoint-devtools-performance",
+                      "docs/kane-cli-checkpoint-devtools-cookies",
+                      "docs/kane-cli-checkpoint-devtools-localstorage",
+                      "docs/kane-cli-checkpoint-devtools-clipboard"
+                    ]
+                  }
                 ]
               },
               {
                 "group": "Agent Mode",
                 "pages": [
                   "docs/kane-cli-agent-mode",
+                  "docs/kane-cli-parallel-execution"
+                ]
+              },
+              {
+                "group": "CI/CD & Skills",
+                "pages": [
+                  "docs/kane-cli-cicd",
                   "docs/kane-cli-skills"
                 ]
               },

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -26,6 +26,18 @@ kane-cli login
 kane-cli run --url https://example.com "Click the 'More information' link and verify the page loads"
 ```
 
+## Supported IDEs
+
+Kane CLI runs from the integrated terminal of your editor, so you can drive browser tests without leaving your development environment. It is supported in:
+
+* Cursor
+* Antigravity
+* VS Code
+* Codex
+* Kiro (AWS)
+* Eclipse-based IDEs
+* Web-based IDEs
+
 ## Three Modes
 
 | Mode | Command | Best For |

--- a/docs/kane-cli-agent-mode.mdx
+++ b/docs/kane-cli-agent-mode.mdx
@@ -126,6 +126,12 @@ Kane CLI outputs one JSON object per line (NDJSON) to stdout:
 
 ---
 
+# The .evidence proof pack
+
+Every Kane CLI run produces an `.evidence` pack stored natively in the results folder, so failure context travels with the run instead of living in a separate dashboard. Each pack contains the full execution proof for the run: step-by-step traces, screenshots, video, and command, network and console logs, plus the NDJSON event stream and result codes. Coding agents and humans read the same evidence to see exactly what happened, where it failed, and why.
+
+---
+
 ## Parsing Output
 
 Get the `run_end` event:

--- a/docs/kane-cli-api-calls.mdx
+++ b/docs/kane-cli-api-calls.mdx
@@ -1,0 +1,68 @@
+---
+title: "API Calls"
+sidebarTitle: "API Calls"
+description: "Have the Kane CLI agent make HTTP API calls directly inside an objective to seed data, hit a backend, then assert on or reuse the response."
+keywords: ['api calls', 'kane cli', 'http request', 'seed data', 'testmu ai']
+"og:description": "Have the Kane CLI agent make HTTP API calls directly inside an objective to seed data, hit a backend, then assert on or reuse the response."
+---
+
+---
+
+Objectives can have the agent **make an API call directly**, not just observe the requests a page makes. This is useful for seeding data before a flow, hitting a backend to set up state, or checking a service, then asserting on or reusing the response.
+
+## Making a call
+
+Phrase an explicit HTTP request and name its response with "save the response as …":
+
+```
+Call POST https://api.example.com/orders with body {"item": "sku_42", "qty": 1}, save the response as order
+Hit GET https://api.example.com/orders/123, save the response as fetched
+Call DELETE https://api.example.com/orders/123
+```
+
+A pasted `curl` works too and is kept exactly as written: method, headers, body, and auth:
+
+```
+curl -X POST https://api.example.com/login -H 'Content-Type: application/json' -d '{"u":"a","p":"b"}', save the response as login
+```
+
+## Using the response
+
+Once you've saved a response under a name, reference it elsewhere in the objective:
+
+| Reference | Resolves to |
+|-----------|-------------|
+| `{{order.status}}` | the HTTP status code (e.g. `201`) |
+| `{{order.response_body}}` | the whole response body |
+| `{{order.response_body.<field>}}` | a field from the JSON response body |
+
+Assert on it, or feed it into later actions. API calls and browser actions mix freely in one objective:
+
+```
+Call POST https://api.example.com/login with body {"u": "{{user}}", "p": "{{password}}"}, save the response as login,
+assert {{login.status}} is 200,
+then open https://app.example.com and verify the dashboard loads
+```
+
+```
+Call POST https://api.example.com/orders with body {"item": "sku_42", "qty": 1}, save the response as order,
+assert {{order.status}} is 201,
+then open https://app.example.com/orders and verify an order for "sku_42" is visible
+```
+
+## Tokens and secrets
+
+Put any API token or credential in a variable marked `secret: true` (see [Variables and Context](/docs/kane-cli-variables-and-context/)) so it is masked in logs and never stored in plain text:
+
+```
+curl -X DELETE https://api.example.com/records/42 -H "Authorization: Bearer {{api_token}}"
+```
+
+## Make a call vs. observe page traffic
+
+These are two different things:
+
+- **Make a call (this page)**: *you* tell the agent to send a request: seed a record, call a backend, set up state.
+- **[Network assertions](/docs/kane-cli-checkpoint-devtools-network/)**: *observe* the requests the page itself makes during a UI flow (status codes, bodies, timing).
+
+They compose: seed state with a direct call, drive the UI, then assert on the page's own network traffic.

--- a/docs/kane-cli-assurance-coverage.mdx
+++ b/docs/kane-cli-assurance-coverage.mdx
@@ -67,7 +67,7 @@ A freshly designed test has never been executed, and the tooling is honest about
 
 1. `kane-cli design tests` writes `t-…_test.md` files — runnable, but with no recording yet.
 2. `kane-cli testrun` preflight refuses never-authored members (`missing_meta`).
-3. So the first run of each designed test is `kane-cli testmd run <file>` — the agent authors it in a real browser and commits the recording.
+3. So the first run of each designed test is [`kane-cli testmd run <file>`](/docs/kane-cli-testmd/) — the agent authors it in a real browser and commits the recording.
 4. From then on the test replays like any other: batch it with `testrun`, and its verdicts join the pack via `definition_id`.
 
 Until step 3 happens, `cover` reads the test's criteria as *covered on paper, unproven in execution* (`covered_by` present, execution `not-run`). That is a deliberate reading, not a bug — a designed test is a claim until a run proves it.

--- a/docs/kane-cli-assurance.mdx
+++ b/docs/kane-cli-assurance.mdx
@@ -42,7 +42,7 @@ Every stage is a separate command, so you can stop, review, and resume at any po
 | Review | [`kane-cli context review`](/docs/kane-cli-assurance-context/#review) | You promote proposals to **trusted**, edit them, or reject them |
 | Design | [`kane-cli design tests`](/docs/kane-cli-assurance-design/) | Turn one use-case into acceptance criteria, scenarios, and runnable tests — each test tagged with the criteria it verifies |
 | Review the design | [`kane-cli context review`](/docs/kane-cli-assurance-context/#review) | Design output is `derived` too — approve, edit, or reject the generated ACs, scenarios, and tests |
-| Execute | `kane-cli testmd run`, `kane-cli testrun run` | Author and replay the designed tests; every run seals an evidence pack |
+| Execute | [`kane-cli testmd run`](/docs/kane-cli-testmd/), `kane-cli testrun run` | Author and replay the designed tests; every run seals an evidence pack |
 | Measure | [`kane-cli cover`](/docs/kane-cli-assurance-coverage/) | Two axes: what a pack **proved** vs what the design still **owes** |
 | Maintain | [`kane-cli maintain`](/docs/kane-cli-assurance-maintain/) | Reconcile the suite when a source document changes |
 
@@ -64,7 +64,7 @@ Every stage is a separate command, so you can stop, review, and resume at any po
 
 kane-cli has two ways to author tests, for two different jobs:
 
-- **`kane-cli generate`** — quick test cases from a plain-language description. One prompt in, scenarios and cases out. Great for exploring coverage of a feature you can describe in a sentence.
+- **[`kane-cli generate`](/docs/kane-cli-generate/)** — quick test cases from a plain-language description. One prompt in, scenarios and cases out. Great for exploring coverage of a feature you can describe in a sentence.
 - **The assurance lifecycle** — tests derived from your actual requirement documents, with every claim cited, every proposal reviewed, and a permanent, auditable link from each test back to the criteria it verifies. Use it when you need to answer "what exactly is covered, and how do we know?"
 
 If you have a PRD and care about coverage accounting, start with assurance. If you want ten good test ideas in a minute, start with `generate`.

--- a/docs/kane-cli-browser-state.mdx
+++ b/docs/kane-cli-browser-state.mdx
@@ -1,0 +1,61 @@
+---
+title: "Browser State Actions"
+sidebarTitle: "Browser State"
+description: "Set cookies, localStorage, and the clipboard directly from a Kane CLI objective to seed state before a flow or test copy and paste behavior."
+keywords: ['browser state', 'set cookies', 'localstorage', 'clipboard', 'kane cli', 'testmu ai']
+"og:description": "Set cookies, localStorage, and the clipboard directly from a Kane CLI objective to seed state before a flow or test copy and paste behavior."
+---
+
+---
+
+Objectives can directly manage cookies, localStorage, and the clipboard, useful for seeding state before a flow (skip a login, dismiss a consent banner) and for testing copy/paste behavior.
+
+## Cookies
+
+```
+Set a cookie named session with value abc123
+Set cookies consent=yes and tracking=off, then reload the page
+Delete the consent cookie
+Clear all cookies
+```
+
+- Values accept `{{variables}}`: `set a cookie named session with value {{auth_token}}`
+- A cookie without an explicit domain applies to the **current page's site**. Navigate first
+- Reload or navigate after setting if the page must pick the cookie up
+- Provide `path` together with a domain; a path alone is rejected by the browser
+
+## localStorage
+
+```
+Set localStorage keys theme=dark and lang=en
+Delete the lang key from localStorage
+Clear localStorage
+```
+
+- Storage is **per-site**. Navigate to the target site before setting
+- Reload after setting if the app only reads storage on page load
+- Values accept `{{variables}}`
+
+## Clipboard
+
+The run uses an **isolated test clipboard**. Your real OS clipboard is never read or written. Site Copy buttons are captured into it automatically.
+
+```
+Write "John Tester" to the clipboard
+Click the message field, then paste from the clipboard
+Clear the clipboard
+```
+
+- **Paste targets the focused field**: click or focus the field first, then paste (`Ctrl/Cmd+V` in an objective works the same way)
+- Text and images both paste; rich editors receive a real paste event
+- Typical flows: *write → click field → paste*, or *click the site's Copy button → click field → paste*
+
+## Verifying state
+
+Each of these has a matching assertion family. See [Cookies](/docs/kane-cli-checkpoint-devtools-cookies/), [localStorage](/docs/kane-cli-checkpoint-devtools-localstorage/), and [Clipboard](/docs/kane-cli-checkpoint-devtools-clipboard/):
+
+```
+Set a cookie named session with value abc123, reload, and verify the page shows you as logged in
+Set localStorage theme=dark, reload, and verify the dark theme is active
+Click the Copy link button, then verify the clipboard contains "/invoice/42"
+```

--- a/docs/kane-cli-checkpoint-devtools-clipboard.mdx
+++ b/docs/kane-cli-checkpoint-devtools-clipboard.mdx
@@ -1,0 +1,69 @@
+---
+title: "Clipboard Assertions"
+sidebarTitle: "Clipboard"
+description: "Verify what a Copy button actually copied, extract copied values into variables, and confirm clipboard state, using an isolated test clipboard."
+keywords: ['clipboard assertion', 'copy button', 'kane cli', 'devtools', 'testmu ai']
+"og:description": "Verify what a Copy button actually copied, extract copied values into variables, and confirm clipboard state, using an isolated test clipboard."
+---
+
+---
+
+Clipboard assertions let you verify what a "Copy" button actually copied, extract copied values into variables, and confirm clipboard state after your test writes or clears it.
+
+## The Test Clipboard
+
+Every run uses an **isolated test clipboard**:
+
+- **Your real clipboard is safe**: the OS clipboard is never read and never written. Tests can't leak your copied data into results, and nothing you copy mid-run interferes with the test
+- **Automatic capture**: when the page copies something (a Copy button, Ctrl/Cmd+C on a selection), it lands in the test clipboard
+- **One current entry**: like a real clipboard, every copy or clipboard write **replaces** the previous content
+- **Multi-format**: a single entry can carry plain text, HTML, and an image together (e.g. a "Copy image" button)
+- **Same behavior everywhere**: headless, headed, and CI runs all behave identically
+
+### Planning for Multi-Step Tests
+
+Because the clipboard holds one entry at a time:
+
+- Verify a copied value **immediately after** the copy or write that produced it. A later clipboard write/clear replaces it
+- To check several copies, interleave: copy A → verify → copy B → verify
+
+## What You Can Query
+
+| Query | Description |
+|-------|-------------|
+| text content | The plain-text content of the clipboard ("" when empty) |
+| HTML content | The rich-text representation, when present |
+| formats present | Which content types the entry carries (text, HTML, image) |
+| image presence/size | Whether an image was copied, and its byte size |
+
+## Example Assertions
+
+```
+Click the "Copy link" button, then verify the clipboard contains "/invoice/42"
+Verify the clipboard text is "INV-2026-042"
+Verify an image was copied to the clipboard
+Verify the clipboard text is empty
+```
+
+## Example Extractions
+
+```
+Click the Copy button, store the copied coupon code as 'coupon'
+Store the clipboard text as 'copied_link'
+```
+
+Stored values work like any other variable. Fill `{{coupon}}` into a field later, or assert on it.
+
+## Writing and Pasting (actions)
+
+The clipboard isn't read-only. Objectives can also drive it. See [Browser State Actions](/docs/kane-cli-browser-state/):
+
+```
+Write "John Tester" to the clipboard, click the message field, then paste from the clipboard
+```
+
+## Tips
+
+- **Don't paste to verify**: assert on the clipboard directly instead of pasting into a field and reading it back
+- **Prefer positive phrasing** for empties: "verify the clipboard text is empty" rather than "verify X is not on the clipboard"
+- Clipboard actions need a page loaded first. Navigate before writing or pasting

--- a/docs/kane-cli-checkpoint-devtools-console.mdx
+++ b/docs/kane-cli-checkpoint-devtools-console.mdx
@@ -1,0 +1,83 @@
+---
+title: "Console Assertions"
+sidebarTitle: "Console"
+description: "Verify browser console output: errors, warnings, log messages, and JavaScript exceptions captured during test execution."
+keywords: ['console assertion', 'javascript errors', 'console log', 'kane cli', 'devtools', 'testmu ai']
+"og:description": "Verify browser console output: errors, warnings, log messages, and JavaScript exceptions captured during test execution."
+---
+
+---
+
+Console assertions let you verify browser console output: error messages, warnings, log messages, and uncaught JavaScript exceptions.
+
+## How Capture Works
+
+KaneAI captures all browser console output automatically during each test step:
+
+- **Continuous capture**: Every `console.log()`, `console.warn()`, `console.error()`, and uncaught JS exception is recorded
+- **Per-step scope**: Each test step starts with a fresh capture. Console messages from previous steps are not carried over
+- **Limits**: Up to 50,000 messages are stored per step. When the limit is reached, the oldest 10% are dropped
+- **No truncation**: Message text is stored in full. Unlike network response bodies, console messages are never truncated
+- **Object resolution**: When JavaScript logs an object (`console.log({status: "ok"})`), KaneAI resolves it to the actual value instead of storing "JSHandle@object"
+- **Multi-tab support**: Console messages from new tabs and popups are also captured
+- **Top-frame only**: Messages from embedded iframes (payment widgets, third-party components) are not captured
+
+### Planning for Multi-Step Tests
+
+Because console data resets each step, plan accordingly:
+
+- If you need to verify a console message **later**, extract and store it in the same step it appears
+- Console output from step 1 won't be visible in step 3's console log
+
+### Level Normalization
+
+Console message levels are normalized to 5 values:
+
+| Level | What triggers it |
+|-------|-----------------|
+| `log` | `console.log()`, `console.dir()`, `console.table()`, and other info-level calls |
+| `warning` | `console.warn()` |
+| `error` | `console.error()` and uncaught exceptions |
+| `info` | `console.info()` |
+| `debug` | `console.debug()` |
+
+## What You Can Query
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `level` | string | Message level: "log", "warning", "error", "info", "debug" |
+| `text` | string | Full message text (not truncated) |
+| `url` | string | Source file URL |
+| `line_number` | int | Source line number |
+| `is_exception` | bool | True for uncaught JS exceptions (pageerror events) |
+| `stack_trace` | string | Stack trace (exceptions only) |
+
+### Errors vs Exceptions
+
+- **`errors`** includes ALL error-level messages: both `console.error()` calls AND uncaught exceptions
+- **`exceptions`** is a subset of errors: only uncaught JavaScript exceptions
+- To check for app-level errors without exceptions: query errors where `is_exception` is false
+
+## Example Assertions
+
+```
+Assert: no console errors on the page
+Assert: no uncaught JavaScript exceptions
+Assert: console contains "Amplitude SDK triggered"
+Assert: no console warnings
+Assert: no JS errors after clicking Submit
+```
+
+## Example Extractions
+
+```
+Store all console error messages
+Extract the first console error text
+Store all console log output
+```
+
+## Example If/Else
+
+```
+If console contains "feature_flag_enabled" then use new flow, else use legacy flow
+```

--- a/docs/kane-cli-checkpoint-devtools-cookies.mdx
+++ b/docs/kane-cli-checkpoint-devtools-cookies.mdx
@@ -1,0 +1,66 @@
+---
+title: "Cookies Assertions"
+sidebarTitle: "Cookies"
+description: "Verify browser cookies (names, values, and flags such as httpOnly, secure, and sameSite) set during test execution."
+keywords: ['cookies assertion', 'session cookie', 'httponly', 'secure cookie', 'kane cli', 'devtools', 'testmu ai']
+"og:description": "Verify browser cookies (names, values, and flags such as httpOnly, secure, and sameSite) set during test execution."
+---
+
+---
+
+Cookie assertions let you verify browser cookies: check existence, values, and security attributes like httpOnly, secure, and sameSite.
+
+## How Capture Works
+
+Cookies are captured as a **point-in-time snapshot** when the checkpoint triggers:
+
+- **On-demand capture**: Cookies are read from the browser context at the moment the assertion runs, not accumulated over time
+- **Current state only**: You see exactly what cookies exist right now, including any set by the page's JavaScript or server responses
+- **All cookies visible**: Unlike `document.cookie` in JavaScript, KaneAI can see httpOnly cookies too
+- **Domain-scoped**: Cookies are captured for all domains the browser has visited in this session
+
+### Planning for Multi-Step Tests
+
+Because cookies are captured at assertion time:
+
+- If you need to check cookies set by a specific page, assert on the **same page** or **after** you've visited it
+- If cookies are needed in a later step (e.g., after navigating away), extract and store them first
+- Cookies persist in the browser across steps (unlike network/console which reset), but asserting on a different domain may show different cookies
+
+## What You Can Query
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Cookie name (e.g., "session_id") |
+| `value` | string | Cookie value |
+| `domain` | string | Domain (e.g., ".example.com") |
+| `path` | string | Cookie path (e.g., "/") |
+| `expires` | float | Expiry as epoch seconds (-1 for session cookies) |
+| `http_only` | bool | True if HttpOnly flag is set |
+| `secure` | bool | True if Secure flag is set |
+| `same_site` | string | "Strict", "Lax", or "None" |
+
+## Example Assertions
+
+```
+Assert: a cookie named "session_id" exists
+Assert: the session cookie is httpOnly
+Assert: no cookies are set without the Secure flag
+Assert: at least 3 cookies are set on the page
+Assert: the auth cookie has sameSite set to "Strict"
+```
+
+## Example Extractions
+
+```
+Store all cookies
+Extract the value of the "session_id" cookie
+Store all cookie names
+Get all cookies for the example.com domain
+```
+
+## Example If/Else
+
+```
+If a cookie named "auth_token" exists then go to dashboard, else go to login
+```

--- a/docs/kane-cli-checkpoint-devtools-localstorage.mdx
+++ b/docs/kane-cli-checkpoint-devtools-localstorage.mdx
@@ -1,0 +1,78 @@
+---
+title: "localStorage Assertions"
+sidebarTitle: "localStorage"
+description: "Verify key-value pairs stored in the browser localStorage during test execution: auth tokens, feature flags, cached data."
+keywords: ['localstorage assertion', 'browser storage', 'auth token', 'kane cli', 'devtools', 'testmu ai']
+"og:description": "Verify key-value pairs stored in the browser localStorage during test execution: auth tokens, feature flags, cached data."
+---
+
+---
+
+localStorage assertions let you verify data stored in the browser's `window.localStorage`: check key existence, values, and item counts.
+
+## How Capture Works
+
+localStorage is captured as a **point-in-time snapshot** when the checkpoint triggers:
+
+- **On-demand capture**: localStorage is read from the current page at the moment the assertion runs
+- **Current state only**: You see exactly what's in localStorage right now
+- **Domain-scoped**: localStorage is per-origin (protocol + domain + port). You only see data for the current page's origin
+- **String values**: All localStorage values are strings. If the application stores JSON objects, they're stored as JSON strings
+
+### Planning for Multi-Step Tests
+
+Because localStorage is captured at assertion time:
+
+- Assert on localStorage while you're **on the page** that set the values. Navigating to a different domain means a different localStorage
+- If values are needed later, extract and store them before navigating away
+- localStorage persists across steps (unlike network/console) as long as you stay on the same origin
+
+### JSON Values
+
+Applications often store structured data in localStorage as JSON strings:
+
+```javascript
+// Application code
+localStorage.setItem("user_prefs", JSON.stringify({theme: "dark", lang: "en"}));
+```
+
+In assertions, the value is the raw JSON string. You can parse it to check individual fields:
+
+```
+Assert: the "theme" field in the user_prefs localStorage item is "dark"
+```
+
+KaneAI will parse the JSON and drill into the value automatically.
+
+## What You Can Query
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `storage.all()` | dict | All key-value pairs |
+| `storage.get(key)` | string or None | Value for a specific key |
+| `storage.keys()` | list of strings | All key names |
+| `storage.has(key)` | bool | Whether a key exists |
+
+## Example Assertions
+
+```
+Assert: auth_token exists in localStorage
+Assert: the theme preference in localStorage is "dark"
+Assert: localStorage has fewer than 10 items
+Assert: the user_id value in localStorage is not empty
+```
+
+## Example Extractions
+
+```
+Store all localStorage items
+Extract the auth_token from localStorage
+Store the user preferences from localStorage
+Get all localStorage keys
+```
+
+## Example If/Else
+
+```
+If localStorage has "onboarding_complete" then show dashboard, else start onboarding
+```

--- a/docs/kane-cli-checkpoint-devtools-network.mdx
+++ b/docs/kane-cli-checkpoint-devtools-network.mdx
@@ -1,0 +1,73 @@
+---
+title: "Network Assertions"
+sidebarTitle: "Network"
+description: "Verify HTTP traffic (API responses, status codes, headers, response bodies, and request timing) captured by KaneAI in the background."
+keywords: ['network assertion', 'http response', 'api status code', 'kane cli', 'devtools', 'testmu ai']
+"og:description": "Verify HTTP traffic (API responses, status codes, headers, response bodies, and request timing) captured by KaneAI in the background."
+---
+
+---
+
+Network assertions let you verify HTTP traffic: API responses, status codes, headers, response bodies, and request timing.
+
+## How Capture Works
+
+KaneAI captures all HTTP network traffic automatically during each test step:
+
+- **Continuous capture**: Every HTTP request and response is recorded as it happens
+- **Per-step scope**: Each test step starts with a fresh capture. Traffic from previous steps is not carried over
+- **Limits**: Up to 5,000 requests are stored per step. When the limit is reached, the oldest 10% of entries are dropped to make room. Response bodies are capped at 64KB per entry
+- **Text bodies only**: Response bodies are captured for text-based content types (JSON, HTML, XML, CSS, JavaScript). Binary content (images, fonts, videos) is skipped
+- **Multi-tab support**: Traffic from new tabs and popups is also captured
+
+### Planning for Multi-Step Tests
+
+Because network data resets each step, plan accordingly:
+
+- If you need to assert on an API response **later**, extract and store it in the same step the request happens
+- Navigation and API calls in step 1 won't be visible in step 3's network log
+- Use extraction checkpoints to save values across steps
+
+## What You Can Query
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | string | HTTP method (GET, POST, PUT, DELETE, ...) |
+| `url` | string | Full request URL |
+| `domain` | string | Domain (e.g., "api.example.com") |
+| `path` | string | URL path without query string |
+| `query_params` | dict | Query parameters |
+| `resource_type` | string | xhr, fetch, document, script, image, ... |
+| `request_headers` | dict | Request headers |
+| `request_body` | string | Request body (may be truncated) |
+| `response_status` | int | HTTP status code (200, 404, 500, ...) |
+| `response_headers` | dict | Response headers |
+| `response_body` | string | Response body (text types only, may be truncated) |
+| `timing.duration_ms` | float | Total request duration in milliseconds |
+| `timing.ttfb_ms` | float | Time to first byte in milliseconds |
+| `failed` | bool | True if request failed at network level |
+| `failure_reason` | string | Error reason (e.g., "net::ERR_CONNECTION_REFUSED") |
+
+## Example Assertions
+
+```
+Assert: no API calls returned 5xx status codes
+Assert: the POST /api/login returned HTTP status 200
+Assert: all API responses completed in under 2 seconds
+Assert: no network requests failed with connection errors
+Assert: the /posts endpoint returned at least 10 items in the response body
+```
+
+## Example Extractions
+
+```
+Store the response body of the POST /api/login request
+Extract the status code of the last API call to /api/users
+Store all API request URLs
+```
+
+## Example If/Else
+
+```
+If the /api/auth returned 200 then proceed to dashboard, else show error message
+```

--- a/docs/kane-cli-checkpoint-devtools-performance.mdx
+++ b/docs/kane-cli-checkpoint-devtools-performance.mdx
@@ -1,0 +1,67 @@
+---
+title: "Performance Assertions"
+sidebarTitle: "Performance"
+description: "Verify Core Web Vitals and other performance metrics (LCP, CLS, INP, FCP, TTFB) captured during test execution."
+keywords: ['performance assertion', 'core web vitals', 'lcp', 'cls', 'inp', 'kane cli', 'devtools', 'testmu ai']
+"og:description": "Verify Core Web Vitals and other performance metrics (LCP, CLS, INP, FCP, TTFB) captured during test execution."
+---
+
+---
+
+Performance assertions let you verify [Core Web Vitals](https://web.dev/articles/vitals) and other key performance metrics for the current page.
+
+## How Capture Works
+
+Performance data is **navigation-based**. Metrics are measured for the most recent page navigation:
+
+- **Automatic measurement**: KaneAI uses the [web-vitals](https://github.com/GoogleChrome/web-vitals) library to capture metrics
+- **Per-navigation scope**: Metrics reflect the last full page load. If you navigate to a new page, the metrics reset for that navigation
+- **Point-in-time snapshot**: When a performance checkpoint triggers, KaneAI captures the current metrics at that moment
+
+### What This Means for Your Tests
+
+- Performance metrics describe the **last navigation**. If you navigate to Page A then Page B, the metrics reflect Page B
+- Place performance assertions **after** the page you want to measure has fully loaded
+- Use a wait step if the page needs time to settle before measuring
+
+## Available Metrics
+
+| Metric | What It Measures | Good Threshold | Learn More |
+|--------|-----------------|----------------|------------|
+| **LCP** | Largest Contentful Paint: when the largest visible element finishes rendering | < 2,500ms | [web.dev/lcp](https://web.dev/articles/lcp) |
+| **CLS** | Cumulative Layout Shift: visual stability, how much the page layout shifts | < 0.1 | [web.dev/cls](https://web.dev/articles/cls) |
+| **INP** | Interaction to Next Paint: responsiveness to user input | < 200ms | [web.dev/inp](https://web.dev/articles/inp) |
+| **FCP** | First Contentful Paint: when the first content appears on screen | < 1,800ms | [web.dev/fcp](https://web.dev/articles/fcp) |
+| **TTFB** | Time to First Byte: server response time | < 800ms | [web.dev/ttfb](https://web.dev/articles/ttfb) |
+
+> **Note**: Not all metrics are available for every page. INP requires user interaction to trigger. Some metrics may be `null` if the browser hasn't measured them yet.
+
+## Example Assertions
+
+```
+Assert: page LCP is under 2500ms
+Assert: CLS is below 0.1
+Assert: TTFB is under 800ms
+Assert: FCP is less than 1800ms
+Assert: page performance meets Core Web Vitals thresholds
+```
+
+## Example Extractions
+
+```
+Store the page LCP value
+Extract all web vitals metrics
+Store the TTFB for this page
+```
+
+## Example If/Else
+
+```
+If LCP is under 2500ms then continue, else report performance issue
+```
+
+## Tips
+
+- **Wait for load**: Place a wait step before performance assertions to ensure the page has fully loaded and metrics are available
+- **Navigate first**: Metrics are per-navigation. Make sure you've navigated to the target page before asserting
+- **Not all metrics are instant**: CLS accumulates over time, INP requires interaction. LCP and FCP are typically available after the page visually completes loading

--- a/docs/kane-cli-checkpoint-devtools.mdx
+++ b/docs/kane-cli-checkpoint-devtools.mdx
@@ -1,0 +1,57 @@
+---
+title: "DevTools Assertions"
+sidebarTitle: "Overview"
+description: "Verify data that is not visible on the page: HTTP network traffic, console output, performance metrics, cookies, localStorage, and clipboard."
+keywords: ['devtools assertion', 'network', 'console', 'performance', 'cookies', 'localstorage', 'kane cli', 'testmu ai']
+"og:description": "Verify data that is not visible on the page: HTTP network traffic, console output, performance metrics, cookies, localStorage, and clipboard."
+---
+
+---
+
+DevTools assertions let you verify data that isn't visible on the page: HTTP network traffic, browser console output, performance metrics, cookies, localStorage, and clipboard. KaneAI captures this data automatically in the background; you just write what to check.
+
+## Available Domains
+
+| Domain | What It Captures | Documentation |
+|--------|-----------------|---------------|
+| [Network](/docs/kane-cli-checkpoint-devtools-network/) | HTTP requests and responses | Status codes, headers, response bodies, timing |
+| [Console](/docs/kane-cli-checkpoint-devtools-console/) | Browser console messages | Errors, warnings, log messages, JS exceptions |
+| [Performance](/docs/kane-cli-checkpoint-devtools-performance/) | Core Web Vitals | LCP, CLS, INP, FCP, TTFB |
+| [Cookies](/docs/kane-cli-checkpoint-devtools-cookies/) | Browser cookies | Names, values, flags (httpOnly, secure, sameSite) |
+| [localStorage](/docs/kane-cli-checkpoint-devtools-localstorage/) | Browser localStorage | Key-value pairs stored in the browser |
+| [Clipboard](/docs/kane-cli-checkpoint-devtools-clipboard/) | Browser clipboard | Copied text, HTML, image, and formats present |
+
+## How It Works
+
+Each DevTools domain follows the same pattern:
+
+1. **Capture**: KaneAI captures the data automatically during your test run
+2. **Generate**: When a checkpoint triggers, the AI generates code to query the captured data
+3. **Execute**: The code runs in an isolated sandbox and returns a result
+4. **Assert**: The result is compared against your expected value
+
+You don't write code. You write natural language objectives, and KaneAI handles the rest.
+
+## Examples
+
+```
+Assert: no API calls returned 5xx
+Assert: no console errors on the page
+Assert: page LCP is under 2500ms
+Assert: session cookie exists and is httpOnly
+Assert: auth_token is stored in localStorage
+```
+
+## All Checkpoint Types Work
+
+DevTools assertions support all three checkpoint types:
+
+- **Assert**: "Assert: no console errors", fails the test if there are errors
+- **Extract**: "Store all cookies", saves the data for later steps
+- **If/Else**: "If the API returned 200 then proceed, else retry", branch on the result
+
+## Important Notes
+
+- DevTools data is **not visible in a screenshot**. KaneAI will never try to open the browser DevTools panel
+- Each domain captures data differently. See individual pages for details on timing and scope
+- All assertions run in an isolated sandbox. Generated code cannot access the file system or network

--- a/docs/kane-cli-checkpoint-textual.mdx
+++ b/docs/kane-cli-checkpoint-textual.mdx
@@ -1,0 +1,51 @@
+---
+title: "Textual (DOM) Assertions"
+sidebarTitle: "Textual (DOM)"
+description: "Extract data from the DOM (element states, attributes, and computed styles) and assert on values that may not be visible in a screenshot."
+keywords: ['dom assertion', 'textual assertion', 'element state', 'kane cli', 'testmu ai']
+"og:description": "Extract data from the DOM (element states, attributes, and computed styles) and assert on values that may not be visible in a screenshot."
+---
+
+---
+
+Textual assertions extract data from the page's DOM: element states, attributes, and computed styles that aren't always visible in a screenshot.
+
+## When It's Used
+
+- Element states: disabled, enabled, checked, readonly, expanded
+- CSS properties with exact values: `font-size: 16px`, `opacity: 0.5`, `display: none`
+- HTML attributes: `placeholder`, `aria-*`, `data-*`, `class`, `id`, `href`, `src`, `type`, `value`
+- Attribute existence: "has placeholder", "has aria-label"
+- Exact CSS color values: `rgb(255,0,0)`, `#ff0000`
+
+## Examples
+
+### Assertions
+
+```
+Assert: the submit button is disabled
+Assert: the checkbox is checked
+Assert: the input field has placeholder "Enter email"
+Assert: the element has aria-label "Close dialog"
+Assert: the font-size of the heading is 24px
+```
+
+### Extractions
+
+```
+Extract the href of the first link
+Store the value attribute of the email input
+Get the class of the error message element
+```
+
+## When NOT to Use
+
+- For visible text content (prices, labels) → use [Visual](/docs/kane-cli-checkpoint-visual/)
+- For color names like "red background" → use [Visual](/docs/kane-cli-checkpoint-visual/) (DOM may return `transparent` or inherited values)
+- For network/console/cookie data → use [DevTools](/docs/kane-cli-checkpoint-devtools/)
+
+## How It Works
+
+1. KaneAI captures the DOM snapshot of the page
+2. The AI model identifies the target element and extracts the requested property
+3. The value is compared against the expected value

--- a/docs/kane-cli-checkpoint-title.mdx
+++ b/docs/kane-cli-checkpoint-title.mdx
@@ -1,0 +1,37 @@
+---
+title: "Title Assertions"
+sidebarTitle: "Title"
+description: "Verify the browser tab document.title, useful for confirming navigation reached the expected page."
+keywords: ['page title assertion', 'document.title', 'kane cli', 'testmu ai']
+"og:description": "Verify the browser tab document.title, useful for confirming navigation reached the expected page."
+---
+
+---
+
+Title assertions check the browser tab's document title (`document.title`).
+
+## When It's Used
+
+- Page title verification: "title contains Dashboard"
+- Navigation confirmation: "title is Home Page"
+
+## Examples
+
+### Assertions
+
+```
+Assert: page title contains "Dashboard"
+Assert: title is "My Account - Settings"
+```
+
+### Extractions
+
+```
+Store the page title
+```
+
+## How It Works
+
+1. KaneAI reads `page.title()` directly
+2. The title string is compared against the expected value
+3. No screenshot or DOM analysis needed, this is a direct read

--- a/docs/kane-cli-checkpoint-url.mdx
+++ b/docs/kane-cli-checkpoint-url.mdx
@@ -1,0 +1,47 @@
+---
+title: "URL Assertions"
+sidebarTitle: "URL"
+description: "Check values in the browser address bar: current URL path, query parameters, fragments, and redirect targets."
+keywords: ['url assertion', 'query parameter assertion', 'kane cli', 'testmu ai']
+"og:description": "Check values in the browser address bar: current URL path, query parameters, fragments, and redirect targets."
+---
+
+---
+
+URL assertions check values in the browser's address bar: the current URL path, query parameters, fragments, and redirect targets.
+
+## When It's Used
+
+- URL path: "URL contains /checkout"
+- Query parameters: "URL has param `sort=price`"
+- Redirect verification: "redirected to /login"
+- Fragment/hash: "URL hash is #section-2"
+
+## Examples
+
+### Assertions
+
+```
+Assert: URL contains /checkout
+Assert: the page redirected to /dashboard
+Assert: URL path is /products/42
+```
+
+### Extractions
+
+```
+Store the current URL
+Extract the URL path
+```
+
+### If/Else
+
+```
+If URL contains /login then enter credentials, else go to profile
+```
+
+## How It Works
+
+1. KaneAI reads the current `page.url` value directly
+2. The URL string is compared against the expected value using the specified operator
+3. No screenshot or DOM analysis needed, this is a direct read

--- a/docs/kane-cli-checkpoint-visual.mdx
+++ b/docs/kane-cli-checkpoint-visual.mdx
@@ -1,0 +1,56 @@
+---
+title: "Visual Assertions"
+sidebarTitle: "Visual"
+description: "Verify what is visible on the screen by analyzing the current screenshot. Visual is the default analyze method KaneAI uses for assertions."
+keywords: ['visual assertion', 'screenshot assertion', 'kane cli', 'kaneai', 'testmu ai']
+"og:description": "Verify what is visible on the screen by analyzing the current screenshot. Visual is the default analyze method KaneAI uses for assertions."
+---
+
+---
+
+Visual assertions verify what's visible on screen by analyzing the current screenshot. This is the default method, when in doubt, KaneAI uses visual analysis.
+
+## When It's Used
+
+- Text content: prices, labels, headings, counts, messages
+- Visibility: "is the login button visible", "are search results displayed"
+- Color checks using color names: "has red background", "blue text"
+- Any content that appears visually on the page
+
+## Examples
+
+### Assertions
+
+```
+Assert: the product price is $29.99
+Assert: the search results show at least 5 items
+Assert: the error message is visible
+Assert: the hero section displays "Welcome back"
+```
+
+### Extractions
+
+```
+Store the product price
+Extract the heading text
+Get the number of items in the cart
+```
+
+### If/Else
+
+```
+If the login button is visible then click it, else click Sign Up
+```
+
+## How It Works
+
+1. KaneAI takes a screenshot of the current page
+2. The AI model analyzes the screenshot to find the requested information
+3. The extracted value is compared against the expected value using the specified operator
+
+## Best Practices
+
+- Use visual assertions for any text or content you can see on screen
+- Be specific about what to look for: "the price in the cart summary" not just "the price"
+- For exact CSS values (like `rgb(255,0,0)` or `#ff0000`), use [Textual (DOM)](/docs/kane-cli-checkpoint-textual/) instead
+- For element states (disabled, checked), use [Textual (DOM)](/docs/kane-cli-checkpoint-textual/) instead

--- a/docs/kane-cli-checkpoints.mdx
+++ b/docs/kane-cli-checkpoints.mdx
@@ -1,0 +1,80 @@
+---
+title: "Checkpoints"
+sidebarTitle: "Overview"
+description: "Checkpoints are verification points KaneAI evaluates during test execution: assert conditions, branch on results, or extract values for later use."
+keywords: ['kane cli checkpoints', 'assertions', 'extractions', 'testmu ai', 'kaneai', 'browser automation']
+"og:description": "Checkpoints are verification points KaneAI evaluates during test execution: assert conditions, branch on results, or extract values for later use."
+---
+
+---
+
+Checkpoints are verification points that KaneAI evaluates during test execution. They let you assert conditions, branch on results, or extract values for later use.
+
+## Checkpoint Types
+
+| Type | What it does |
+|------|-------------|
+| **Assertion** | Verify a condition is true, fails the test if not |
+| **If/Else** | Branch execution based on a condition |
+| **Extraction** | Store a value for use in later steps |
+
+All three types work with every analyze method below.
+
+## Analyze Methods
+
+Each checkpoint uses an analyze method to determine *where* to look for the data:
+
+| Method | Data Source | When to Use |
+|--------|-----------|-------------|
+| [Visual](/docs/kane-cli-checkpoint-visual/) | Screenshot (what you see on screen) | Text, labels, prices, counts, colors, visibility checks |
+| [Textual (DOM)](/docs/kane-cli-checkpoint-textual/) | Page DOM elements | Element states (disabled, checked), CSS properties, HTML attributes |
+| [URL](/docs/kane-cli-checkpoint-url/) | Browser URL bar | URL path, query params, redirects |
+| [Title](/docs/kane-cli-checkpoint-title/) | Page title | Document title verification |
+| [DevTools](/docs/kane-cli-checkpoint-devtools/) | Browser internals | Network traffic, console logs, performance, cookies, localStorage, clipboard |
+
+## How to Use
+
+Write your assertions naturally in the objective. KaneAI automatically picks the right analyze method:
+
+```
+Assert: the price is $29.99                    → Visual
+Assert: the submit button is disabled          → Textual (DOM)
+Assert: URL contains /checkout                 → URL
+Assert: page title contains "Dashboard"        → Title
+Assert: no API calls returned 5xx              → DevTools (Network)
+Assert: no console errors                      → DevTools (Console)
+Assert: page LCP is under 2500ms               → DevTools (Performance)
+Assert: session cookie exists                  → DevTools (Cookies)
+Assert: auth_token exists in localStorage      → DevTools (localStorage)
+Assert: the clipboard has the copied link      → DevTools (Clipboard)
+```
+
+Extractions work the same way:
+
+```
+Store the product price                        → Visual
+Store the current URL                          → URL
+Store all cookies                              → DevTools (Cookies)
+Store the API response body                    → DevTools (Network)
+```
+
+## Operators
+
+Assertions support these comparison operators:
+
+| Operator | Meaning | Example |
+|----------|---------|---------|
+| `equals` | Exact match | price equals "29.99" |
+| `contains` | Substring match | URL contains "/checkout" |
+| `not_contains` | Does not contain | title not contains "Error" |
+| `gt` / `gte` | Greater than / or equal | items greater than 5 |
+| `lt` / `lte` | Less than / or equal | LCP less than 2500 |
+| `not_equals` | Not equal | status not equals "failed" |
+
+## Learn More
+
+- [Visual Assertions](/docs/kane-cli-checkpoint-visual/): screenshot-based text and visibility checks
+- [Textual (DOM) Assertions](/docs/kane-cli-checkpoint-textual/): element states and attributes
+- [URL Assertions](/docs/kane-cli-checkpoint-url/): URL-based checks
+- [Title Assertions](/docs/kane-cli-checkpoint-title/): page title checks
+- [DevTools Assertions](/docs/kane-cli-checkpoint-devtools/): network, console, performance, cookies, localStorage, clipboard

--- a/docs/kane-cli-configuration.mdx
+++ b/docs/kane-cli-configuration.mdx
@@ -57,7 +57,7 @@ Empty fields are shown as `(none)`. The `chrome` path is empty by default, in wh
 | `window_size.width` | integer | `1920` | Chrome window width in pixels (800–3840) | `kane-cli config set-window <WxH>` |
 | `window_size.height` | integer | `1080` | Chrome window height in pixels (600–2160) | `kane-cli config set-window <WxH>` |
 | `chrome_profile_path` | string | `""` | Path to a Chrome user-data dir. Empty means a fresh profile per run. | `kane-cli config chrome-profile [path]` |
-| `default_url` | string \| null | `https://kaneai-playground.lambdatest.io` | Starting URL when a run begins. | Internal default |
+| `default_url` | string \| null | `https://kaneai-playground.lambdatest.io` | Starting URL when a run begins. | `kane-cli config set-url <url>` |
 | `model` | string | `"v16-alpha"` | Reasoning + vision model used by the agent. | Internal default |
 | `project_id` | string \| null | `null` | <BrandName /> Test Manager project ID for upload | `kane-cli config project [id]` |
 | `project_name` | string \| null | `null` | Display name of the selected project | Set by `kane-cli config project` |

--- a/docs/kane-cli-error-codes.mdx
+++ b/docs/kane-cli-error-codes.mdx
@@ -261,7 +261,7 @@ An external obstacle on the target website prevented the agent from completing t
 ```bash
 kane-cli run "Log in and navigate to dashboard" \
   --url https://myapp.com/login \
-  --variables '{"username": {"value": "test@example.com"}, "password": {"value": "s3cret", "sensitive": true}}' \
+  --variables '{"username": {"value": "test@example.com"}, "password": {"value": "s3cret", "secret": true}}' \
   --agent
 ```
 

--- a/docs/kane-cli-generate-workflow.mdx
+++ b/docs/kane-cli-generate-workflow.mdx
@@ -1,0 +1,136 @@
+---
+title: "The Generate Workflow"
+sidebarTitle: "Workflow"
+description: "Walk the kane-cli generate loop end to end: generate, refine in plain language, save functional cases as _test.md files, and run them with testmd. Includes worked examples, agent/CI automation, and exit codes."
+keywords: ['kane cli generate workflow', 'kane cli test case generation', 'generate refine save run', 'kane cli ai test cases', 'kaneai', 'testmu ai', 'browser test automation']
+"og:description": "Walk the kane-cli generate loop end to end: generate, refine in plain language, save functional cases as _test.md files, and run them with testmd. Includes worked examples, agent/CI automation, and exit codes."
+---
+
+---
+
+`kane-cli generate` is built around a simple loop: **generate → refine → save → run**. Each command is one turn that exits when done; you move between turns with the request id. This page walks the loop end to end. For the feature overview and option reference, see [Generating test cases with AI](/docs/kane-cli-generate/).
+
+## 1. Generate
+
+Start with a plain-language description of what you want covered:
+
+```bash
+kane-cli generate "checkout flow on a shopping site"
+```
+
+kane-cli generates scenarios and cases and prints the result, ending with a **request id** and the exact commands to refine or save it:
+
+```
+✓ Generated 3 scenarios · 11 cases  (request 23271)
+
+▸ Login
+   - Valid credentials [Positive]
+   - Wrong password [Negative]
+   - Empty fields [Edge]
+▸ Checkout
+   - Guest checkout [Positive]
+   - Expired card [Negative]
+   ...
+
+  Refine:  kane-cli generate "<refinement>" --refine --req 23271
+  Save:    kane-cli generate --save --req 23271
+```
+
+Keep the request id, every later command uses it.
+
+Bound the size with limits when you want a tighter or broader set:
+
+```bash
+kane-cli generate "checkout flow on a shopping site" --scenario-limit 4 --per-scenario-limit 6
+```
+
+Add `--memory` to reuse relevant existing cases and avoid duplicating coverage you already have.
+
+## 2. Refine
+
+Refinement is a plain-language conversation. Each refine is a fresh command with `--refine --req <id>`:
+
+```bash
+kane-cli generate "also cover an expired card and an out-of-stock item" --refine --req 23271
+kane-cli generate "drop the social-login scenario, focus on guest checkout" --refine --req 23271
+```
+
+Each refine returns the updated result. Repeat until the set looks right.
+
+### When generation asks a question
+
+Sometimes a turn ends by asking you something instead of finishing, for example, *"Which environment should these target, staging or production?"* This is a normal outcome, not a failure (the command exits `0`). Answer it by refining with your answer:
+
+```bash
+kane-cli generate "target staging" --refine --req 23271
+```
+
+(Driving this from a script or agent? Add `--agent` (or rely on it being auto-on when stdin is not a TTY) and read the answer-needed signal from the NDJSON, then re-invoke the same way.)
+
+## 3. Save
+
+When you are happy with the set, save it. `--save` writes the **functional** cases as `_test.md` files:
+
+```bash
+kane-cli generate --save --req 23271
+```
+
+By default this writes under `<cwd>/.testmuai/tests`:
+
+```
+.testmuai/tests/
+  checkout-23271/
+    login/
+      valid-credentials_test.md
+      wrong-password_test.md
+    checkout/
+      guest-checkout_test.md
+      ...
+```
+
+Choose a different location with `--out`, and name the suite with `--name`:
+
+```bash
+kane-cli generate --save --req 23271 --out ./tests --name checkout-suite
+```
+
+Only functional cases are written: non-functional cases (Security, Performance, …) are part of the generated result but are not saved as runnable tests. See [Saving is functional-only](/docs/kane-cli-generate/#saving-is-functional-only).
+
+## 4. Run
+
+The saved files are ordinary `_test.md` tests. Run any of them with `testmd`:
+
+```bash
+kane-cli testmd run .testmuai/tests/checkout-23271/checkout/guest-checkout_test.md
+```
+
+From here, everything in the [testmd docs](/docs/kane-cli-testmd/) applies: replay from cache, edit steps, compose with `@import`, and commit the output to git.
+
+## Automating it (agents / CI)
+
+Pass `--agent` (auto-on when stdin is not a TTY) to get structured NDJSON on stdout instead of the human display, so a script or coding agent can drive the loop:
+
+```bash
+kane-cli generate "checkout flow on a shopping site" --agent
+kane-cli generate "add an expired-card case" --refine --req 23271 --agent
+kane-cli generate --save --req 23271 --agent
+```
+
+Each command prints one JSON object per line; the final line is the terminal event carrying the request id, the status, and the refine/save commands to run next.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Turn completed, including a turn that ended with a clarification question |
+| `1` | Generation failed |
+| `2` | Error: authentication / setup / transport, or an invalid combination of flags |
+| `3` | Generation stopped or cancelled |
+| `130` | Interrupted (Ctrl-C) |
+
+Invalid flag combinations exit `2` with a message explaining the fix, for example using `--refine` without `--req`, passing a description with `--save`, using `--out` without `--save`, or `--req` without `--refine` or `--save`.
+
+## Next steps
+
+- [Generating test cases with AI](/docs/kane-cli-generate/): overview, modes, and the full option reference.
+- [Running tests with testmd](/docs/kane-cli-testmd/): run and replay the files `--save` produces.

--- a/docs/kane-cli-generate.mdx
+++ b/docs/kane-cli-generate.mdx
@@ -1,0 +1,135 @@
+---
+title: "Generating Test Cases with AI"
+sidebarTitle: "Overview"
+description: "Turn a plain-language description of what you want to test into structured test scenarios and test cases with kane-cli generate: refine in plain language, then save the functional cases as runnable _test.md files."
+keywords: ['kane cli generate', 'kane cli test case generation', 'kane cli ai test cases', 'generate test cases', 'kaneai', 'testmu ai', 'browser test automation']
+"og:description": "Turn a plain-language description of what you want to test into structured test scenarios and test cases with kane-cli generate: refine in plain language, then save the functional cases as runnable _test.md files."
+---
+
+---
+
+`kane-cli generate` turns a plain-language description of *what you want to test* into structured **test scenarios** and **test cases**, without writing them by hand and without launching a browser. This page covers AI test-case generation from both the command line and the interactive kane-cli TUI.
+
+A generation produces:
+
+- **Test Scenarios**: logical groupings of related checks (e.g. "Login", "Checkout").
+- **Test Cases**: the individual checks inside each scenario, each typed **Positive**, **Negative**, or **Edge**.
+
+You generate, review the result, **refine** it in plain language as many times as you like, and optionally **save** the functional cases as runnable `_test.md` files that [`kane-cli testmd`](/docs/kane-cli-testmd/) can execute and replay.
+
+<Note>
+For the full picture of AI test-case generation, including richer inputs (files, PDFs, issue links) and pushing cases into Test Manager or automation, see the [AI test-case generation guide](/docs/generate-test-cases-with-ai/). The **CLI here takes a text description** (optionally with local files attached via [`--files`](#attaching-files-for-context)) and writes local `_test.md` files. See [Limits and scope](#limits-and-scope).
+</Note>
+
+## Quick start
+
+```bash
+# 1. Generate from a description
+kane-cli generate "checkout flow on a shopping site"
+
+# 2. Refine it (repeat as needed)
+kane-cli generate "also cover an expired card and an out-of-stock item" --refine --req 23271
+
+# 3. Save the functional cases as runnable tests
+kane-cli generate --save --req 23271
+#    → .testmuai/tests/<suite>/<scenario>/<case>_test.md
+
+# 4. Run them
+kane-cli testmd run .testmuai/tests/checkout-23271/login/valid-credentials_test.md
+```
+
+The request id (`23271` above) is printed at the end of each generation and is how you continue a request across commands.
+
+## The three modes
+
+`generate` runs **one turn per command, then exits**. You continue a request by running the command again with `--req <id>`. (That's the scripted/headless surface; run interactively, kane-cli opens a live TUI session instead, see [Interactive mode (TUI)](#interactive-mode-tui).)
+
+| Mode | Command | What it does |
+|---|---|---|
+| **New** | `kane-cli generate "<what to test>"` | Starts a fresh request and generates scenarios + cases. Prints a request id. |
+| **Refine** | `kane-cli generate "<change>" --refine --req <id>` | Adjusts an existing request in plain language: add coverage, narrow scope, change focus. |
+| **Save** | `kane-cli generate --save --req <id> [--out <dir>]` | Writes the request's **functional** cases to `_test.md` files. No new generation. |
+
+`--refine` and `--save` both require `--req`. `--refine` needs a change description; `--save` takes no description.
+
+## Options
+
+| Option | Purpose |
+|---|---|
+| `--req <id>` | The request id to refine or save. |
+| `--out <dir>` | Where `--save` writes. Defaults to `<cwd>/.testmuai/tests` (the same location the TUI uses). |
+| `--name <name>` | Names the run and the saved suite folder. |
+| `--scenario-limit <n>` | Maximum number of scenarios to generate. |
+| `--per-scenario-limit <n>` | Maximum test cases per scenario. |
+| `--memory` | Use the **memory layer**: reuse relevant existing test cases and reduce duplicates. |
+| `--files <paths>` | Comma-separated local files to attach as context (new generations and refines only). See [Attaching files for context](#attaching-files-for-context). |
+| `--project <id>` / `--folder <id>` | Test Manager project / folder. |
+| `--agent` | Emit structured NDJSON on stdout (auto-on when run non-interactively / piped). |
+| `--env`, `--username`, `--access-key` | Environment and authentication, same as [`kane-cli run`](/docs/kane-cli-quickstart/). See [Authentication](/docs/kane-cli-authentication/). |
+
+## Attaching files for context
+
+Give the generator more to work from by attaching local files with `--files` (a comma-separated list of paths) on a **new** generation or a **refine**:
+
+```bash
+kane-cli generate "test the login flow described in the attached spec" --files ./login-spec.pdf,./wireframe.png
+```
+
+The files are sent along with your description and reflected in the generated scenarios and cases: attach a spec, a screenshot of the UI, a PDF or Word document, or a CSV of inputs.
+
+- **Supported types**: documents (`.txt`, `.json`, `.xml`, `.csv`, `.pdf`, `.docx`, `.xlsx`), images (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.webp`), audio (`.mp3`, `.wav`, `.m4a`), and video (`.mp4`, `.mov`, `.webm`, `.mpeg`, `.mpga`).
+- **Limits**: up to **10 files**, each **50 MB** or smaller.
+- **Checked before anything is sent**: all paths are validated as a set. If any is missing, an unsupported type, too large, or over the count, the command stops and lists the offending paths so nothing is uploaded by mistake. Files outside the current directory are allowed but flagged with a warning.
+- **Not with `--save`**: files attach to a generation or refine, not a save (`--files` with `--save` is rejected).
+
+In the interactive TUI, type `@` in the generate prompt to attach a file inline instead of passing `--files`.
+
+## Interactive mode (TUI)
+
+The commands above are the scripted surface. The kane-cli TUI **launches in Run mode** (for running tests) by default. Switch to **Generate mode** with **`/generate`**, and back with `/run`. Or jump straight in: running `kane-cli generate "<objective>"` in a terminal (without `--agent`) opens the TUI directly in Generate mode and submits your objective.
+
+Unlike the one-turn command-line surface, the TUI is a **live session**: generated scenarios stay pinned in a **Scenarios** box that you refine and browse in place:
+
+| Input | Action |
+|---|---|
+| *(type any text)* | **Refine**: describe a change in plain language; the set updates in place |
+| `@<file>` | **Attach a file**: type `@` to pick a local file to add as context (same files as `--files`) |
+| `/view [S<n>]` | Open the **scenario browser**: drill scenarios → cases → case detail |
+| `/save` | Save the functional cases to `<cwd>/.testmuai/tests/…` |
+| `/cancel` | Cancel the current generation |
+| `/run` | Switch back to Run mode |
+
+In the scenario browser: `↑↓` move · `↵` open · `◂ ▸` previous/next sibling · `x` remove a case · `←`/`esc` back. **Non-functional cases** (Security, Performance, …) show a **gray `✓`** with a "won't be saved" note. `/save` writes only functional cases (see [Saving is functional-only](#saving-is-functional-only)).
+
+If generation asks a **clarifying question**, just type your answer to continue. After `/save`, the files are ordinary `_test.md` tests under `.testmuai/tests/`, run them with [`kane-cli testmd run`](/docs/kane-cli-testmd/).
+
+## How a result is shaped
+
+Each generated case carries:
+
+- a **title** and **steps**,
+- a **type**: Positive (expected to pass), Negative (tests failure handling), or Edge (corner cases),
+- a **category**: e.g. *Functional*, *Security*, *Performance*,
+- a **priority**.
+
+Scenarios are ordered by importance. The full result is returned at the end of the turn so it can be reviewed before you refine or save.
+
+## Saving is functional-only
+
+`--save` writes **only test cases whose category is *Functional***: those are the ones that translate into runnable `_test.md` tests. Non-functional cases (Security, Performance, and so on) are still generated and shown, but they are **not** written to disk. If a request has no functional cases, `--save` writes nothing and tells you so.
+
+Saved files are ordinary `_test.md` tests in the standard format, identical to a hand-written one. From there everything in [the testmd docs](/docs/kane-cli-testmd/) applies: run them, edit them, replay them from cache, commit them to git.
+
+This is the intended path: **generate authors test cases → testmd runs them.**
+
+## Limits and scope
+
+- **Input is a text description, optionally with attached files.** Attach local files with `--files` (a spec, screenshot, PDF, or CSV) to give the generator more context. Issue-link inputs and the web product's "Create / Create and Automate" are not part of the CLI.
+- **Refinement is whole-request.** You refine the request as a whole in plain language; targeting an individual scenario or case from the CLI is not yet supported.
+- **Scenario and per-scenario counts** are bounded by `--scenario-limit` / `--per-scenario-limit`.
+
+## Next steps
+
+- [The generate workflow](/docs/kane-cli-generate-workflow/): the new → refine → save → run loop, worked examples, and exit codes.
+- [Running tests with testmd](/docs/kane-cli-testmd/): run and replay the `_test.md` files `--save` produces.
+- [Authentication](/docs/kane-cli-authentication/): logging in and choosing an environment.

--- a/docs/kane-cli-installation.mdx
+++ b/docs/kane-cli-installation.mdx
@@ -1,16 +1,21 @@
 ---
 title: "Installing Kane CLI"
 sidebarTitle: "Installation"
-description: "Install Kane CLI using npm. Supports macOS (Apple Silicon and Intel), Linux (x64), and Windows (x64)."
+description: "Install Kane CLI using npm or Homebrew. Supports macOS (Apple Silicon and Intel), Linux (x64 and arm64), and Windows (x64)."
 keywords: ['kane cli', 'install kane cli', 'kaneai', 'testmu ai', 'npm install']
-"og:description": "Install Kane CLI using npm. Supports macOS (Apple Silicon and Intel), Linux (x64), and Windows (x64)."
+"og:description": "Install Kane CLI using npm or Homebrew. Supports macOS (Apple Silicon and Intel), Linux (x64 and arm64), and Windows (x64)."
 ---
 
 ---
 
-Kane CLI is published to the public npm registry as `@testmuai/kane-cli`. Install it globally with `npm` to get the `kane-cli` command on your `PATH`.
+Kane CLI is published to the public npm registry as `@testmuai/kane-cli` and to a Homebrew tap. Install it with `npm` or `brew` to get the `kane-cli` command on your `PATH`.
 
 ## Install
+
+<Tabs>
+  <Tab title="npm">
+
+Requires Node.js 18 or higher.
 
 ```bash
 npm install -g @testmuai/kane-cli
@@ -18,8 +23,23 @@ npm install -g @testmuai/kane-cli
 
 Platform-specific native binaries are installed automatically for your OS. No additional configuration is needed.
 
+  </Tab>
+
+  <Tab title="Homebrew">
+
+For macOS and Linux. Node.js is not required.
+
+```bash
+brew install LambdaTest/kane/kane-cli
+```
+
+Homebrew also installs Google Chrome automatically through the `google-chrome` cask, so no additional setup is needed.
+
+  </Tab>
+</Tabs>
+
 <Note>
-Kane CLI requires **Node.js 18 or higher** and **Google Chrome** installed on your system. Chrome is used as the automation browser and is launched automatically when you run a test.
+Kane CLI requires **Google Chrome** installed on your system. Chrome is used as the automation browser and is launched automatically when you run a test. The npm install additionally requires **Node.js 18 or higher**. The Homebrew install bundles Chrome for you and needs no Node.js.
 </Note>
 
 ## Verify

--- a/docs/kane-cli-modes.mdx
+++ b/docs/kane-cli-modes.mdx
@@ -61,7 +61,7 @@ Typing `/` in chat mode opens an autocomplete palette. Continue typing to filter
 | `/whoami` | `[--profile name]` | Show profile info |
 | `/balance` | | Show credit balance |
 | `/profiles` | `list\|switch\|delete` | Manage profiles |
-| `/config` | `show\|set-window\|set-mode\|chrome-profile\|project\|folder` | Manage configuration |
+| `/config` | `show\|set-window\|set-url\|set-mode\|chrome-profile\|project\|folder` | Manage configuration |
 | `/new` | | Start a fresh session (uploads the current session first) |
 | `/summary` | `[index]` | View detailed run summaries |
 | `/cancel` | | Abort the current run |
@@ -166,7 +166,7 @@ When stdin is not a TTY, Kane CLI automatically switches to plain NDJSON mode (t
 | Exit Code | Meaning |
 |-----------|---------|
 | `0` | Test passed |
-| `1` | Test failed (assertion not met) |
+| `1` | Test failed (agent reached an unrecoverable failure, or the upload failed) |
 | `2` | Error (auth failure, Chrome crash) |
 | `3` | Timeout or cancelled |
 

--- a/docs/kane-cli-skills.mdx
+++ b/docs/kane-cli-skills.mdx
@@ -190,4 +190,4 @@ When you ask your AI agent to test something on the web, the skill:
 | Codex CLI | `~/.codex/AGENTS.md` (appended section) | `AGENTS.md` (appended section) |
 | Gemini CLI | `~/.gemini/skills/kane-cli/SKILL.md` | `.gemini/skills/kane-cli/SKILL.md` |
 
-Source files: [github.com/LambdaTest/kane-cli/tree/main/skills](https://github.com/LambdaTest/kane-cli/tree/main/skills)
+Source files: [github.com/LambdaTest/kane-cli/tree/main/skill-installer/skills](https://github.com/LambdaTest/kane-cli/tree/main/skill-installer/skills)

--- a/docs/kane-cli-testmd.mdx
+++ b/docs/kane-cli-testmd.mdx
@@ -1,0 +1,347 @@
+---
+title: "Test.md"
+sidebarTitle: "Test.md"
+description: "Write browser tests as Markdown files that replay from cache after the first run: no LLM cost, faster execution. Commit tests to git, share recordings, and run in CI."
+keywords: ['kane cli testmd', 'kane cli replayable tests', 'kane cli test files', 'kaneai', 'testmu ai', 'markdown tests', 'browser test automation']
+"og:description": "Write browser tests as Markdown files that replay from cache after the first run: no LLM cost, faster execution. Commit tests to git, share recordings, and run in CI."
+---
+
+---
+
+`testmd` lets you write browser tests as Markdown files (`_test.md`) and commit them to your repo. On the first run, the AI agent authors each step and saves a recording. On every subsequent run, each step **replays from cache** with no LLM cost and much faster execution. Commit the test file and its recordings to git so teammates and CI can re-run the same tests without re-authoring.
+
+## Quick Start
+
+**Step 1:** Create a test file. The filename must end in `_test.md`:
+
+```markdown
+---
+mode: testing
+---
+
+# Amazon search
+
+## Open Amazon
+Open https://www.amazon.com.
+
+## Search for headphones
+Type "wireless headphones" into the search box and submit.
+Verify at least one product result is visible.
+```
+
+**Step 2:** Run the test:
+
+```bash
+kane-cli testmd run amazon_test.md --agent
+```
+
+On the first run, the agent authors each step and caches the recording. On every later run, the steps replay from cache instantly.
+
+<Tip>
+Always combine `--agent` with `--headless` in CI/CD environments to avoid display server errors.
+</Tip>
+
+---
+
+## When to Use testmd vs run
+
+`kane-cli run` is one-shot. It runs an objective, uploads results, and exits. It is ideal for quick, one-off verifications like checking if a page loads correctly or extracting a value from a live site.
+
+`kane-cli testmd run` is for tests you want to persist. Use it when you are building a login flow smoke test, a regression suite, or any test you plan to re-run across builds. The test file lives in your repo, recordings are cached and committed alongside it, and every subsequent run replays from cache without consuming LLM credits. Teammates and CI pick up the same recordings and replay them identically.
+
+If you run an ad-hoc objective with `kane-cli run` and later decide you want to keep it, use the `--name` flag to save it as a `_test.md` file (see [Recording a Test from a Live Session](#recording-a-test-from-a-live-session) below).
+
+---
+
+## File Format
+
+A `_test.md` file has four parts in order:
+
+### YAML Frontmatter
+
+Configuration between `---` markers at the top of the file:
+
+```yaml
+---
+mode: testing
+max_steps: 30
+headless: true
+---
+```
+
+**Supported keys:**
+
+| Key | Scope | Description |
+|-----|-------|-------------|
+| `mode` | root | `testing` (default) or `action`. Testing mode pushes through auth walls for negative-test assertions. Action mode halts on auth walls. |
+| `max_steps` | root + step | Max agent reasoning steps per step. Default: `30` |
+| `timeout` | root + step | Hard kill per step, in seconds |
+| `headless` | root | Run Chrome with no visible window |
+| `variables` | root + step | Variables with `{{name}}` syntax, same format as [Variables & Context](/docs/kane-cli-variables-and-context/) |
+| `code_export` | root + step | Generate Playwright code after the run |
+| `code_language` | root + step | `python` or `javascript` for code export |
+| `global_context` / `local_context` | root + step | Inline Markdown or file path for agent context |
+
+### Title and Steps
+
+After the frontmatter, add a `# H1` title for the test. This is purely decorative. Kane CLI ignores everything before the first `## ` heading.
+
+Each `## H2` heading marks a test step. The heading text is a label for your reference; the agent reads the **step body** underneath it. Write the body as either plain English prose describing what the agent should do, or a single `@import <path>` line to pull in a reusable helper file. Do not mix prose and `@import` in the same step.
+
+### Per-Step Config Overrides
+
+You can override frontmatter settings for individual steps by adding a `yaml` fenced block immediately under the step heading:
+
+````markdown
+## Submit the form
+```yaml
+timeout: 90
+optional: true
+```
+Click submit and verify the confirmation banner.
+````
+
+Setting `optional: true` tells Kane CLI that a failure on this step should not fail the overall test. The run continues to the next step.
+
+---
+
+## Replay and Cascade Rule
+
+This is the most important concept in `testmd`.
+
+### Replay
+
+After the first run, each step replays from its cached recording with no AI agent, no LLM cost, and much faster execution. A step replays only if **all** of these hold:
+
+- A recording for that step exists
+- The step's prose is unchanged since the recording
+- The step's `yaml` block is unchanged
+- No earlier step invalidated it
+
+### Cascade
+
+Editing step N **re-authors step N and every step after it**. Each step starts where the previous step left off (URL, login state, open tabs). When step 3 changes, step 4 cannot safely replay against state that no longer exists.
+
+<Warning>
+A one-line tweak at the top of a 20-step test re-authors all 20 steps on the next run. To minimize re-authoring, edit only the steps you need to change.
+</Warning>
+
+**Useful commands:**
+
+| Action | How |
+|--------|-----|
+| Re-record one step | Edit only that step (steps after it cascade automatically) |
+| Force full re-authoring | Use `--author` flag for one run |
+| Wipe cache entirely | Run `rm -rf output-<stem>/` |
+
+---
+
+## Reusing Flows with `@import`
+
+Extract repeating flows (login, setup, cookie banner dismissal) into helper files:
+
+```markdown
+## Sign in
+@import ./helpers/login.md
+```
+
+**Rules:**
+
+- Helper filename **must not** end in `_test.md`. Only `_test.md` files are valid entry points
+- Path resolves relative to the **importing file**, not the shell's working directory
+- The step body must be exactly `@import <path>` with no mixed prose or extra lines
+- The step's `yaml` block may contain **only** `optional`
+- `optional: true` on `@import` is allowed only at the root file level, not on nested imports
+- Variables and context propagate into helpers automatically
+
+<Note>
+Editing a helper re-authors that step in **every test that imports it**, plus everything after the import in those tests. The same cascade rule applies.
+</Note>
+
+---
+
+## Recording a Test from a Live Session
+
+Run an ad-hoc objective with the `--name` flag to save it as a replayable test file:
+
+```bash
+kane-cli run "Search for noise-cancelling headphones on amazon.com" --name amazon-search
+```
+
+On exit, Kane CLI writes the test file to `.testmuai/tests/amazon-search_test.md`. Move that file into your repo and re-run it with `testmd run`.
+
+<Note>
+Without `--name`, ad-hoc runs are ephemeral and nothing is written to disk.
+</Note>
+
+---
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `kane-cli testmd run <path> --agent` | Run a test file |
+| `kane-cli testmd list` | List `*_test.md` files under the current directory |
+| `kane-cli testmd status <path>` | Show Test Manager identity and local sync state |
+| `kane-cli testmd export <path>` | Regenerate code export from existing recordings (no browser launch) |
+| `kane-cli testmd delete <path>` | Delete the test and its `output-<stem>/` cache locally. Does NOT delete from Test Manager |
+
+---
+
+## Flags for `testmd run`
+
+All [`kane-cli run` flags](/docs/kane-cli-cli-reference/) apply (`--agent`, `--headless`, `--max-steps`, `--timeout`, `--variables`, etc.), plus these additional flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--name <name>` | none | Persist the run under this name. Must match `[a-zA-Z0-9_-]+` |
+| `--on-lock-conflict <mode>` | none | Behavior when another user holds the test's edit lock: `readonly` (replay-only, no upload), `fail` (exit 2), or `wait` (block until released) |
+| `--retry` | off | On replay failure, restart with a shrinking replay window |
+| `--retry-count <n>` | `3` | Max retry restarts before falling back to full re-author |
+| `--author` | off | Force authoring every step, skipping replay entirely |
+| `--code-language <lang>` | `python` | Code export language: `python` or `javascript` |
+
+<Note>
+Flag values win over frontmatter for all settings **except** `variables`. The file owns variables. You can add new keys via flags but cannot override file-defined ones.
+</Note>
+
+---
+
+## Output Directory
+
+After a run, Kane CLI creates an output directory next to the test file:
+
+```
+amazon_test.md
+output-amazon/
+  Result.md                      # Human-readable run report
+  .internal/                     # Cached recordings, do not edit
+  playwright-python-code/        # Only if code_export is enabled
+```
+
+`output-<stem>/` is **commit-safe**. Commit it to git so teammates and CI replay the same recordings.
+
+For tests using `@import`, helper recordings land next to the helper file in `helper-output-<helper>-<root>-<step>/` directories. These are also commit-safe.
+
+### Result.md
+
+After each run, `Result.md` is generated with:
+
+| Section | Contents |
+|---------|----------|
+| Frontmatter | `status`, `started`, `duration_s`, `session_id` |
+| Step results | One entry per step: `✓ passed`, `✗ failed`, or `⏭ skipped` (suffixed `(optional)` for soft-failing optional steps) |
+| Import failure paths | For `@import` steps that failed, the path to the failing sub-step inside the helper |
+
+<Tip>
+To check whether a test passed or where it failed, read `Result.md` instead of re-running the test.
+</Tip>
+
+---
+
+## CI/CD Usage
+
+```bash
+kane-cli testmd run ./tests/checkout_test.md \
+  --agent \
+  --headless \
+  --on-lock-conflict wait \
+  --retry
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--agent` | Structured NDJSON to stdout |
+| `--headless` | No browser window |
+| `--on-lock-conflict wait` | Block instead of failing if a teammate is editing the same test |
+| `--retry` | Automatically recover from transient replay failures |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | ✅ Passed |
+| 1 | ❌ Failed (test ran but did not pass) |
+| 2 | ⚠️ Error (auth, setup, parse error, or `--on-lock-conflict fail`) |
+| 3 | ⏱️ Timeout, cancelled, or `--on-lock-conflict wait` timed out |
+
+---
+
+## Common Parse Errors
+
+Parse errors abort **before** any browser launch with exit code `2`:
+
+| Error Message | Fix |
+|---------------|-----|
+| `frontmatter is missing closing '---'` | Add the trailing `---` |
+| `invalid YAML in frontmatter` | Validate the YAML block |
+| `step body must be exactly one of prose / @import` | Split into two steps |
+| `step config on @import may only contain 'optional'` | Remove other keys from the yaml block |
+| `cannot @import a test file` | Imports may only reference helpers (not files ending in `_test.md`) |
+| `cyclic reference` | Restructure helpers to break the circular dependency |
+| `chrome config is global-only` | Move Chrome key to root frontmatter |
+| `'<key>' is run-level and cannot be set per-step` | Move `mode` / `on_lock_conflict` to root frontmatter |
+| `unknown config key` | Remove or fix the key |
+| `auth/identity keys are CLI-only` | Pass `username` / `access_key` as CLI flags, not in frontmatter |
+
+---
+
+## Example: Full Test with Imports
+
+**`tests/checkout_test.md`:**
+
+```markdown
+---
+mode: testing
+headless: true
+variables:
+  username:
+    value: "testuser@example.com"
+  password:
+    value: "s3cret!"
+    secret: true
+---
+
+# Checkout flow
+
+## Login
+@import ./helpers/login.md
+
+## Add item to cart
+Go to the products page, search for "wireless headphones", and click "Add to Cart" on the first result.
+
+## Verify cart
+Go to the cart page. Assert the cart contains 1 item. Store the total price as 'cart_total'.
+
+## Complete checkout
+Click "Proceed to Checkout", fill in shipping details, and assert the order confirmation page loads.
+```
+
+**`tests/helpers/login.md`:**
+
+```markdown
+# Login helper
+
+## Open the login page
+Go to https://app.example.com/login.
+
+## Sign in
+Enter {{username}} in the email field and {{password}} in the password field, then click "Sign In". Assert the dashboard loads.
+```
+
+**Run:**
+
+```bash
+kane-cli testmd run tests/checkout_test.md --agent
+```
+
+---
+
+## Next Steps
+
+- [Writing Objectives](/docs/kane-cli-writing-objectives/): Learn how to write effective natural language objectives
+- [Variables & Context](/docs/kane-cli-variables-and-context/): Parameterize tests with variables, secrets, and context files
+- [Agent Mode](/docs/kane-cli-agent-mode/): Parse structured NDJSON output from Kane CLI
+- [CI/CD Integration](/docs/kane-cli-cicd/): Add Kane CLI to your pipeline
+- [CLI Reference](/docs/kane-cli-cli-reference/): Full flag and command reference
+- [Troubleshooting](/docs/kane-cli-troubleshooting/): Debug common issues

--- a/docs/kane-cli-troubleshooting.mdx
+++ b/docs/kane-cli-troubleshooting.mdx
@@ -240,6 +240,32 @@ echo 'export PATH="$(npm config get prefix)/bin:$PATH"' >> ~/.zshrc
 node --version   # Must be 18 or higher
 ```
 
+### Install fails with "sharp: Please add node-addon-api"
+
+**Symptom:** `npm install -g @testmuai/kane-cli` fails with `sharp: Please add node-addon-api to your dependencies` (any Node version, any platform).
+
+<Note>
+Kane CLI 0.3.4+ treats `sharp` as an optional dependency, so the install still succeeds even if sharp fails. Screenshots simply upload as PNG instead of WebP (about 30% larger, no functional impact). On an older version, upgrade first with `npm install -g @testmuai/kane-cli@latest`.
+</Note>
+
+**Cause:** `sharp` powers optional PNG to WebP screenshot compression. When it cannot load its prebuilt binary it tries to build from source, which fails. The most common trigger on macOS is a system-wide libvips (often pulled in by `brew install appium`, `imagemagick`, or `gdal`).
+
+**Fix (most common, macOS):**
+```bash
+# Diagnose: a printed version means libvips is the cause
+pkg-config --modversion vips-cpp
+
+# Bypass libvips detection. Uninstall first, since npm considers
+# kane-cli already installed and will not re-resolve sharp otherwise.
+npm uninstall -g @testmuai/kane-cli
+SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install -g @testmuai/kane-cli
+
+# Make it permanent
+echo 'export SHARP_IGNORE_GLOBAL_LIBVIPS=1' >> ~/.zshrc && source ~/.zshrc
+```
+
+Two other triggers: npm configured to skip optional dependencies (`npm config get omit` should not contain `optional`, so clear it with `npm config delete omit` and reinstall), and a proxy or private registry that does not forward the `@img` scope (add an `@img:registry=https://registry.npmjs.org/` pass-through). If you are fine with PNG screenshots, no action is needed.
+
 ---
 
 ## "Update available" Notice

--- a/docs/kane-cli-variables-and-context.mdx
+++ b/docs/kane-cli-variables-and-context.mdx
@@ -31,7 +31,6 @@ Variables are JSON objects keyed by name. Each entry describes a single variable
 |-------|----------|------|---------|-------------|
 | `value` | Yes | string | — | The variable's value. Entries without `value` are ignored. |
 | `secret` | No | boolean | `false` | When `true`, the value is masked in logs and routed to the <BrandName /> secrets store instead of being synced as plain Test Manager variables. |
-| `syntax` | No | string | `{{<name>}}` | Custom placeholder syntax. Defaults to the double-brace form using the variable name. |
 
 ### Usage in Objectives
 

--- a/docs/kane-cli-writing-objectives.mdx
+++ b/docs/kane-cli-writing-objectives.mdx
@@ -18,6 +18,10 @@ The objective string is the most important input to Kane CLI. How you phrase it 
 | ✅ **Assertion** | assert, verify, confirm, check that, ensure | Validates a condition: produces pass/fail |
 | 📦 **Extraction** | store X as 'name' | Reads a value from the page, persists in output |
 
+<Note>
+**Assertions** and **extractions** are evaluated as [Checkpoints](/docs/kane-cli-checkpoints/). See the reference for all analyze methods (Visual, Textual, URL, Title, DevTools) and comparison operators.
+</Note>
+
 ### Actions
 
 Use imperative verbs to describe what the agent should do:


### PR DESCRIPTION
Brings the Mintlify Kane CLI documentation to full content parity with the **`testmuCom`** branch, which this PR treats as the source of truth. Formatting stays native to each platform (`<Note>` vs `:::note`, `<Tab>` vs `<TabItem>`, `<a id>` vs `{#anchor}`, `/docs/` vs `/support/docs/`); only *content* is synced.

Before this PR, Mintlify carried 24 of the 42 Kane CLI pages on `testmuCom`, and 10 of those 24 had content drift — including four cases where Mintlify was actively wrong.

## 1. Ports 17 missing pages

| Group | Pages |
|---|---|
| Core Concepts | `api-calls`, `browser-state`, `testmd` |
| Generate Test Cases *(new group)* | `generate`, `generate-workflow` |
| Checkpoints *(new group)* | `checkpoints`, `checkpoint-visual`, `checkpoint-textual`, `checkpoint-url`, `checkpoint-title`, and `checkpoint-devtools` + its 6 children (network, console, performance, cookies, localStorage, clipboard) |

Checkpoints and Test.md were previously referenced by name in the Assurance pages with no page to link to.

## 2. Backfills content missing from existing pages

- **`installation`** — the entire **Homebrew** install path was absent (`brew install LambdaTest/kane/kane-cli`, the tap, the automatic `google-chrome` cask, "no Node.js required"). npm was presented as the only option.
- **`index`** — missing the **Supported IDEs** section (Cursor, Antigravity, VS Code, Codex, Kiro, Eclipse-based, web-based).
- **`agent-mode`** — missing **"The .evidence proof pack"**.
- **`troubleshooting`** — missing the whole **`sharp: Please add node-addon-api`** entry (symptom, libvips cause, the `SHARP_IGNORE_GLOBAL_LIBVIPS=1` fix, two secondary triggers).
- **`modes`** — `set-url` was missing from the `/config` subcommand list; the string appeared nowhere in the Mintlify Kane CLI set.
- **`configuration`** — `default_url` claimed to be an "Internal default" rather than settable via `kane-cli config set-url <url>`.

## 3. Fixes incorrect content

- **`skills`** — the source link pointed at `github.com/LambdaTest/kane-cli/tree/main/skills`, which **404s**. Corrected to `tree/main/skill-installer/skills` (verified 200).
- **`error-codes`** — the `--variables` example used `"sensitive": true`. The field is `"secret"` (as this repo's own schema table states), so anyone copy-pasting it got an **unmasked password in logs**.
- **`variables-and-context`** — still documented a `syntax` variable field that was removed from the docs on 2026-06-27 and never synced across.
- **`modes`** — exit code `1` was described as *"Test failed (assertion not met)"*; it is *"agent reached an unrecoverable failure, or the upload failed"*. This is the code people script CI against.

## 4. Restores stripped cross-links

`writing-objectives` → Checkpoints, `assurance` → `testmd` / `generate`, `assurance-coverage` → `testmd`. These were plain text before because the targets did not exist.

## 5. Navigation

`docs.json` now mirrors the `testmuCom` `KaneCLISidebar` exactly:

- Core Concepts absorbs `tms-integration` and `testmd`, and gains `api-calls` + `browser-state`
- New **Generate Test Cases** and **Checkpoints** groups (the latter with a **DevTools** sub-group)
- `parallel-execution` moves to **Agent Mode**; `cicd` + `skills` become **CI/CD & Skills**
- The **Integrations & Automation** group is retired

The one intentional structural difference: `docs/index` stays a standalone first entry rather than a category link on Getting Started, because it carries `slug: /` and is this site's homepage. Docusaurus has no equivalent concept.

## Verification

- `mint validate` — passes with output **identical to pristine `stage-mintlify`**. The single OpenAPI warning is pre-existing on the branch and unrelated to this change.
- `mint broken-links` — the ported and edited pages introduce **one** dangling link: `kane-cli-generate` → `/docs/generate-test-cases-with-ai/`. That is carried over verbatim from `testmuCom`; the target is a KaneAI/Test Manager page not yet ported to Mintlify, and the link resolves itself once it is. (For context, `docs/` already carries 18 other pre-existing dangling links and `support/` carries 62.)
- Automated prose diff across all 42 pages: every remaining delta is a known formatting class (admonition syntax, tab components, anchor style, URL prefix, credential-placeholder code blocks, and the em-dash house-style pass applied only on Docusaurus). No content deltas remain.

## Out of scope

One defect runs the other way and belongs in a `testmuCom` PR, not here: on Docusaurus the `error-codes` H2s render as literal `## 1xx -- Success` (double hyphen), collateral from the em-dash-removal pass. Mintlify already has these correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)