### PR TITLE
docs(kane-cli): code export supports javascript, not python only

### DIFF
--- a/docs/kane-cli-cli-reference.md
+++ b/docs/kane-cli-cli-reference.md
@@ -77,7 +77,7 @@ kane-cli run "<objective>" [options]
 | `--agent` | Output structured NDJSON (for AI coding agents) | Off |
 | `--mode <name>` | Run mode: `action` (strict) or `testing` (lenient) | Config value, otherwise `testing` |
 | `--code-export` | Generate code export after run uploads | Off |
-| `--code-language <lang>` | Code export language (currently `python`) | `python` |
+| `--code-language <lang>` | Code export language: `python` or `javascript` | `python` |
 | `--skip-code-validation` | Skip post-codegen worker-side validation | On |
 | `--no-skip-code-validation` | Force post-codegen worker-side validation | Off |
 | `--username <user>` | Basic auth username (overrides stored profile) | N/A |

--- a/docs/kane-cli-configuration.md
+++ b/docs/kane-cli-configuration.md
@@ -103,7 +103,7 @@ Empty fields are shown as `(none)`. The `chrome` path is empty by default, in wh
 | `folder_name` | string \| null | `null` | Display name of the selected folder | Set by `kane-cli config folder` |
 | `mode` | `"action"` \| `"testing"` | `"testing"` | Agent behaviour on auth walls, blocked pages, or error pages. | `kane-cli config set-mode <action\|testing>` |
 | `code_export.enabled` | boolean | `false` | Generate code export after upload completes. | TUI menu, or `--code-export` flag |
-| `code_export.language` | `"python"` | `"python"` | Output language for generated code. Only `python` is supported. | `--code-language <lang>` |
+| `code_export.language` | `"python"` \| `"javascript"` | `"python"` | Output language for generated code. Accepts `python` or `javascript`. | `--code-language <lang>` |
 | `code_export.skip_validation` | boolean | `true` | Skip post-codegen worker-side validation. | TUI menu, or `--skip-code-validation` |
 
 ---
@@ -175,7 +175,7 @@ The `code_export` block enables and configures generated code output produced af
 - **The TUI**: open the config menu, choose Code Export, and toggle the `enabled` and `skip_validation` switches.
 - **Per-run flags** on `kane-cli run`:
   - `--code-export` to enable for this run only
-  - `--code-language <lang>` to pick the output language (only `python` is supported)
+  - `--code-language <lang>` to pick the output language (`python` or `javascript`)
   - `--skip-code-validation` / `--no-skip-code-validation` to control post-codegen validation
 
 Code export requires a Test Manager upload, so it is only meaningful when a project is configured. See [Test Manager Integration](/support/docs/kane-cli-tms-integration/) for the full upload pipeline.

--- a/docs/kane-cli-tms-integration.md
+++ b/docs/kane-cli-tms-integration.md
@@ -116,7 +116,7 @@ Code export converts a completed test case into runnable Playwright code that yo
 
 ### What It Produces
 
-Currently the only supported language is **Python with Playwright**. Code export runs server-side after the test case is finalised. Kane CLI polls Test Manager until generation is complete, then downloads the resulting files.
+The supported languages are **Python with Playwright** and **JavaScript with Playwright**. Code export runs server-side after the test case is finalised. Kane CLI polls Test Manager until generation is complete, then downloads the resulting files.
 
 ### Enabling Code Export
 
@@ -143,7 +143,7 @@ kane-cli run "Add an item to the cart" \
   --skip-code-validation
 ```
 
-`--no-skip-code-validation` forces validation on for that run. `--code-language` only accepts `python`.
+`--no-skip-code-validation` forces validation on for that run. `--code-language` accepts `python` or `javascript`.
 
 ### Where to Find the Output
 

--- a/static/docs/kane-cli-cli-reference.md
+++ b/static/docs/kane-cli-cli-reference.md
@@ -36,7 +36,7 @@ kane-cli run "<objective>" [options]
 | `--agent` | Output structured NDJSON (for AI coding agents) | Off |
 | `--mode ` | Run mode: `action` (strict) or `testing` (lenient) | Config value, otherwise `testing` |
 | `--code-export` | Generate code export after run uploads | Off |
-| `--code-language ` | Code export language (currently `python`) | `python` |
+| `--code-language ` | Code export language: `python` or `javascript` | `python` |
 | `--skip-code-validation` | Skip post-codegen worker-side validation | On |
 | `--no-skip-code-validation` | Force post-codegen worker-side validation | Off |
 | `--username ` | Basic auth username (overrides stored profile) | N/A |

--- a/static/docs/kane-cli-configuration.md
+++ b/static/docs/kane-cli-configuration.md
@@ -53,7 +53,7 @@ Empty fields are shown as `(none)`. The `chrome` path is empty by default, in wh
 | `folder_name` | string \| null | `null` | Display name of the selected folder | Set by `kane-cli config folder` |
 | `mode` | `"action"` \| `"testing"` | `"testing"` | Agent behaviour on auth walls, blocked pages, or error pages. | `kane-cli config set-mode ` |
 | `code_export.enabled` | boolean | `false` | Generate code export after upload completes. | TUI menu, or `--code-export` flag |
-| `code_export.language` | `"python"` | `"python"` | Output language for generated code. Only `python` is supported. | `--code-language ` |
+| `code_export.language` | `"python"` \| `"javascript"` | `"python"` | Output language for generated code. Accepts `python` or `javascript`. | `--code-language ` |
 | `code_export.skip_validation` | boolean | `true` | Skip post-codegen worker-side validation. | TUI menu, or `--skip-code-validation` |
 
 ## Updating Settings
@@ -123,7 +123,7 @@ The `code_export` block enables and configures generated code output produced af
 - **The TUI**: open the config menu, choose Code Export, and toggle the `enabled` and `skip_validation` switches.
 - **Per-run flags** on `kane-cli run`:
   - `--code-export` to enable for this run only
-  - `--code-language ` to pick the output language (only `python` is supported)
+  - `--code-language ` to pick the output language (`python` or `javascript`)
   - `--skip-code-validation` / `--no-skip-code-validation` to control post-codegen validation
 
 Code export requires a Test Manager upload, so it is only meaningful when a project is configured. See [Test Manager Integration](/support/docs/kane-cli-tms-integration/) for the full upload pipeline.

--- a/static/docs/kane-cli-tms-integration.md
+++ b/static/docs/kane-cli-tms-integration.md
@@ -65,7 +65,7 @@ Code export converts a completed test case into runnable Playwright code that yo
 
 ### What It Produces
 
-Currently the only supported language is **Python with Playwright**. Code export runs server-side after the test case is finalised. Kane CLI polls Test Manager until generation is complete, then downloads the resulting files.
+The supported languages are **Python with Playwright** and **JavaScript with Playwright**. Code export runs server-side after the test case is finalised. Kane CLI polls Test Manager until generation is complete, then downloads the resulting files.
 
 ### Enabling Code Export
 
@@ -92,7 +92,7 @@ kane-cli run "Add an item to the cart" \
 --skip-code-validation
 ```
 
-`--no-skip-code-validation` forces validation on for that run. `--code-language` only accepts `python`.
+`--no-skip-code-validation` forces validation on for that run. `--code-language` accepts `python` or `javascript`.
 
 ### Where to Find the Output
 


### PR DESCRIPTION
Three Kane CLI docs pages claimed `--code-language` only accepts `python`. It also accepts `javascript`.

## Why

Kane CLI 0.6.7 reports:

```
--code-language <lang>       Code export language: python (default) | javascript
```

The TUI Code Export menu lists both `python` and `javascript`. Test.md already documented both, so the docs contradicted each other and the product.

## What changed

| Page | Was | Now |
|---|---|---|
| CLI Reference | "Code export language (currently `python`)" | "Code export language: `python` or `javascript`" |
| Configuration | "Only `python` is supported." | "Accepts `python` or `javascript`." plus the type column now shows both |
| Configuration | run flags: "(only `python` is supported)" | "(`python` or `javascript`)" |
| Test Manager Integration | "`--code-language` only accepts `python`." | "accepts `python` or `javascript`." |
| Test Manager Integration | "Currently the only supported language is **Python with Playwright**." | "The supported languages are **Python with Playwright** and **JavaScript with Playwright**." |

Applied to both the Docusaurus pages and their `static/docs/` plain-text mirrors, which `llms.txt` serves to AI agents. Test.md needed no change, it was already correct.

Defaults are untouched, `python` remains the default everywhere.

## Verification

Repo-wide grep confirms no python-only claim remains in `docs/` or `static/docs/`. All three pages render correctly on a local build at port 3001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)