### PR TITLE
docs(kane-cli): add coding-agent SKILL callout to Mintlify (Docusaurus parity)

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -7,7 +7,11 @@ keywords: ['kane cli', 'kaneai', 'browser automation', 'testmu ai', 'ai cli', 'n
 slug: /
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 **Kane CLI** `kane-cli` is an AI-powered browser automation tool that runs from your terminal. Describe what you want to test in plain English: Kane CLI navigates websites, clicks elements, fills forms, extracts data, and validates outcomes in a real Chrome browser.
 

--- a/docs/kane-cli-agent-mode.mdx
+++ b/docs/kane-cli-agent-mode.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli agent mode', 'ndjson', 'kaneai', 'testmu ai', 'ai agent int
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 Agent Mode outputs structured NDJSON instead of the interactive terminal UI. It's how AI coding agents (Claude Code, Codex CLI, Gemini CLI) consume Kane CLI results: parse events programmatically, extract the final result, and present it to the user.
 

--- a/docs/kane-cli-api-calls.mdx
+++ b/docs/kane-cli-api-calls.mdx
@@ -6,7 +6,11 @@ keywords: ['api calls', 'kane cli', 'http request', 'seed data', 'testmu ai']
 "og:description": "Have the Kane CLI agent make HTTP API calls directly inside an objective to seed data, hit a backend, then assert on or reuse the response."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Objectives can have the agent **make an API call directly**, not just observe the requests a page makes. This is useful for seeding data before a flow, hitting a backend to set up state, or checking a service, then asserting on or reusing the response.
 

--- a/docs/kane-cli-assurance-automation.mdx
+++ b/docs/kane-cli-assurance-automation.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli assurance ci', 'headless test design', 'ndjson event stream
 "og:description": "The headless contract for kane-cli assurance — the --mode ask policy, exit codes, NDJSON event streams, and the pause → answer → resume loop."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 The conversational assurance commands — `context extract`, `design tests`, and `maintain reconcile` — are interactive by default. This page is the contract for running them **headless**: from CI, from a script, or from an AI agent driving kane-cli.
 

--- a/docs/kane-cli-assurance-context.mdx
+++ b/docs/kane-cli-assurance-context.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli context', 'context ingest', 'use-case extraction', 'require
 "og:description": "Snapshot requirement documents into a local, content-addressed store and extract use-cases with an AI agent using kane-cli context."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 `kane-cli context` builds a local, content-addressed knowledge store (`.context/` in your project directory) from your requirement documents, and extracts **use-cases** from them with an AI agent. It is the first stage of the [assurance lifecycle](/docs/kane-cli-assurance/): Source → Use-case → Scenario → AC → Test.
 

--- a/docs/kane-cli-assurance-coverage.mdx
+++ b/docs/kane-cli-assurance-coverage.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli cover', 'test coverage', 'coverage gaps', 'evidence pack', 
 "og:description": "Measure coverage on two axes with kane-cli cover — what a sealed evidence pack proved in execution, and what the design still owes."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 `kane-cli cover` measures coverage on two independent axes over the same store:
 

--- a/docs/kane-cli-assurance-design.mdx
+++ b/docs/kane-cli-assurance-design.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli design tests', 'ai test design', 'acceptance criteria', 'te
 "og:description": "Turn one committed use-case into acceptance criteria, scenarios, and exactly one runnable test per scenario with kane-cli design tests."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 `kane-cli design tests` turns **one committed use-case** into everything that proves it: acceptance criteria (ACs), scenarios, and exactly one runnable test per scenario — conversationally, on the same chat surface [`kane-cli context extract`](/docs/kane-cli-assurance-context/#extract) uses. Everything the engine emits is **derived** knowledge you review; approvals promote it, nothing is silently trusted.
 

--- a/docs/kane-cli-assurance-maintain.mdx
+++ b/docs/kane-cli-assurance-maintain.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli maintain', 'maintain reconcile', 'test suite maintenance', 
 "og:description": "Keep tests aligned with changing requirements — kane-cli maintain reconcile triages one changed source into an ADD/MODIFY/ARCHIVE plan you approve card by card."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Products change; tests shouldn't rot. `kane-cli maintain` closes the [assurance loop](/docs/kane-cli-assurance/): when a requirement document changes, `maintain reconcile` turns that one changed source into an honest, row-by-row update plan for your suite, and `maintain evolve` re-designs a use-case whose design went stale. Everything works over the same `.context/` store — maintain adds no new knowledge kinds, it moves the existing ones.
 

--- a/docs/kane-cli-assurance.mdx
+++ b/docs/kane-cli-assurance.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli assurance', 'requirements to tests', 'test coverage lifecyc
 "og:description": "Go from requirement documents to designed, runnable tests with the kane-cli assurance commands — every test permanently linked to the requirement it verifies."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 kane-cli began as a way to author and replay browser tests. The **assurance** commands take on the step before and after: describe what your product must do, and kane-cli designs the tests that prove it — each one permanently linked to the requirement it verifies. Run them, and coverage stops being a guess: every run reports exactly what it proved and what it still owes. And as your product changes, the suite is reconciled instead of quietly rotting.
 

--- a/docs/kane-cli-authentication.mdx
+++ b/docs/kane-cli-authentication.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli authentication', 'kane cli login', 'kane cli profiles', 'ka
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 Kane CLI authenticates against your <BrandName /> account before it can run tests, upload sessions, or interact with Test Manager. There are two authentication methods:
 

--- a/docs/kane-cli-browser-state.mdx
+++ b/docs/kane-cli-browser-state.mdx
@@ -6,7 +6,11 @@ keywords: ['browser state', 'set cookies', 'localstorage', 'clipboard', 'kane cl
 "og:description": "Set cookies, localStorage, and the clipboard directly from a Kane CLI objective to seed state before a flow or test copy and paste behavior."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Objectives can directly manage cookies, localStorage, and the clipboard, useful for seeding state before a flow (skip a login, dismiss a consent banner) and for testing copy/paste behavior.
 

--- a/docs/kane-cli-changelog.mdx
+++ b/docs/kane-cli-changelog.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli changelog', 'kane cli releases', 'kaneai', 'testmu ai']
 "og:description": "Kane CLI release history, version notes, and links to GitHub releases."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Full release notes and version history are published on GitHub:
 

--- a/docs/kane-cli-checkpoint-devtools-clipboard.mdx
+++ b/docs/kane-cli-checkpoint-devtools-clipboard.mdx
@@ -6,7 +6,11 @@ keywords: ['clipboard assertion', 'copy button', 'kane cli', 'devtools', 'testmu
 "og:description": "Verify what a Copy button actually copied, extract copied values into variables, and confirm clipboard state, using an isolated test clipboard."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Clipboard assertions let you verify what a "Copy" button actually copied, extract copied values into variables, and confirm clipboard state after your test writes or clears it.
 

--- a/docs/kane-cli-checkpoint-devtools-console.mdx
+++ b/docs/kane-cli-checkpoint-devtools-console.mdx
@@ -6,7 +6,11 @@ keywords: ['console assertion', 'javascript errors', 'console log', 'kane cli', 
 "og:description": "Verify browser console output: errors, warnings, log messages, and JavaScript exceptions captured during test execution."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Console assertions let you verify browser console output: error messages, warnings, log messages, and uncaught JavaScript exceptions.
 

--- a/docs/kane-cli-checkpoint-devtools-cookies.mdx
+++ b/docs/kane-cli-checkpoint-devtools-cookies.mdx
@@ -6,7 +6,11 @@ keywords: ['cookies assertion', 'session cookie', 'httponly', 'secure cookie', '
 "og:description": "Verify browser cookies (names, values, and flags such as httpOnly, secure, and sameSite) set during test execution."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Cookie assertions let you verify browser cookies: check existence, values, and security attributes like httpOnly, secure, and sameSite.
 

--- a/docs/kane-cli-checkpoint-devtools-localstorage.mdx
+++ b/docs/kane-cli-checkpoint-devtools-localstorage.mdx
@@ -6,7 +6,11 @@ keywords: ['localstorage assertion', 'browser storage', 'auth token', 'kane cli'
 "og:description": "Verify key-value pairs stored in the browser localStorage during test execution: auth tokens, feature flags, cached data."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 localStorage assertions let you verify data stored in the browser's `window.localStorage`: check key existence, values, and item counts.
 

--- a/docs/kane-cli-checkpoint-devtools-network.mdx
+++ b/docs/kane-cli-checkpoint-devtools-network.mdx
@@ -6,7 +6,11 @@ keywords: ['network assertion', 'http response', 'api status code', 'kane cli', 
 "og:description": "Verify HTTP traffic (API responses, status codes, headers, response bodies, and request timing) captured by KaneAI in the background."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Network assertions let you verify HTTP traffic: API responses, status codes, headers, response bodies, and request timing.
 

--- a/docs/kane-cli-checkpoint-devtools-performance.mdx
+++ b/docs/kane-cli-checkpoint-devtools-performance.mdx
@@ -6,7 +6,11 @@ keywords: ['performance assertion', 'core web vitals', 'lcp', 'cls', 'inp', 'kan
 "og:description": "Verify Core Web Vitals and other performance metrics (LCP, CLS, INP, FCP, TTFB) captured during test execution."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Performance assertions let you verify [Core Web Vitals](https://web.dev/articles/vitals) and other key performance metrics for the current page.
 

--- a/docs/kane-cli-checkpoint-devtools.mdx
+++ b/docs/kane-cli-checkpoint-devtools.mdx
@@ -6,7 +6,11 @@ keywords: ['devtools assertion', 'network', 'console', 'performance', 'cookies',
 "og:description": "Verify data that is not visible on the page: HTTP network traffic, console output, performance metrics, cookies, localStorage, and clipboard."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 DevTools assertions let you verify data that isn't visible on the page: HTTP network traffic, browser console output, performance metrics, cookies, localStorage, and clipboard. KaneAI captures this data automatically in the background; you just write what to check.
 

--- a/docs/kane-cli-checkpoint-textual.mdx
+++ b/docs/kane-cli-checkpoint-textual.mdx
@@ -6,7 +6,11 @@ keywords: ['dom assertion', 'textual assertion', 'element state', 'kane cli', 't
 "og:description": "Extract data from the DOM (element states, attributes, and computed styles) and assert on values that may not be visible in a screenshot."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Textual assertions extract data from the page's DOM: element states, attributes, and computed styles that aren't always visible in a screenshot.
 

--- a/docs/kane-cli-checkpoint-title.mdx
+++ b/docs/kane-cli-checkpoint-title.mdx
@@ -6,7 +6,11 @@ keywords: ['page title assertion', 'document.title', 'kane cli', 'testmu ai']
 "og:description": "Verify the browser tab document.title, useful for confirming navigation reached the expected page."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Title assertions check the browser tab's document title (`document.title`).
 

--- a/docs/kane-cli-checkpoint-url.mdx
+++ b/docs/kane-cli-checkpoint-url.mdx
@@ -6,7 +6,11 @@ keywords: ['url assertion', 'query parameter assertion', 'kane cli', 'testmu ai'
 "og:description": "Check values in the browser address bar: current URL path, query parameters, fragments, and redirect targets."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 URL assertions check values in the browser's address bar: the current URL path, query parameters, fragments, and redirect targets.
 

--- a/docs/kane-cli-checkpoint-visual.mdx
+++ b/docs/kane-cli-checkpoint-visual.mdx
@@ -6,7 +6,11 @@ keywords: ['visual assertion', 'screenshot assertion', 'kane cli', 'kaneai', 'te
 "og:description": "Verify what is visible on the screen by analyzing the current screenshot. Visual is the default analyze method KaneAI uses for assertions."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Visual assertions verify what's visible on screen by analyzing the current screenshot. This is the default method, when in doubt, KaneAI uses visual analysis.
 

--- a/docs/kane-cli-checkpoints.mdx
+++ b/docs/kane-cli-checkpoints.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli checkpoints', 'assertions', 'extractions', 'testmu ai', 'ka
 "og:description": "Checkpoints are verification points KaneAI evaluates during test execution: assert conditions, branch on results, or extract values for later use."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Checkpoints are verification points that KaneAI evaluates during test execution. They let you assert conditions, branch on results, or extract values for later use.
 

--- a/docs/kane-cli-cicd.mdx
+++ b/docs/kane-cli-cicd.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli cicd', 'github actions browser testing', 'kaneai', 'testmu 
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 Kane CLI runs headlessly in CI/CD pipelines using credentials passed as environment variables or inline flags. Tests fail fast on assertion errors and return standard exit codes for pipeline control flow.
 
@@ -35,8 +38,8 @@ Pass credentials directly on the run command using environment variables from yo
 ```bash
 kane-cli run "Verify checkout flow completes" \
   --url https://staging.myapp.com \
-  --username "$LT_USERNAME" \
-  --access-key "$LT_ACCESS_KEY" \
+  --username "YOUR_LT_USERNAME" \
+  --access-key "YOUR_LT_ACCESS_KEY" \
   --headless \
   --agent \
   --timeout 300

--- a/docs/kane-cli-cli-reference.mdx
+++ b/docs/kane-cli-cli-reference.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli reference', 'kane cli commands', 'kaneai', 'testmu ai', 'cl
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 ## Commands
 

--- a/docs/kane-cli-configuration.mdx
+++ b/docs/kane-cli-configuration.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli configuration', 'kane cli config', 'kane cli settings', 'ka
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 Kane CLI stores persistent settings at `~/.testmuai/kaneai/tui-config.json`. Most settings are managed through `kane-cli config` subcommands; a few are managed through interactive pickers in TUI mode, and one (code export) is toggled from the TUI menu.
 

--- a/docs/kane-cli-error-codes.mdx
+++ b/docs/kane-cli-error-codes.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli error codes', 'kane cli result codes', 'kaneai errors', 'te
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 Every Kane CLI run ends with a `result_code` in the `run_end` event. This page lists every code, explains what triggered it, and tells you what to do next.
 

--- a/docs/kane-cli-generate-workflow.mdx
+++ b/docs/kane-cli-generate-workflow.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli generate workflow', 'kane cli test case generation', 'gener
 "og:description": "Walk the kane-cli generate loop end to end: generate, refine in plain language, save functional cases as _test.md files, and run them with testmd. Includes worked examples, agent/CI automation, and exit codes."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 `kane-cli generate` is built around a simple loop: **generate → refine → save → run**. Each command is one turn that exits when done; you move between turns with the request id. This page walks the loop end to end. For the feature overview and option reference, see [Generating test cases with AI](/docs/kane-cli-generate/).
 

--- a/docs/kane-cli-generate.mdx
+++ b/docs/kane-cli-generate.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli generate', 'kane cli test case generation', 'kane cli ai te
 "og:description": "Turn a plain-language description of what you want to test into structured test scenarios and test cases with kane-cli generate: refine in plain language, then save the functional cases as runnable _test.md files."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 `kane-cli generate` turns a plain-language description of *what you want to test* into structured **test scenarios** and **test cases**, without writing them by hand and without launching a browser. This page covers AI test-case generation from both the command line and the interactive kane-cli TUI.
 

--- a/docs/kane-cli-installation.mdx
+++ b/docs/kane-cli-installation.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli', 'install kane cli', 'kaneai', 'testmu ai', 'npm install']
 "og:description": "Install Kane CLI using npm or Homebrew. Supports macOS (Apple Silicon and Intel), Linux (x64 and arm64), and Windows (x64)."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Kane CLI is published to the public npm registry as `@testmuai/kane-cli` and to a Homebrew tap. Install it with `npm` or `brew` to get the `kane-cli` command on your `PATH`.
 

--- a/docs/kane-cli-modes.mdx
+++ b/docs/kane-cli-modes.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli modes', 'interactive tui', 'headless cli', 'agent mode', 'k
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 Kane CLI has three modes. Choose based on who (or what) is running the test.
 

--- a/docs/kane-cli-parallel-execution.mdx
+++ b/docs/kane-cli-parallel-execution.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli parallel', 'parallel testing', 'kaneai', 'testmu ai', 'batc
 "og:description": "Run multiple independent Kane CLI browser tests in parallel using shell background processes or AI agent sub-tasks."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 Run multiple independent browser tests concurrently to reduce total execution time. Instead of running tests sequentially (sum of all durations), parallel execution runs them simultaneously: total time equals the longest single test.
 

--- a/docs/kane-cli-quickstart.mdx
+++ b/docs/kane-cli-quickstart.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli quickstart', 'kaneai', 'testmu ai', 'browser test', 'first 
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 This guide takes you from a fresh install to a passing run in under five minutes.
 

--- a/docs/kane-cli-skills.mdx
+++ b/docs/kane-cli-skills.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli skill', 'claude code skill', 'codex cli', 'gemini cli', 'ka
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 A Kane CLI **skill** is a markdown instruction file that teaches an AI coding agent how to use `kane-cli`: when to invoke it, how to build commands, how to parse NDJSON output, how to present results, and how to handle failures. Install the skill once, and your agent handles browser automation tasks automatically whenever you ask.
 

--- a/docs/kane-cli-testmd.mdx
+++ b/docs/kane-cli-testmd.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli testmd', 'kane cli replayable tests', 'kane cli test files'
 "og:description": "Write browser tests as Markdown files that replay from cache after the first run: no LLM cost, faster execution. Commit tests to git, share recordings, and run in CI."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 `testmd` lets you write browser tests as Markdown files (`_test.md`) and commit them to your repo. On the first run, the AI agent authors each step and saves a recording. On every subsequent run, each step **replays from cache** with no LLM cost and much faster execution. Commit the test file and its recordings to git so teammates and CI can re-run the same tests without re-authoring.
 

--- a/docs/kane-cli-tms-integration.mdx
+++ b/docs/kane-cli-tms-integration.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli tms', 'kane cli test manager', 'kane cli upload', 'kane cli
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 By default, Kane CLI uploads each session to <BrandName /> Test Manager as a test case. This page covers what gets uploaded, where it ends up, and the related features: project and folder selection, code export, share links, the post-session feedback prompt, and the local session directory.
 

--- a/docs/kane-cli-troubleshooting.mdx
+++ b/docs/kane-cli-troubleshooting.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli troubleshooting', 'kaneai errors', 'testmu ai', 'chrome fai
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 ## Log Locations
 

--- a/docs/kane-cli-variables-and-context.mdx
+++ b/docs/kane-cli-variables-and-context.mdx
@@ -7,8 +7,11 @@ keywords: ['kane cli variables', 'kane cli context', 'kaneai', 'testmu ai', 'sec
 ---
 
 import { BrandName } from "/snippets/BrandName.mdx";
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
 
 ---
+
+<AgentSkillCallout />
 
 **Variables** keep credentials and test data out of your objectives. **Context files** give the agent persistent background information — guidance, conventions, and notes that apply across runs.
 

--- a/docs/kane-cli-writing-objectives.mdx
+++ b/docs/kane-cli-writing-objectives.mdx
@@ -6,7 +6,11 @@ keywords: ['kane cli objectives', 'natural language testing', 'kaneai', 'testmu 
 "og:description": "Learn the three objective patterns: actions, assertions, and extractions: and how to write natural language objectives that produce reliable test results."
 ---
 
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
 ---
+
+<AgentSkillCallout />
 
 The objective string is the most important input to Kane CLI. How you phrase it determines what the agent does and whether it succeeds. Objectives follow three patterns that you can combine freely.
 

--- a/snippets/AgentSkillCallout.mdx
+++ b/snippets/AgentSkillCallout.mdx
@@ -1,0 +1,7 @@
+<Note>
+**Using Claude Code, Cursor, or another coding agent?** Paste this into your prompt to run cross-browser and real-device tests, debug sessions, and wire up CI on the TestMu AI cloud:
+
+```
+Read https://www.testmuai.com/support/docs/SKILL.md to set up TestMu AI (formerly LambdaTest) cloud testing.
+```
+</Note>


### PR DESCRIPTION
Follow-up to #3287. That PR brought the Kane CLI **page bodies** to parity with `testmuCom` (Docusaurus). This PR closes the remaining **rendered** gap: a content block that lives in the Docusaurus theme layer, not in any page's Markdown, so a file diff can't see it.

## The gap

Every Docusaurus doc page injects a coding-agent callout right below the `<h1>` via `custom.js` (the `AGENT_CALLOUT` block) — an info box:

> **Using Claude Code, Cursor, or another coding agent?** Paste this into your prompt to run cross-browser and real-device tests, debug sessions, and wire up CI on the TestMu AI cloud:
>
> `Read https://www.testmuai.com/support/docs/SKILL.md to set up TestMu AI (formerly LambdaTest) cloud testing.`

Because it's a client-side injection, it was absent from **all** Mintlify Kane CLI pages, not just Authentication (the page in the report).

## The fix

- New reusable snippet **`snippets/AgentSkillCallout.mdx`** — renders the identical content as a Mintlify `<Note>` with a copyable code line (Docusaurus gives it a copy button too).
- Imported at the top of every Kane CLI page, right under the title, matching the Docusaurus position.
- Applied to all **40** real Kane CLI pages. The two redirect stubs (`kane-cli-getting-started`, `kane-cli-agent-output`) are skipped — they only bounce to their targets, which already carry the callout.

## Also in this PR

One content alignment found while scanning: the cicd **"Authentication in CI/CD"** quick example used `$LT_USERNAME`/`$LT_ACCESS_KEY`, while Docusaurus shows the placeholder there. Changed to `YOUR_LT_USERNAME`/`YOUR_LT_ACCESS_KEY` (the Mintlify placeholder convention). The env-var form is still used, correctly, in the GitHub Actions and GitLab YAML examples below — matching Docusaurus.

## Verification

- I rendered **all 42 Kane CLI pages on both live sites** (hydrated headless Chrome, so client-injected content is captured) and diffed the doc bodies word-for-word. After excluding the callout, every page matches at 93–99%, and **every residual is a known formatting class** — admonition labels (`Note`/`Tip` render as icons on Mintlify), `<angle-bracket>` placeholders split differently by the two syntax highlighters, and the documented `YOUR_LAMBDATEST_*` ↔ `YOUR_LT_*` placeholder convention. The callout was the **only** systematic content block present on Docusaurus and missing from Mintlify.
- `mint validate`: passes with output identical to pristine `stage-mintlify` (the lone OpenAPI warning is pre-existing and unrelated).
- Rendered every page type on a local `mint dev` server: callout present on all 40 pages, absent on the 2 stubs.

## Note on the live deploy (not part of this PR)

While comparing, I noticed the live Mintlify site is **partially stale** vs the merged `stage-mintlify`: e.g. the Checkpoints note added to `writing-objectives` in #3287 is in the branch source but not yet rendering on `www.testmuai.com/docs/kane-cli-writing-objectives`, even though other #3287 changes (the Checkpoints/Generate pages, the Homebrew tab) are live. Looks like a Mintlify redeploy/CDN lag; it should self-resolve, but worth a look if it persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)