### PR TITLE
docs(accessibility): state that hybrid apps are not supported

### DIFF
--- a/docs/accessibility-app-scanner.md
+++ b/docs/accessibility-app-scanner.md
@@ -13,6 +13,10 @@ canonical: https://www.testmuai.com/support/docs/accessibility-app-scanner/
 
 Accessibility App Scanner is the **manual** mobile app workflow for reviewing accessibility issues on **real Android or iOS devices**, screen by screen, without writing Appium code.
 
+:::warning
+Accessibility scanning supports **native** Android and iOS apps only. **Hybrid apps**, meaning native apps with embedded webview content, are **not supported**. This applies to both App Scanner and [Native App Automation](/support/docs/accessibility-native-app-automation-test/). To check the web content itself, test the web application directly with [Manual Testing (DevTools)](/support/docs/accessibility-devtools/) or [web Automation](/support/docs/accessibility-automation-test/).
+:::
+
 ## When to use this
 
 Use App Scanner when you want to **inspect** Android or iOS app screens interactively and validate findings as you move through the app, ideal for exploratory passes, design reviews, or reproducing issues filed by users.
@@ -20,6 +24,7 @@ Use App Scanner when you want to **inspect** Android or iOS app screens interact
 ## Prerequisites
 
 - Access to **Accessibility** and **App Scanner** for your organization
+- A **native** Android or iOS app. Hybrid apps with embedded webview content are not supported
 - A **build** of the app you are authorized to test (store build, enterprise IPA/APK, or uploaded artifact per your workflow)
 - A **device profile** that matches your audience (OS version, screen size)
 

--- a/docs/accessibility-native-app-automation-test.md
+++ b/docs/accessibility-native-app-automation-test.md
@@ -19,6 +19,7 @@ Use this page when your team **already runs Appium** for functional tests and wa
 
 ## Prerequisites
 
+- A **native** Android or iOS app. Hybrid apps with embedded webview content are not supported
 - Appium client and test project targeting TestMu AI **real devices** or emulators per your subscription
 - `LT_USERNAME` / `LT_ACCESS_KEY` available to the process
 - Accessibility enabled on the mobile session (see framework guides below for capability examples)
@@ -47,6 +48,10 @@ driver.executeScript("lambda-accessibility-scan");
 ## Product boundary
 
 This page is for direct Appium-based automation. If you are authoring the flow in KaneAI, use [Mobile App Accessibility Testing](/support/docs/kaneai-mobile-app-accessibility/). If you want manual screen-by-screen testing, use [Accessibility App Scanner (Overview)](/support/docs/accessibility-app-scanner/).
+
+:::warning
+Accessibility scanning supports **native** Android and iOS apps only. **Hybrid apps**, meaning native apps with embedded webview content, are **not supported**. This applies to both Native App Automation and [App Scanner](/support/docs/accessibility-app-scanner/). To check the web content itself, test the web application directly with [Manual Testing (DevTools)](/support/docs/accessibility-devtools/) or [web Automation](/support/docs/accessibility-automation-test/).
+:::
 
 ## Related docs
 


### PR DESCRIPTION
### Issue

Users often ask whether hybrid apps, meaning native apps that render part or all of the interface inside a webview, can be scanned for accessibility. They cannot, and neither mobile page stated the limit.

### Change

Confirms in the docs that accessibility scanning covers native Android and iOS apps only, and that hybrid apps are not supported by App Scanner or Native App Automation.

- `accessibility-app-scanner.md`: warning under the intro plus a native app prerequisite
- `accessibility-native-app-automation-test.md`: the same boundary, so the answer is visible on whichever mobile page the user lands on

Both notes point users to DevTools or web automation for the web content itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uy6943Ap7trz2wQf9Jkkk