### PR TITLE
docs(accessibility): state that Test Scheduling is desktop only

### DIFF
--- a/docs/accessibility-faq.md
+++ b/docs/accessibility-faq.md
@@ -115,6 +115,14 @@ Yes. Mobile app accessibility testing is supported through:
 
 Mobile web browser accessibility testing through automation is not currently supported.
 
+## Can I schedule accessibility scans for native mobile apps?
+No. [Test Scheduling](/support/docs/accessibility-test-scheduling/) is supported on **desktop only**. Scheduled scans run against websites and web apps on desktop browsers, and native Android or iOS apps cannot be added to a scheduled scan.
+
+To cover a mobile app, use one of the mobile surfaces instead:
+
+- **App Scanner (Manual):** [Accessibility App Scanner](/support/docs/accessibility-app-scanner/)
+- **Native App Automation:** [Native App Automation](/support/docs/accessibility-native-app-automation-test/)
+
 ## Do you support accessibility testing for PDFs?
 Yes. PDF Accessibility Scanning is available as part of the Accessibility product. See [PDF Accessibility Scanning](/support/docs/accessibility-pdf-accessibility-scanning/) for details on supported capabilities and how to use this feature.
 

--- a/docs/accessibility-test-scheduling-scan.md
+++ b/docs/accessibility-test-scheduling-scan.md
@@ -44,6 +44,10 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
       })
     }}
 ></script>
+:::note
+Scheduled scans are supported on **desktop only**. You can schedule scans for websites and web apps that run on desktop browsers. **Native Android and iOS apps are not supported** in this flow. For mobile apps, see [Accessibility App Scanner](/support/docs/accessibility-app-scanner/) or [Native App Automation](/support/docs/accessibility-native-app-automation-test/).
+:::
+
 ## Step 1: Access the Scheduled Scan Feature
 - Open the Accessibility Testing Dashboard.
 - Click the “Scheduled Scan” option from the menu.

--- a/docs/accessibility-test-scheduling.md
+++ b/docs/accessibility-test-scheduling.md
@@ -13,6 +13,10 @@ canonical: https://www.testmuai.com/support/docs/accessibility-test-scheduling/
 
 Test Scheduling helps teams run recurring Accessibility scans on websites and web apps without manually starting a new scan every time.
 
+:::note
+Test Scheduling is supported on **desktop only**. Scheduled scans run against websites and web apps on desktop browsers. **Native Android and iOS apps are not supported** and cannot be added to a scheduled scan. To test a mobile app, use [Accessibility App Scanner](/support/docs/accessibility-app-scanner/) for manual screen by screen scanning or [Native App Automation](/support/docs/accessibility-native-app-automation-test/) for Appium runs.
+:::
+
 When you want recurring Accessibility scans outside of Web Scanner, this overview explains how the native scheduling flow fits the product, how it differs from Web Scanner, and where to go for setup, URL import, authentication, and recurring schedules. Use it to orient sitemap-based or crawler-driven workflows and ongoing visibility into accessibility drift.
 
 ## Use this when
@@ -20,6 +24,14 @@ When you want recurring Accessibility scans outside of Web Scanner, this overvie
 - you want recurring scans
 - you want to import or discover many URLs at once
 - you need scheduled visibility into accessibility drift over time
+
+## What is supported
+
+| Surface | Supported in Test Scheduling |
+|---|---|
+| Websites and web apps on desktop browsers | Yes |
+| Native Android apps | No |
+| Native iOS apps | No |
 
 ## Product boundary
 


### PR DESCRIPTION
### Issue

Users often ask whether accessibility scheduling supports native apps. The docs never stated the boundary, so the answer had to come from support every time.

### Change

Documents that Test Scheduling is supported on desktop only, for websites and web apps, and that native Android and iOS apps cannot be added to a scheduled scan.

- `accessibility-test-scheduling.md`: note under the intro plus a **What is supported** table
- `accessibility-test-scheduling-scan.md`: note at the top of the step-by-step flow, where users actually configure the scan
- `accessibility-faq.md`: new FAQ **Can I schedule accessibility scans for native mobile apps?**, pointing to App Scanner and Native App Automation

All new links are site-relative to existing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uy6943Ap7trz2wQf9Jkkk