### PR TITLE
docs(home): point Kane CLI cards on the docs home page to the Mintlify site

### DIFF
--- a/src/pages/docs.js
+++ b/src/pages/docs.js
@@ -179,14 +179,14 @@ export default function Home() {
           <div className="home_inners_box">
             <h2 className="homeMain_h2"><Icon light="Realtime-light-icon.svg" dark="Realtime-dark-icon.svg" alt="" />Kane CLI &nbsp;<NewTag value="NEW" /></h2>
             <div className="home_inners">
-              <a href="/support/docs/kane-cli-introduction/"><p className="p_home_inners">Getting Started</p></a>
-              <a href="/support/docs/kane-cli-installation/"><p className="p_home_inners">Installation</p></a>
-              <a href="/support/docs/kane-cli-quickstart/"><p className="p_home_inners">Quick Start</p></a>
-              <a href="/support/docs/kane-cli-writing-objectives/"><p className="p_home_inners">Writing Objectives</p></a>
-              <a href="/support/docs/kane-cli-generate/"><p className="p_home_inners">Generate Test Cases</p></a>
-              <a href="/support/docs/kane-cli-checkpoints/"><p className="p_home_inners">Checkpoints</p></a>
-              <a href="/support/docs/kane-cli-agent-mode/"><p className="p_home_inners">Agent Mode</p></a>
-              <a href="/support/docs/kane-cli-cli-reference/"><p className="p_home_inners">CLI Reference</p></a>
+              <a href="/docs/kane-cli-introduction"><p className="p_home_inners">Getting Started</p></a>
+              <a href="/docs/kane-cli-installation"><p className="p_home_inners">Installation</p></a>
+              <a href="/docs/kane-cli-quickstart"><p className="p_home_inners">Quick Start</p></a>
+              <a href="/docs/kane-cli-writing-objectives"><p className="p_home_inners">Writing Objectives</p></a>
+              <a href="/docs/kane-cli-generate"><p className="p_home_inners">Generate Test Cases</p></a>
+              <a href="/docs/kane-cli-checkpoints"><p className="p_home_inners">Checkpoints</p></a>
+              <a href="/docs/kane-cli-agent-mode"><p className="p_home_inners">Agent Mode</p></a>
+              <a href="/docs/kane-cli-cli-reference"><p className="p_home_inners">CLI Reference</p></a>
             </div>
           </div>
           <div className="home_inners_box">


### PR DESCRIPTION
## What

The product grid on the docs home page (`src/pages/docs.js`) linked all eight **Kane CLI** cards to `/support/docs/kane-cli-*/` (Docusaurus). Kane CLI documentation is actually served by the **Mintlify** stack at `/docs/`, so clicking "Kane CLI" on the index took readers to the wrong stack.

This repoints only the Kane CLI card. All 18 other product cards are untouched and still point at `/support/docs/`.

| Card link | Before | After |
|---|---|---|
| Getting Started | `/support/docs/kane-cli-introduction/` | `/docs/kane-cli-introduction` |
| Installation | `/support/docs/kane-cli-installation/` | `/docs/kane-cli-installation` |
| Quick Start | `/support/docs/kane-cli-quickstart/` | `/docs/kane-cli-quickstart` |
| Writing Objectives | `/support/docs/kane-cli-writing-objectives/` | `/docs/kane-cli-writing-objectives` |
| Generate Test Cases | `/support/docs/kane-cli-generate/` | `/docs/kane-cli-generate` |
| Checkpoints | `/support/docs/kane-cli-checkpoints/` | `/docs/kane-cli-checkpoints` |
| Agent Mode | `/support/docs/kane-cli-agent-mode/` | `/docs/kane-cli-agent-mode` |
| CLI Reference | `/support/docs/kane-cli-cli-reference/` | `/docs/kane-cli-cli-reference` |

## Notes

- **No trailing slash** on the new targets. That is the canonical form on the Mintlify site: `https://www.testmuai.com/docs/<slug>/` 308-redirects to `/docs/<slug>`, so the slash-less form avoids a redirect hop.
- `Getting Started` targets `/docs/kane-cli-introduction`, the new home of the Kane CLI introduction page. That page currently serves the Mintlify site root and is being moved in the companion `stage-mintlify` PR — **merge that one first**, or this link 404s.
- These are plain `<a href>` elements, so the paths are root-absolute and bypass the Docusaurus `baseUrl` (`/support/`) — which is what we want, since `/docs/` is a different stack. Consequence: they do not resolve against a local `docusaurus start` server, only against the deployed site.

## Verification

- `docusaurus start` compiles clean (only the pre-existing `all-apis.json` prebuild error, unrelated).
- Home page renders 19 cards / 113 links; 8 now resolve to `/docs/*`, the other 105 unchanged at `/support/docs/*`.
- All 8 target slugs confirmed to exist on `stage-mintlify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)