### PR TITLE
docs(accessibility): state that autoScan is not supported on real devices

### DIFF
--- a/docs/accessibility-appium-testng.md
+++ b/docs/accessibility-appium-testng.md
@@ -30,11 +30,14 @@ UiAutomator2Options options = new UiAutomator2Options();
 options.setDeviceName("Pixel.*");
 options.setApp("lt://APP_ID"); // or storage URL per your setup
 options.setCapability("accessibility", true);
-// options.setCapability("accessibility.autoscan", true); // optional
 AppiumDriver driver = new AndroidDriver(new URL("https://mobile-hub.lambdatest.com/wd/hub"), options);
 ```
 
-Use the **official capability set** your account documentation lists for the current Appium version; the critical addition is `"accessibility": true`.
+Use the **official capability set** your account documentation lists for the current Appium version. The critical addition is `"accessibility": true`.
+
+:::warning
+`accessibility.autoscan` is a **web automation** capability and is **not supported on real devices**. On real devices, each screen you want covered has to be scanned with the `lambda-accessibility-scan` hook. See [Scan Configurations via Capabilities](/support/docs/accessibility-automation-scan-configurations/).
+:::
 
 ### 2. Call the scan hook after navigation
 
@@ -59,7 +62,7 @@ Open **[Navigating the Dashboard](/support/docs/accessibility-testing-navigating
 | Symptom | What to check |
 |--------|----------------|
 | Hook throws | Driver must be a session where accessibility capability was set; verify spelling `lambda-accessibility-scan`. |
-| Empty report | Hook never called and autoscan off; or page never reached stable state. |
+| Empty report | Hook never called, or the screen never reached a stable state. autoScan does not cover this, it is not supported on real devices. |
 
 ## Related docs
 

--- a/docs/accessibility-appium-webdriverio.md
+++ b/docs/accessibility-appium-webdriverio.md
@@ -30,13 +30,16 @@ export const config = {
     'appium:deviceName': 'Pixel.*',
     'appium:app': 'lt://APP_ID',
     'accessibility': true,
-    // 'accessibility.autoscan': true,
   }],
   // host/user/key per your standard WDIO LambdaTest preset
 };
 ```
 
 Match keys to your Appium server version (`appium:` prefix for W3C caps).
+
+:::warning
+`accessibility.autoscan` is a **web automation** capability and is **not supported on real devices**. On real devices, each screen you want covered has to be scanned with the `lambda-accessibility-scan` hook. See [Scan Configurations via Capabilities](/support/docs/accessibility-automation-scan-configurations/).
+:::
 
 ### 2. Call the hook after screens load
 

--- a/docs/accessibility-automation-scan-configurations.md
+++ b/docs/accessibility-automation-scan-configurations.md
@@ -56,6 +56,12 @@ In automation there is no scan-configuration panel. The scan scope is supplied t
 Per-rule enable/disable picking is a **Manual-only** feature and is not used in automation. In automation, the rule set is computed from the WCAG version plus the group toggles.
 :::
 
+:::warning
+**autoScan is not supported on real devices.** The `accessibility.autoscan` capability is a **web automation** capability only. It cannot be used to scan a whole app flow on a real device the way it scans a whole web flow on desktop.
+
+On real devices, every scan must be triggered explicitly with the `lambda-accessibility-scan` hook at each stable screen. A screen that is never followed by a hook call is never scanned. See [Automating Accessibility Testing with Selenium](/support/docs/accessibility-automation-test/) for autoScan on web.
+:::
+
 ## When to use this
 
 Use these capabilities when users **already run Appium** against <BrandName /> real devices and want each accessibility scan scoped to a specific WCAG target and set of rule groups, without opening a UI. See [Native App Automation Appium (Overview)](/support/docs/accessibility-native-app-automation-test/) for the surrounding test setup and the `lambda-accessibility-scan` hook.
@@ -79,6 +85,7 @@ Use these capabilities when users **already run Appium** against <BrandName /> r
 Notes:
 
 - Defaults apply only when `accessibility` is `true` and the specific capability is omitted.
+- `accessibility.autoscan` is deliberately absent from this table. It is a web automation capability and is **not supported for app automation on real devices**. Use the `lambda-accessibility-scan` hook instead.
 - `accessibility.aiEnabled` is the same AI toggle used elsewhere in accessibility; it is reused here.
 - A backend capability `accessibility.needsReview` also exists but is not part of the standard automation scan config (defaults off).
 

--- a/docs/accessibility-native-app-automation-test.md
+++ b/docs/accessibility-native-app-automation-test.md
@@ -13,6 +13,10 @@ canonical: https://www.testmuai.com/support/docs/accessibility-native-app-automa
 
 Native App Automation uses **Appium** with the **`lambda-accessibility-scan`** hook to generate accessibility results during **Android** or **iOS** test runs on the TestMu AI grid.
 
+:::warning
+Scans on real devices are **hook driven only**. The `accessibility.autoscan` capability used in web automation is **not supported on real devices**, so a full app flow cannot be scanned automatically. Call `lambda-accessibility-scan` at every screen you want covered. See [Scan Configurations via Capabilities](/support/docs/accessibility-automation-scan-configurations/).
+:::
+
 ## When to use this
 
 Use this page when your team **already runs Appium** for functional tests and wants accessibility checks in the **same execution path** with deterministic checkpoints.


### PR DESCRIPTION
### Issue

Users often ask whether the whole flow can be scanned on a real device, the way `accessibility.autoscan` scans a whole flow in desktop web automation. It cannot. Worse, two Appium guides shipped a commented out `accessibility.autoscan` capability labelled "optional", which reads as an endorsement.

### Change

Documents that `accessibility.autoscan` is a web automation capability and is not supported for app automation on real devices, where scans are hook driven only.

- `accessibility-automation-scan-configurations.md`: warning under the intro, plus a note explaining why `autoscan` is absent from the capability table
- `accessibility-native-app-automation-test.md`: same boundary stated on the overview page users land on first
- `accessibility-appium-testng.md`: removed the misleading commented capability, added the warning, and corrected the "Empty report" troubleshooting row that told users to check whether autoscan was off
- `accessibility-appium-webdriverio.md`: removed the same commented capability, added the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uy6943Ap7trz2wQf9Jkkk