### PR TITLE
docs(home): add the product index as the Mintlify home page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -43,10 +43,11 @@
         "tab": "Docs",
         "icon": "book-open-lines",
         "pages": [
+          "docs/index",
           {
             "group": "Kane CLI",
             "pages": [
-              "docs/index",
+              "docs/kane-cli-introduction",
               {
                 "group": "Getting Started",
                 "pages": [

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,63 +1,590 @@
 ---
-title: "Kane CLI"
-sidebarTitle: "Introduction"
-description: "Kane CLI is an AI-powered command-line tool that runs browser automation tests in plain English: from your terminal, IDE, or CI pipeline."
-keywords: ['kane cli', 'kaneai', 'browser automation', 'testmu ai', 'ai cli', 'natural language testing']
-"og:description": "Kane CLI is an AI-powered command-line tool that runs browser automation tests in plain English: from your terminal, IDE, or CI pipeline."
+mode: "custom"
+title: "TestMu AI Documentation"
+description: "Explore guides, API docs, and examples for TestMu AI (Formerly LambdaTest) - the AI-native quality engineering platform."
 slug: /
 ---
 
-import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+<div className="w-full bg-gray-100 dark:bg-[#171a21]">
+  <div
+    style={{
+      maxWidth: '80rem',
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      paddingLeft: '1.25rem',
+      paddingRight: '1.25rem',
+      paddingTop: '2rem',
+      paddingBottom: '2rem',
+    }}
+  >
+    <div className="flex flex-col lg:flex-row items-center gap-10" >
+      <div className="w-full lg:w-2/3 text-left">
+        <h1 className="text-4xl font-semibold text-gray-900 dark:text-white" style={{ letterSpacing: '0px' }}>
+          TestMu AI (Formerly LambdaTest) Documentation
+        </h1>
+        <p className="mt-4 text-md text-[#6d6e79] dark:text-[#a1a1a3] font-normal" style={{ maxWidth: '35rem' }}>
+          Build, run, and scale tests on TestMu AI, the AI-native quality engineering platform. Setup guides, API references, and tutorials in one place.
+        </p>
+        <div className="flex items-center justify-start">
+          <button
+            type="button"
+            className="hidden w-full lg:flex items-center text-sm leading-6 py-4 pl-4 pr-4 text-gray-500 rounded-full"
+            id="home-search-entry"
+            style={{
+              marginTop: '2rem',
+              maxWidth: '35rem',
+              background: '#FFF',
+              boxShadow: '0px 1px 4px 0px rgba(8, 9, 10, 0.25), 0px 0px 0px 4px rgba(255, 255, 255, 0.20)',
+              cursor: 'pointer',
+              textAlign: 'left',
+            }}
+            onClick={()=> document.getElementById('search-bar-entry').click()}
+          >
+            <svg
+              className="h-4 w-4 ml-1.5 flex-none bg-primary hover:bg-gray-600 dark:bg-primary-dark dark:hover:bg-white/70"
+              style={{
+              marginRight: '0.5rem',
+              maskImage:
+                'url("https://mintlify.b-cdn.net/v6.5.1/solid/magnifying-glass.svg")',
+              maskRepeat: 'no-repeat',
+              maskPosition: 'center center',
+              }}
+            />
+            Search or ask...
+          </button>
+        </div>
+      </div>
+      <div className="w-full lg:w-1/2">
+        <img src="/assets/images/support/home_light.png" alt="TestMu AI" className="w-full max-h-90 object-contain" />
+      </div>
+    </div>
+  </div>
+</div>
 
----
+<div className="w-full">
+  <div
+    style={{
+      maxWidth: '80rem',
+      marginLeft: 'auto',
+      marginRight: 'auto',
+      paddingLeft: '1.25rem',
+      paddingRight: '1.25rem',
+      paddingTop: '4rem',
+      paddingBottom: '4rem',
+    }}
+  >
 
-<AgentSkillCallout />
+<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
 
-**Kane CLI** `kane-cli` is an AI-powered browser automation tool that runs from your terminal. Describe what you want to test in plain English: Kane CLI navigates websites, clicks elements, fills forms, extracts data, and validates outcomes in a real Chrome browser.
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="window-restore" size={24} />
+      <h3 className="text-lg font-semibold m-0">Web Automation</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/getting-started-with-testmu-automation/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Selenium Testing
+      </a>
+      <a href="/support/docs/getting-started-with-cypress-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Cypress Testing
+      </a>
+      <a href="/support/docs/playwright-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Playwright Testing
+      </a>
+      <a href="/support/docs/puppeteer-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Puppeteer Testing
+      </a>
+      <a href="/support/docs/k6-browser-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        K6 Testing
+      </a>
+    </div>
+  </div>
 
-- **Run browser tests from any terminal or IDE**: no test scripts, no selectors, no framework boilerplate
-- **Integrate into CI/CD pipelines**: headless mode with structured JSON output and standard exit codes
-- **Use as a skill in AI coding agents**: Claude Code, Codex CLI, and Gemini CLI can invoke Kane CLI directly to test and verify web UIs on your behalf
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="window" size={24} />
+      <h3 className="text-lg font-semibold m-0">App Automation</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/getting-started-with-appium-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Appium Testing
+      </a>
+      <a href="/support/docs/getting-started-with-espresso-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Espresso Testing
+      </a>
+      <a href="/support/docs/getting-started-with-xcuitest/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        XCUI Testing
+      </a>
+      <a href="/support/docs/getting-started-with-flutter-dart-android-automation/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Flutter Testing
+      </a>
+      <a href="/support/docs/app-automation-on-emulators-simulators/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Virtual Devices
+      </a>
+    </div>
+  </div>
 
-```bash
-# Install
-npm install -g @testmuai/kane-cli
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="square-bolt" size={24} />
+      <h3 className="text-lg font-semibold m-0">HyperExecute</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/getting-started-with-hyperexecute/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Getting Started
+      </a>
+      <a href="/support/docs/hyperexecute-yaml-parameters/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        HyperExecute YAML
+      </a>
+      <a href="/support/docs/hyperexecute-cli-run-tests-on-hyperexecute-grid/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        HyperExecute CLI
+      </a>
+      <a href="/support/docs/hyperexecute-cli-gui/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        HyperExecute GUI <span style={{border: '1px solid #bf3989', color: '#bf3989', borderRadius: '1em', padding: '0.1em 0.5em', fontWeight: 'bold', fontSize: '0.8em', marginLeft: '0.5em', verticalAlign: 'middle', display: 'inline-block'}}>BETA</span>
+      </a>
+      <a href="/support/docs/hyperexecute-mcp-server/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        HyperExecute MCP Server
+      </a>
+      <a href="/support/docs/key-features-of-hyperexecute/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Features
+      </a>
+      <a href="/support/docs/integration-with-hyperexecute/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Integrations
+      </a>
+      <a href="/support/docs/hyperexecute-private-cloud-setup/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Private Cloud
+      </a>
+    </div>
+  </div>
 
-# Authenticate
-kane-cli login
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="chart-line-up" size={24} />
+      <h3 className="text-lg font-semibold m-0">Insights</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/analytics-dashboard-templates/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Pre-built Dashboards
+      </a>
+      <a href="/support/docs/analytics-create-dashboard/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Custom Dashboards
+      </a>
+      <a href="/support/docs/analytics-widgets/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Widgets
+      </a>
+      <a href="/support/docs/analytics-dashboard-copilot/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Dashboard CoPilot AI
+      </a>
+      <a href="/support/docs/analytics-test-case-insights/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Test Case Insights
+      </a>
+      <a href="/support/docs/analytics-build-comparison/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Build Insights
+      </a>
+      <a href="/support/docs/analytics-modules-test-intelligence-flaky-test-analytics/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Flaky Test Insights
+      </a>
+      <a href="/support/docs/analytics-modules-test-intelligence-command-logs-analytics/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Command Logs Insights
+      </a>
+    </div>
+  </div>
 
-# Run your first test
-kane-cli run --url https://example.com "Click the 'More information' link and verify the page loads"
-```
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="cloud" size={24} />
+      <h3 className="text-lg font-semibold m-0">Browser Cloud</h3> <span style={{border: '1px solid #bf3989', color: '#bf3989', borderRadius: '1em', padding: '0.1em 0.5em', fontWeight: 'bold', fontSize: '0.8em', marginLeft: '0.5em', verticalAlign: 'middle', display: 'inline-block'}}>NEW</span>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/what-is-browser-cloud/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        What is Browser Cloud
+      </a>
+      <a href="/support/docs/launch-first-session/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Launch Session With SDK
+      </a>
+      <a href="/support/docs/browser-cloud-skills/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Launch Session With Agent Skills
+      </a>
+      <a href="/support/docs/connect-to-session/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Connect to a Session
+      </a>
+    </div>
+  </div>
 
-## Supported IDEs
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="magic" size={24} />
+      <h3 className="text-lg font-semibold m-0">SmartUI</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/smart-visual-regression-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Getting Started
+      </a>
+      <a href="/support/docs/smartui-selenium-js-sdk/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Explore SDKs
+      </a>
+      <a href="/support/docs/smartui-cli/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        CLI
+      </a>
+      <a href="/support/docs/smartui-upload-api-v2/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Upload Screenshots
+      </a>
+      <a href="/support/docs/smartui-pdf-comparison/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Smart PDF Comparison
+      </a>
+      <a href="/support/docs/smart-ui-build-options/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Build Config and Options
+      </a>
+      <a href="/support/docs/test-settings-options/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Advance Comparison Options
+      </a>
+      <a href="/support/docs/html-dom-smartui-options/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Handling Dynamic Data
+      </a>
+    </div>
+  </div>
 
-Kane CLI runs from the integrated terminal of your editor, so you can drive browser tests without leaving your development environment. It is supported in:
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="clock" size={24} />
+      <h3 className="text-lg font-semibold m-0">KaneAI</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/getting-started-with-kane-ai/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Getting Started
+      </a>
+      <a href="/support/docs/author-your-first-desktop-browser-test/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Author Desktop Browser Test
+      </a>
+      <a href="/support/docs/author-your-first-mobile-app-test/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Author Mobile App Test
+      </a>
+      <a href="/support/docs/kane-ai-api-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        API Testing
+      </a>
+      <a href="/support/docs/kane-ai-command-guide/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Command Types
+      </a>
+      <a href="/support/docs/kaneai-ci-cd-automation/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Test Automation with CI/CD
+      </a>
+      <a href="/support/docs/kaneai-faqs/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        FAQs
+      </a>
+    </div>
+  </div>
 
-* Cursor
-* Antigravity
-* VS Code
-* Codex
-* Kiro (AWS)
-* Eclipse-based IDEs
-* Web-based IDEs
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="terminal" size={24} />
+      <h3 className="text-lg font-semibold m-0">Kane CLI</h3> <span style={{border: '1px solid #bf3989', color: '#bf3989', borderRadius: '1em', padding: '0.1em 0.5em', fontWeight: 'bold', fontSize: '0.8em', marginLeft: '0.5em', verticalAlign: 'middle', display: 'inline-block'}}>NEW</span>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/docs/kane-cli-introduction" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Getting Started
+      </a>
+      <a href="/docs/kane-cli-installation" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Installation
+      </a>
+      <a href="/docs/kane-cli-quickstart" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Quick Start
+      </a>
+      <a href="/docs/kane-cli-writing-objectives" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Writing Objectives
+      </a>
+      <a href="/docs/kane-cli-generate" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Generate Test Cases
+      </a>
+      <a href="/docs/kane-cli-checkpoints" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Checkpoints
+      </a>
+      <a href="/docs/kane-cli-agent-mode" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Agent Mode
+      </a>
+      <a href="/docs/kane-cli-cli-reference" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        CLI Reference
+      </a>
+    </div>
+  </div>
 
-## Three Modes
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="eye" size={24} />
+      <h3 className="text-lg font-semibold m-0">Web Scanner</h3> <span style={{border: '1px solid #bf3989', color: '#bf3989', borderRadius: '1em', padding: '0.1em 0.5em', fontWeight: 'bold', fontSize: '0.8em', marginLeft: '0.5em', verticalAlign: 'middle', display: 'inline-block'}}>NEW</span>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/web-scanner-overview/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Overview
+      </a>
+      <a href="/support/docs/web-scanner-getting-started/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Getting Started
+      </a>
+      <a href="/support/docs/web-scanner-visual-scan/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Visual UI Scans
+      </a>
+      <a href="/support/docs/web-scanner-accessibility-scan/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Accessibility Scans
+      </a>
+      <a href="/support/docs/web-scanner-adding-urls/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Adding URLs
+      </a>
+      <a href="/support/docs/web-scanner-scheduling-options/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Scheduling Options
+      </a>
+    </div>
+  </div>
 
-| Mode | Command | Best For |
-|------|---------|----------|
-| **Interactive TUI** | `kane-cli --tui` | Development, exploration, chained multi-run sessions |
-| **Non-Interactive CLI Mode** | `kane-cli run "..." --headless --agent` | CI/CD pipelines, shell scripts |
-| **Agent Mode** | `kane-cli run "..." --agent` | AI coding agents (Claude, Codex, Gemini) |
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="robot" size={24} />
+      <h3 className="text-lg font-semibold m-0">Agent Testing Platform</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/getting-started-with-agent-testing-platform/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Overview
+      </a>
+      <a href="/support/docs/chat-agent/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Supported Agent Types
+      </a>
+      <a href="/support/docs/testing-your-first-ai-agent/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Test Your First Agent
+      </a>
+      <a href="/support/docs/testmu-a2a-cli/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Test With Agent Testing CLI
+      </a>
+      <a href="/support/docs/chat-agent-api-integration/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Integrate a Chat Agent API
+      </a>
+      <a href="/support/docs/agent-testing-platform-faqs/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        FAQs
+      </a>
+    </div>
+  </div>
 
-## Next Steps
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="clock" size={24} />
+      <h3 className="text-lg font-semibold m-0">Real Time</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/getting-started-with-desktop-browser-real-time-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Web Browser Testing
+      </a>
+      <a href="/support/docs/getting-started-with-mobile-browser-real-time-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Mobile Browser Testing
+      </a>
+      <a href="/support/docs/getting-started-with-mobile-app-real-time-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Mobile App Testing
+      </a>
+      <a href="/support/docs/chrome-os-web-browser-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        ChromeOS Web Browser Testing
+      </a>
+      <a href="/support/docs/chrome-os-app-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        ChromeOS App Testing
+      </a>
+      <a href="/support/docs/developer-tools/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Key Features
+      </a>
+    </div>
+  </div>
 
-- [Installation](/docs/kane-cli-installation/): Install Kane CLI and verify your setup
-- [Quick Start](/docs/kane-cli-quickstart/): Authenticate and run your first test in 5 minutes
-- [Authentication](/docs/kane-cli-authentication/): OAuth, basic auth, and profile management
-- [Writing Objectives](/docs/kane-cli-writing-objectives/): Learn how to write effective natural language objectives
-- [Configuration](/docs/kane-cli-configuration/): Window size, Chrome profiles, Test Manager project, and run mode
-- [Test Manager Integration](/docs/kane-cli-tms-integration/): Uploads, share links, code export, and session history
-- [Agent Mode](/docs/kane-cli-agent-mode/): Use Kane CLI with AI coding agents
-- [CI/CD Integration](/docs/kane-cli-cicd/): Add Kane CLI to your pipeline
-- [Skills](/docs/kane-cli-skills/): Install the Kane CLI skill for Claude, Codex, or Gemini
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="mobile-signal" size={24} />
+      <h3 className="text-lg font-semibold m-0">Real Device</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/app-testing-on-real-devices/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Real Device App Testing
+      </a>
+      <a href="/support/docs/browser-testing-on-real-devices/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Real Device Browser Testing
+      </a>
+      <a href="/support/docs/public-cloud-vs-private-cloud/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Private Cloud
+      </a>
+    </div>
+  </div>
+
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="list-check" size={24} />
+      <h3 className="text-lg font-semibold m-0">Test Manager</h3> <span style={{border: '1px solid #bf3989', color: '#bf3989', borderRadius: '1em', padding: '0.1em 0.5em', fontWeight: 'bold', fontSize: '0.8em', marginLeft: '0.5em', verticalAlign: 'middle', display: 'inline-block'}}>NEW</span>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/create-projects/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Create Projects
+      </a>
+      <a href="/support/docs/insights-dashboard/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Insights Dashboard
+      </a>
+      <a href="/support/docs/manual-test-case-creation/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Manual Test Cases
+      </a>
+      <a href="/support/docs/automated-test-cases-with-ai/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Automated Test Cases
+      </a>
+      <a href="/support/docs/test-run-creation-and-management/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Test Run
+      </a>
+      <a href="/support/docs/milestone-creation-and-management/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Milestones
+      </a>
+      <a href="/support/docs/link-jira-issues-with-test-manager/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Issue Tracker Integration
+      </a>
+    </div>
+  </div>
+
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="list-check" size={24} />
+      <h3 className="text-lg font-semibold m-0">TestMu AI MCP Server</h3> <span style={{border: '1px solid #bf3989', color: '#bf3989', borderRadius: '1em', padding: '0.1em 0.5em', fontWeight: 'bold', fontSize: '0.8em', marginLeft: '0.5em', verticalAlign: 'middle', display: 'inline-block'}}>NEW</span>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/lambdatest-mcp-server/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Setting up TestMu AI MCP Server
+      </a>
+    </div>
+  </div>
+
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="plug" size={24} />
+      <h3 className="text-lg font-semibold m-0">Integrations</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/bug-tracking-tools/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Bug Tracking
+      </a>
+      <a href="/support/docs/integrations-with-project-management-tools/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Project Management
+      </a>
+      <a href="/support/docs/integrations-with-ci-cd-tools/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        CI / CD Integration
+      </a>
+      <a href="/support/docs/integrate-test-reporting-test-management-tools/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Test Reporting
+      </a>
+      <a href="/support/docs/team-communication-tools/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Communication Tools
+      </a>
+      <a href="/support/docs/plugins-and-extensions/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Plugin and Extensions
+      </a>
+    </div>
+  </div>
+
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="shield-virus" size={24} />
+      <h3 className="text-lg font-semibold m-0">Accessibility Testing</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/accessibility-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Getting Started
+      </a>
+      <a href="/support/docs/accessibility-devtools/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Accessibility DevTools
+      </a>
+      <a href="/support/docs/accessibility-automation/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Accessibility Web Automation
+      </a>
+      <a href="/support/docs/accessibility-test-scheduling/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Sitemap Scheduling
+      </a>
+      <a href="/support/docs/accessibility-app-scanner/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Native App Scanner
+      </a>
+      <a href="/support/docs/accessibility-native-app-automation-test/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Native App Automation
+      </a>
+      <a href="/support/docs/screen-reader-on-accessibility/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Screen Reader
+      </a>
+    </div>
+  </div>
+
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="fingerprint" size={24} />
+      <h3 className="text-lg font-semibold m-0">Testing Locally</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/testing-locally-hosted-pages/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Testing Locally Hosted Pages
+      </a>
+      <a href="/support/docs/lambda-tunnel-modifiers/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        TestMu AI Tunnel Modifiers
+      </a>
+      <a href="/support/docs/docker-tunnel/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Docker Tunnel
+      </a>
+      <a href="/support/docs/troubleshooting-lambda-tunnel/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Troubleshooting Tunnel
+      </a>
+      <a href="/support/docs/load-balancing-in-lambda-tunnel/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Load Balancing in Tunnel
+      </a>
+      <a href="/support/docs/dedicated-proxy/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        IP Whitelisting
+      </a>
+      <a href="/support/docs/charles-proxy/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Charles Proxy
+      </a>
+    </div>
+  </div>
+
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="gear" size={24} />
+      <h3 className="text-lg font-semibold m-0">Settings and Security</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/account-management/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Account Management
+      </a>
+      <a href="/support/docs/network-whitelisting-and-tunnel-guide/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Network Whitelisting Guide
+      </a>
+      <a href="/support/docs/testmu-public-ip/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        TestMu AI Public IP
+      </a>
+      <a href="/support/docs/single-sign-on/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Single Sign On
+      </a>
+      <a href="/support/docs/scim/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        SCIM
+      </a>
+    </div>
+  </div>
+
+  <div className="flex flex-col">
+    <div className="flex items-center gap-3 mb-3">
+      <Icon icon="folder" size={24} />
+      <h3 className="text-lg font-semibold m-0">Other Docs</h3>
+    </div>
+    <div className="flex flex-col gap-2">
+      <a href="/support/docs/lt-browser/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        LT Browser
+      </a>
+      <a href="/support/docs/test-logs/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Test Logs
+      </a>
+      <a href="/support/docs/test-intelligence-overview/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Test Intelligence
+      </a>
+      <a href="/support/docs/automated-screenshot-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Screenshot Testing
+      </a>
+      <a href="/support/docs/responsive-testing/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Responsive Testing
+      </a>
+      <a href="/support/docs/concurrency-widget/" className="text-[#2b7ade] dark:text-blue-400 transition-colors text-sm font-semibold py-1 hover:underline underline-offset-4 antialiased">
+        Concurrency Widget
+      </a>
+    </div>
+  </div>
+</div>
+</div>
+</div>

--- a/docs/kane-cli-introduction.mdx
+++ b/docs/kane-cli-introduction.mdx
@@ -1,0 +1,62 @@
+---
+title: "Kane CLI"
+sidebarTitle: "Introduction"
+description: "Kane CLI is an AI-powered command-line tool that runs browser automation tests in plain English: from your terminal, IDE, or CI pipeline."
+keywords: ['kane cli', 'kaneai', 'browser automation', 'testmu ai', 'ai cli', 'natural language testing']
+"og:description": "Kane CLI is an AI-powered command-line tool that runs browser automation tests in plain English: from your terminal, IDE, or CI pipeline."
+---
+
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
+---
+
+<AgentSkillCallout />
+
+**Kane CLI** `kane-cli` is an AI-powered browser automation tool that runs from your terminal. Describe what you want to test in plain English: Kane CLI navigates websites, clicks elements, fills forms, extracts data, and validates outcomes in a real Chrome browser.
+
+- **Run browser tests from any terminal or IDE**: no test scripts, no selectors, no framework boilerplate
+- **Integrate into CI/CD pipelines**: headless mode with structured JSON output and standard exit codes
+- **Use as a skill in AI coding agents**: Claude Code, Codex CLI, and Gemini CLI can invoke Kane CLI directly to test and verify web UIs on your behalf
+
+```bash
+# Install
+npm install -g @testmuai/kane-cli
+
+# Authenticate
+kane-cli login
+
+# Run your first test
+kane-cli run --url https://example.com "Click the 'More information' link and verify the page loads"
+```
+
+## Supported IDEs
+
+Kane CLI runs from the integrated terminal of your editor, so you can drive browser tests without leaving your development environment. It is supported in:
+
+* Cursor
+* Antigravity
+* VS Code
+* Codex
+* Kiro (AWS)
+* Eclipse-based IDEs
+* Web-based IDEs
+
+## Three Modes
+
+| Mode | Command | Best For |
+|------|---------|----------|
+| **Interactive TUI** | `kane-cli --tui` | Development, exploration, chained multi-run sessions |
+| **Non-Interactive CLI Mode** | `kane-cli run "..." --headless --agent` | CI/CD pipelines, shell scripts |
+| **Agent Mode** | `kane-cli run "..." --agent` | AI coding agents (Claude, Codex, Gemini) |
+
+## Next Steps
+
+- [Installation](/docs/kane-cli-installation/): Install Kane CLI and verify your setup
+- [Quick Start](/docs/kane-cli-quickstart/): Authenticate and run your first test in 5 minutes
+- [Authentication](/docs/kane-cli-authentication/): OAuth, basic auth, and profile management
+- [Writing Objectives](/docs/kane-cli-writing-objectives/): Learn how to write effective natural language objectives
+- [Configuration](/docs/kane-cli-configuration/): Window size, Chrome profiles, Test Manager project, and run mode
+- [Test Manager Integration](/docs/kane-cli-tms-integration/): Uploads, share links, code export, and session history
+- [Agent Mode](/docs/kane-cli-agent-mode/): Use Kane CLI with AI coding agents
+- [CI/CD Integration](/docs/kane-cli-cicd/): Add Kane CLI to your pipeline
+- [Skills](/docs/kane-cli-skills/): Install the Kane CLI skill for Claude, Codex, or Gemini


### PR DESCRIPTION
## What

The Mintlify site has no way back to the rest of the documentation. It opens straight into the Kane CLI introduction, and every other product lives on the Docusaurus stack at `/support/docs/` — so a reader who lands on Kane CLI docs is stuck there.

This makes `/docs` serve the **same product index** that `/support/docs/` serves.

**Link rules on the new home page:**
- **Kane CLI → `/docs/<slug>`** — stays inside Mintlify (8 links)
- **everything else → `/support/docs/<slug>/`** — goes to Docusaurus (105 links)

## Changes

**1. `docs/index.mdx` is now the product index** (`mode: "custom"`, 19 product cards)

Generated from `src/pages/docs.js` on `testmuCom` so the two grids stay in parity — same cards, same order, same labels, same NEW/BETA pills, same link targets. Verified identical: 19 cards / 113 links on both.

Styling follows the existing `docs/index-backup.mdx` (hero + search button + `lg:grid-cols-4` card grid). Products that already had an icon there keep it; the new cards use `cloud` (Browser Cloud), `terminal` (Kane CLI) and `robot` (Agent Testing Platform).

**2. The Kane CLI introduction moves to `docs/kane-cli-introduction.mdx`**

Content is unchanged — only the frontmatter `slug: /` is dropped so the URL derives from the path, like every other page. The slug matches the one the Docusaurus stack already uses for the same page.

⚠️ **Its URL changes from `/docs` to `/docs/kane-cli-introduction`.** A Mintlify redirect cannot cover this, because `/docs` is now the home page. Anything currently pointing at `/docs` expecting the Kane CLI landing page (npm README, the `kane-cli` repo, CLI help output) will land on the product index instead — one extra click, not a 404.

**3. `docs.json` navigation**

`docs/index` becomes the first page of the Docs tab, above the Kane CLI group; `docs/kane-cli-introduction` replaces `docs/index` as the group's first entry. The sidebar on every Kane CLI page now shows a "TestMu AI Documentation" link back to the index.

## Verification

Local `mint dev`:

| URL | Serves |
|---|---|
| `/docs` | TestMu AI Documentation (new index) |
| `/docs/kane-cli-introduction` | Kane CLI (moved, renders correctly) |
| `/docs/kane-cli-installation` | Installing Kane CLI (unchanged) |

- `docs.json` is valid JSON; every `docs/*` nav entry resolves to a real file.
- All 8 `/docs/*` links on the index resolve to existing `.mdx` files.
- Screenshotted the index and a Kane CLI page — grid, pills and sidebar all render correctly.

## Merge order

Merge this **before** the companion Docusaurus PRs (#3298 → `stage`, #3299 → `testmuCom`), which link to `/docs/kane-cli-introduction`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)