### PR TITLE
docs(accessibility): fix autoScan capability casing on the Playwright page

### DIFF
--- a/docs/playwright-accessibility-test.md
+++ b/docs/playwright-accessibility-test.md
@@ -149,12 +149,16 @@ await page.evaluate('lambda-accessibility-scan');
 *Note: If you do not execute the hook in your script when using this method, no accessibility reports will be generated.*
 
 #### 2. Continuous Auto-Scanning
-If you want the accessibility scanner to run automatically on every single page navigation throughout the entire test session without writing manual hooks, you can pass the `accessibility.autoscan` capability:
+If you want the accessibility scanner to run automatically on every single page navigation throughout the entire test session without writing manual hooks, you can pass the `accessibility.autoScan` capability:
 
 ```javascript
 capabilities['accessibility'] = true; // Enable accessibility testing
-capabilities['accessibility.autoscan'] = true; // Automatically scan all pages
+capabilities['accessibility.autoScan'] = true; // Automatically scan all pages
 ```
+
+:::note
+The capability name is case sensitive here. In Playwright it is `accessibility.autoScan`, with a capital **S**.
+:::
 
 #### Advanced Capabilities
 You can also define other settings capabilities to refine your scan rules as described below:


### PR DESCRIPTION
### Issue

Reported by Akshay Verma against https://www.lambdatest.com/support/docs/playwright-accessibility-test/

The page documents:

```javascript
capabilities['accessibility.autoscan'] = true; // Automatically scan all pages
```

The correct key for Playwright is `accessibility.autoScan`, with a capital **S**. Anyone copying the snippet gets a silently ignored capability: no auto scanning, no report, and nothing to indicate why.

### Change

- Corrected both the prose reference and the code snippet on `playwright-accessibility-test.md`
- Added a short note that the capability name is case sensitive, since the failure mode is silent

### Please confirm before merge

Every other accessibility guide in the repo uses lowercase `accessibility.autoscan`: Selenium, TestNG, JUnit 5, NUnit, Cucumber Java, Robot Framework, WebdriverIO, Appium TestNG, HyperExecute Selenium, and the tool comparison page. `LambdaTest/agent-skills` also uses lowercase.

So one of two things is true, and this PR only assumes the first:

1. **Playwright genuinely differs** from the Selenium style capability parsing, in which case this PR is complete as is
2. **`autoScan` is the correct key everywhere** and the other 10 pages are wrong too, in which case this is one instance of a much larger doc bug and I will raise a follow-up PR covering all of them

Someone from the platform side confirming which of the two applies would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uy6943Ap7trz2wQf9Jkkk