### PR TITLE
docs(accessibility): document how scan consumption is counted

### DIFF
--- a/docs/accessibility-automation-test.md
+++ b/docs/accessibility-automation-test.md
@@ -134,12 +134,14 @@ driver.executeScript("lambda-accessibility-scan");
 *Note: If you do not execute the hook in your script when using this method, no accessibility reports will be generated.*
 
 #### 2. Continuous Auto-Scanning
-If you want the accessibility scanner to run automatically on every single page navigation throughout the entire test session without writing manual hooks, you can pass the `accessibility.autoscan` capability:
+If you want the accessibility scanner to run automatically as your test drives the application, without writing manual hooks, you can pass the `accessibility.autoscan` capability:
 
 ```java
 capability.setCapability("accessibility", true); // Enable accessibility testing
-capability.setCapability("accessibility.autoscan", true); // Automatically scan all pages
+capability.setCapability("accessibility.autoscan", true); // Scan automatically as the test interacts with the app
 ```
+
+With autoScan enabled, a scan is triggered by **interactive commands** such as navigation, clicks, and `executeScript()`. Read only operations such as `findElement()`, explicit waits, and attribute reads do not trigger a scan. Each triggered scan consumes 1 accessibility scan, so an interaction heavy test consumes more than 1 scan per page. See [How scan consumption works](/support/docs/accessibility-testing/#how-scan-consumption-works).
 
 #### Advanced Capabilities
 You can also define other settings capabilities to refine your scan rules as described below:

--- a/docs/accessibility-testing.md
+++ b/docs/accessibility-testing.md
@@ -66,6 +66,28 @@ Use this section when you want the fastest path from "I need to test accessibili
 - Using Web Scanner docs for the Accessibility-native scheduling surface.
 - Using KaneAI guidance when your team is running direct Appium automation.
 
+## How scan consumption works
+
+Accessibility scan consumption is based on **how scans are triggered**, not on the number of unique URLs visited or the number of DOM changes on a page.
+
+### Manual scan (`lambda-accessibility-scan`)
+
+- Each scan hook invocation consumes **1 accessibility scan**.
+- Calling the hook 3 times consumes 3 scans, regardless of how many automation commands run in between.
+- Calling the hook twice on the same page consumes 2 scans.
+
+### AutoScan (`accessibility.autoscan: true`)
+
+- A scan is triggered by **interactive automation commands** such as navigation, clicks, and `executeScript()`.
+- Each such command consumes **1 accessibility scan**.
+- **Read only operations do not consume scans.** Examples are `findElement()`, explicit waits, and attribute reads.
+
+In short, consumption is determined by the automation actions that trigger a scan, not by unique URLs or DOM changes. On an interaction heavy flow this matters, because every interaction on the same page counts as its own scan, so autoScan can consume more scans than the number of pages the test visits. Use the `lambda-accessibility-scan` hook when you want to control exactly how many scans a run consumes. See [Automating Accessibility Testing with Selenium](/support/docs/accessibility-automation-test/) for both approaches.
+
+:::note
+autoScan applies to **web** automation. On real devices, app automation scans are triggered only by the `lambda-accessibility-scan` hook, so each hook call is 1 scan. See [Native App Automation](/support/docs/accessibility-native-app-automation-test/).
+:::
+
 ## Accessibility standards
 
 Accessibility Testing helps you work toward standards such as WCAG, ADA, EAA, and Section 508. Automated testing covers many rules, but it does not replace manual verification for every accessibility requirement. See the [Web](/support/docs/accessibility-web-what-we-cover/), [iOS](/support/docs/accessibility-ios-what-we-cover/), and [Android](/support/docs/accessibility-android-what-we-cover/) checklists for supported rules plus each platform’s **manual test checklist**, with links into each rule repository.


### PR DESCRIPTION
### Issue

Users ask how accessibility scan consumption works. The docs never stated the rule, and the Selenium guide described autoScan as running "on every single page navigation", which under-states consumption on interaction heavy flows.

### Change

Adds an explicit consumption section to the Accessibility Getting Started page:

- **Manual scan (`lambda-accessibility-scan`)**: each hook invocation consumes 1 scan, regardless of how many automation commands run in between
- **AutoScan (`accessibility.autoscan: true`)**: a scan is triggered by interactive commands such as navigation, clicks and `executeScript()`, each consuming 1 scan. Read only operations (`findElement()`, waits, attribute reads) consume nothing
- States the takeaway plainly: consumption follows scan-triggering actions, not unique URLs or DOM changes
- Notes that on real devices consumption is hook driven only

`accessibility-automation-test.md` is updated in the same PR so the autoScan description no longer contradicts the new section, and links to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uy6943Ap7trz2wQf9Jkkk