### PR TITLE
docs(smartui): use @latest for SmartUI CLI install commands (TE-22391)

### DIFF
--- a/docs/hyperexecute-smart-ui-capture-onboarding.md
+++ b/docs/hyperexecute-smart-ui-capture-onboarding.md
@@ -137,13 +137,13 @@ Install the required SmartUI CLI package. You can install it globally or locally
 ### Global Installation (Recommended)
 
 ```bash
-npm install -g @lambdatest/smartui-cli@4.1.54-beta.0
+npm install -g @lambdatest/smartui-cli@latest
 ```
 
 ### Local Installation
 
 ```bash
-npm install @lambdatest/smartui-cli@4.1.54-beta.0
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::tip Sample Repository
@@ -398,7 +398,7 @@ cacheDirectories:
 
 pre:
   # Install SmartUI CLI and dependencies
-  - npm install @lambdatest/smartui-cli@4.1.54-beta.0
+  - npm install @lambdatest/smartui-cli@latest
   - npm install playwright@1.57.0
   - npx playwright install
 
@@ -435,7 +435,7 @@ cacheDirectories:
   - ${CACHE_DIR}
 
 pre:
-  - npm install @lambdatest/smartui-cli@4.1.54-beta.0
+  - npm install @lambdatest/smartui-cli@latest
   - npm install playwright@1.57.0
   - npx playwright install
 
@@ -689,7 +689,7 @@ env:
   SMART_GIT: true  # Enable Smart Git for branch management
 
 pre:
-  - npm install @lambdatest/smartui-cli@4.1.54-beta.0
+  - npm install @lambdatest/smartui-cli@latest
 
 matrix:
   section: ["section1_category_a", "section2_category_b", "section3_category_c", "section4_category_d", "section5_category_e"]
@@ -795,7 +795,7 @@ env:
   PROJECT_TOKEN: ${PROJECT_TOKEN_CATEGORY_A}  # Unique token per project
 
 pre:
-  - npm install @lambdatest/smartui-cli@4.1.54-beta.0
+  - npm install @lambdatest/smartui-cli@latest
 
 testSuites:
   - npx smartui capture urls_category_a.json --config config.json --buildName "CategoryA-Build"
@@ -1171,7 +1171,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          npm install @lambdatest/smartui-cli@4.1.54-beta.0
+          npm install @lambdatest/smartui-cli@latest
           npm install playwright@1.57.0
           npx playwright install
 

--- a/docs/hyperexecute-smart-ui-sdk-maestro.md
+++ b/docs/hyperexecute-smart-ui-sdk-maestro.md
@@ -116,7 +116,7 @@ Now, let's set up the test suite to integrate with SmartUI.
 The SmartUI CLI is required to capture and upload screenshots. Install it in your project directory:
 
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::note

--- a/docs/hyperexecute-smart-ui-sdk-selenium-csharp.md
+++ b/docs/hyperexecute-smart-ui-sdk-selenium-csharp.md
@@ -227,7 +227,7 @@ cacheDirectories:
 pre:
   - dotnet clean
   - dotnet build
-  - npm install @lambdatest/smartui-cli
+  - npm install @lambdatest/smartui-cli@latest
   - dotnet restore
   - npx smartui config:create .smartui.json
 

--- a/docs/hyperexecute-smart-ui-sdk-selenium-javascript.md
+++ b/docs/hyperexecute-smart-ui-sdk-selenium-javascript.md
@@ -176,7 +176,7 @@ cacheDirectories:
   - node_modules
 
 pre:
-  - npm install @lambdatest/smartui-cli @lambdatest/selenium-driver selenium-webdriver
+  - npm install @lambdatest/smartui-cli@latest @lambdatest/selenium-driver selenium-webdriver
   - npx smartui config:create smartui-web.json
 
 post:
@@ -197,7 +197,7 @@ It is mandatory to mention these commands in the pre flag to download all the ne
 
 ```bash
 pre:
-  - npm install @lambdatest/smartui-cli @lambdatest/selenium-driver selenium-webdriver
+  - npm install @lambdatest/smartui-cli@latest @lambdatest/selenium-driver selenium-webdriver
   - npx smartui config:create smartui-web.json
 ```
 :::

--- a/docs/hyperexecute-smart-ui-sdk-using-cypress.md
+++ b/docs/hyperexecute-smart-ui-sdk-using-cypress.md
@@ -186,7 +186,7 @@ cacheDirectories:
   - cypressCache
 
 pre:
-  - npm install @lambdatest/smartui-cli @lambdatest/cypress-driver cypress@v13
+  - npm install @lambdatest/smartui-cli@latest @lambdatest/cypress-driver cypress@v13
   - npx smartui config:create smartui-web.json
 
 post:
@@ -207,7 +207,7 @@ It is mandatory to mention these commands in the pre flag to download all the ne
 
 ```bash
 pre:
-  - npm install @lambdatest/smartui-cli @lambdatest/cypress-driver cypress@v13
+  - npm install @lambdatest/smartui-cli@latest @lambdatest/cypress-driver cypress@v13
   - npx smartui config:create smartui-web.json
 ```
 :::

--- a/docs/hyperexecute-smart-ui-sdk-using-playwright.md
+++ b/docs/hyperexecute-smart-ui-sdk-using-playwright.md
@@ -170,7 +170,7 @@ env:
   PROJECT_TOKEN: "YOUR_PROJECT_TOKEN" #Enter your project token here
 
 pre:
-  - npm install @lambdatest/smartui-cli @lambdatest/playwright-driver playwright
+  - npm install @lambdatest/smartui-cli@latest @lambdatest/playwright-driver playwright
   - npx smartui config:create smartui-web.json
 
 post:
@@ -191,7 +191,7 @@ It is mandatory to mention these commands in the pre flag to download all the ne
 
 ```bash
 pre:
-  - npm install @lambdatest/smartui-cli @lambdatest/playwright-driver playwright
+  - npm install @lambdatest/smartui-cli@latest @lambdatest/playwright-driver playwright
   - npx smartui config:create smartui-web.json
 ```
 :::

--- a/docs/hyperexecute-smart-ui-sdk-using-puppeteer.md
+++ b/docs/hyperexecute-smart-ui-sdk-using-puppeteer.md
@@ -170,7 +170,7 @@ env:
   PROJECT_TOKEN: "YOUR_PROJECT_TOKEN" #Enter your project token here
 
 pre:
-  - npm install @lambdatest/smartui-cli @lambdatest/puppeteer-driver puppeteer
+  - npm install @lambdatest/smartui-cli@latest @lambdatest/puppeteer-driver puppeteer
   - npx smartui config:create smartui-web.json
 
 post:
@@ -191,7 +191,7 @@ It is mandatory to mention these commands in the pre flag to download all the ne
 
 ```bash
 pre:
-  - npm install @lambdatest/smartui-cli @lambdatest/puppeteer-driver puppeteer
+  - npm install @lambdatest/smartui-cli@latest @lambdatest/puppeteer-driver puppeteer
   - npx smartui config:create smartui-web.json
 ```
 :::

--- a/docs/smartui-cli-build-name.md
+++ b/docs/smartui-cli-build-name.md
@@ -69,12 +69,12 @@ If you haven't already installed SmartUI CLI, install it using npm:
 
 **Global Installation (Recommended):**
 ```bash
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 ```
 
 **Local Installation:**
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 ## Step 2: Configure your Project Token

--- a/docs/smartui-cli-complete-reference.md
+++ b/docs/smartui-cli-complete-reference.md
@@ -735,7 +735,7 @@ $env:LT_SDK_DEBUG="true"
 **Basic Static URL Capture**
 ```bash
 # 1. Install CLI
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 
 # 2. Set project token
 export PROJECT_TOKEN="123456#token"
@@ -833,7 +833,7 @@ npx smartui upload-pdf ./pdfs --markBaseline --buildName "PDF-Baseline"
   env:
     PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
   run: |
-    npm install -g @lambdatest/smartui-cli
+    npm install -g @lambdatest/smartui-cli@latest
     npx smartui exec --buildName "${{ github.sha }}" -- npm test
 ```
 **GitLab CI Example:**
@@ -842,7 +842,7 @@ test:
   variables:
     PROJECT_TOKEN: $PROJECT_TOKEN
   script:
-    - npm install -g @lambdatest/smartui-cli
+    - npm install -g @lambdatest/smartui-cli@latest
     - npx smartui exec --buildName "$CI_COMMIT_SHA" -- npm test
 ```
 </TabItem>

--- a/docs/smartui-cli-figma-app.md
+++ b/docs/smartui-cli-figma-app.md
@@ -116,7 +116,7 @@ Note down both the **project name** and the **project token**. You need the toke
 ### 2. Install SmartUI CLI
 
 ```bash
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 ```
 
 ---

--- a/docs/smartui-cli-figma-web.md
+++ b/docs/smartui-cli-figma-web.md
@@ -104,12 +104,12 @@ Install required NPM modules for `TestMu AI SmartUI CLI` globally or in your pro
 
 **Global Installation (Recommended):**
 ```bash
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 ```
 
 **Local Installation:**
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 ### **Step 2:** Create the design configuration file

--- a/docs/smartui-cli-figma.md
+++ b/docs/smartui-cli-figma.md
@@ -99,12 +99,12 @@ Install required NPM modules for `TestMu AI SmartUI CLI` globally or in your pro
 
 **Global Installation (Recommended):**
 ```bash
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 ```
 
 **Local Installation:**
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::note
@@ -348,7 +348,7 @@ If you are using the Continuous Integration (CI) pipeline for your application a
 steps:
   - name: Running SmartUI Figma CLI Tests
     - run: |
-       npm install @lambdatest/smartui-cli
+       npm install @lambdatest/smartui-cli@latest
        npx playwright install-deps
        npx smartui upload-figma designs.json
 ```
@@ -418,7 +418,7 @@ If you are using the Continuous Integration (CI) pipeline for your application a
 steps:
   - name: Running SmartUI Figma CLI Tests
     - run: |
-       npm install @lambdatest/smartui-cli
+       npm install @lambdatest/smartui-cli@latest
        npx playwright install-deps
        npx smartui upload-figma designs.json
 ```

--- a/docs/smartui-cli-upload.md
+++ b/docs/smartui-cli-upload.md
@@ -78,12 +78,12 @@ Install required NPM modules for `TestMu AI SmartUI CLI` globally or in your pro
 
 **Global Installation (Recommended):**
 ```bash
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 ```
 
 **Local Installation:**
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::note
@@ -163,7 +163,7 @@ If you are using the Continuous Integration (CI) pipeline for your application a
 steps:
   - name: Running SmartUI CLI Tests
     - run: |
-       npm install @lambdatest/smartui-cli
+       npm install @lambdatest/smartui-cli@latest
        npx playwright install-deps
        npx smartui upload <Directory Name> --removeExtensions
 ```

--- a/docs/smartui-cli.md
+++ b/docs/smartui-cli.md
@@ -86,12 +86,12 @@ Install required NPM modules for `TestMu AI SmartUI CLI` globally or in your pro
 
 **Global Installation (Recommended):**
 ```bash
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 ```
 
 **Local Installation:**
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::note
@@ -336,7 +336,7 @@ If you are using the Continuous Integration (CI) pipeline for your application a
 steps:
   - name: Running SmartUI CLI Tests
     - run: |
-       npm install -g @lambdatest/smartui-cli
+       npm install -g @lambdatest/smartui-cli@latest
        npx playwright install-deps
        smartui capture urls.json --config smartui-web.json
 ```

--- a/docs/smartui-cypress-sdk.md
+++ b/docs/smartui-cypress-sdk.md
@@ -92,7 +92,7 @@ cd smartui-cypress-sdk-sample
 1. Install required NPM modules for `TestMu AI SmartUI Cypress SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli @lambdatest/cypress-driver cypress@v13
+npm install @lambdatest/smartui-cli@latest @lambdatest/cypress-driver cypress@v13
 ```
 
 :::note

--- a/docs/smartui-gitlab-pr-checks-exec.md
+++ b/docs/smartui-gitlab-pr-checks-exec.md
@@ -125,7 +125,7 @@ visual_regression_tests:
   
   before_script:
     - npm ci
-    - npm install -g @lambdatest/smartui-cli
+    - npm install -g @lambdatest/smartui-cli@latest
   
   script:
     # Get GitLab project ID and commit SHA
@@ -182,7 +182,7 @@ visual_regression_tests:
   
   before_script:
     - mvn clean install -DskipTests
-    - npm install -g @lambdatest/smartui-cli
+    - npm install -g @lambdatest/smartui-cli@latest
   
   script:
     # Get GitLab project ID and commit SHA
@@ -234,7 +234,7 @@ visual_regression_tests:
   
   before_script:
     - pip install -r requirements.txt
-    - npm install -g @lambdatest/smartui-cli
+    - npm install -g @lambdatest/smartui-cli@latest
   
   script:
     # Get GitLab project ID and commit SHA
@@ -287,7 +287,7 @@ visual_regression_tests:
   
   before_script:
     - bundle install
-    - npm install -g @lambdatest/smartui-cli
+    - npm install -g @lambdatest/smartui-cli@latest
   
   script:
     # Get GitLab project ID and commit SHA
@@ -429,7 +429,7 @@ visual_regression_tests:
   
   before_script:
     - npm ci
-    - npm install -g @lambdatest/smartui-cli
+    - npm install -g @lambdatest/smartui-cli@latest
   
   script:
     - |
@@ -475,7 +475,7 @@ visual_regression_tests:
   
   before_script:
     - mvn clean install -DskipTests
-    - npm install -g @lambdatest/smartui-cli
+    - npm install -g @lambdatest/smartui-cli@latest
   
   script:
     - |
@@ -523,7 +523,7 @@ visual_regression_tests:
   
   before_script:
     - npm ci
-    - npm install -g @lambdatest/smartui-cli
+    - npm install -g @lambdatest/smartui-cli@latest
   
   script:
     - |
@@ -570,7 +570,7 @@ visual_regression_tests:
   
   before_script:
     - mvn clean install -DskipTests
-    - npm install -g @lambdatest/smartui-cli
+    - npm install -g @lambdatest/smartui-cli@latest
   
   script:
     - |
@@ -643,7 +643,7 @@ visual_regression_tests:
 **Symptoms**: `npx smartui exec` command fails or doesn't run tests.
 
 **Solutions**:
-1. Verify SmartUI CLI is installed: `npm install -g @lambdatest/smartui-cli`
+1. Verify SmartUI CLI is installed: `npm install -g @lambdatest/smartui-cli@latest`
 2. Check that `PROJECT_TOKEN` environment variable is set
 3. Verify `.smartui.json` configuration file exists and is valid
 4. Ensure test command after `--` is correct

--- a/docs/smartui-k6-setup.md
+++ b/docs/smartui-k6-setup.md
@@ -93,7 +93,7 @@ cd smartui-k6-sample
 2. Install the required dependencies:
 
 ```bash
-npm install @lambdatest/smartui-cli @lambdatest/k6-driver
+npm install @lambdatest/smartui-cli@latest @lambdatest/k6-driver
 ```
 
 3. Install k6 by referring to the installation guide `https://k6.io/docs/get-started/installation/`:
@@ -355,7 +355,7 @@ smartuiSnapshot(response, "Page-Loaded");
 **Solutions**:
 1. Install required dependencies:
    ```bash
-   npm install @lambdatest/smartui-cli @lambdatest/k6-driver
+   npm install @lambdatest/smartui-cli@latest @lambdatest/k6-driver
    ```
 
 2. Set PROJECT_TOKEN environment variable:

--- a/docs/smartui-pdf-cli-upload.md
+++ b/docs/smartui-pdf-cli-upload.md
@@ -78,7 +78,7 @@ projectToken = "123456#1234abcd-****-****-****-************"
 Install the CLI globally using npm:
 
 ```bash
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 ```
 
 ## Step 2: Setup your credentials
@@ -323,7 +323,7 @@ smartui upload-pdf ./pdfs/ --buildName Release-v1.0-$(date +%Y%m%d)"
 **Solutions**:
 1. Install SmartUI CLI:
    ```bash
-   npm install -g @lambdatest/smartui-cli
+   npm install -g @lambdatest/smartui-cli@latest
    ```
 
 2. Verify npm is available:

--- a/docs/smartui-playwright-java-sdk.md
+++ b/docs/smartui-playwright-java-sdk.md
@@ -92,7 +92,7 @@ Download or Clone the code sample for the Java from the <BrandName /> GitHub rep
 Update your dependencies in `pom.xml` file Install required modules for <BrandName /> SmartUI SDK in your frontend project.
 
 ```bash
-npm install @lambdatest/smartui-cli @lambdatest/playwright-driver playwright
+npm install @lambdatest/smartui-cli@latest @lambdatest/playwright-driver playwright
 mvn clean compile
 ```
 

--- a/docs/smartui-playwright-python-sdk.md
+++ b/docs/smartui-playwright-python-sdk.md
@@ -107,7 +107,7 @@ source venv/bin/activate
 Install required NPM modules for `TestMu AI SmartUI Playwright Python SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::note

--- a/docs/smartui-playwright-sdk.md
+++ b/docs/smartui-playwright-sdk.md
@@ -90,7 +90,7 @@ cd smartui-playwright-sample/sdk
 Install required NPM modules for `TestMu AI SmartUI Playwright SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli @lambdatest/playwright-driver playwright
+npm install @lambdatest/smartui-cli@latest @lambdatest/playwright-driver playwright
 ```
 
 :::note

--- a/docs/smartui-puppeteer-sdk.md
+++ b/docs/smartui-puppeteer-sdk.md
@@ -92,7 +92,7 @@ cd smartui-puppeteer-sample/sdk
 Install required NPM modules for `TestMu AI SmartUI Puppeteer SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli @lambdatest/puppeteer-driver puppeteer
+npm install @lambdatest/smartui-cli@latest @lambdatest/puppeteer-driver puppeteer
 ```
 
 :::note

--- a/docs/smartui-running-your-first-project.md
+++ b/docs/smartui-running-your-first-project.md
@@ -98,7 +98,7 @@ You can check the latest version of [lambdatest-java-sdk]( https://mvnrepository
 - Install your CLI and required modules for running SmartUI SDK and compile your defined dependencies in the `pom.xml` file:
 
 ```zsh
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 mvn clean compile
 ```
 

--- a/docs/smartui-sdk-fetch-results.md
+++ b/docs/smartui-sdk-fetch-results.md
@@ -75,12 +75,12 @@ If you haven't already installed SmartUI CLI, install it using npm:
 
 **Global Installation (Recommended):**
 ```bash
-npm install -g @lambdatest/smartui-cli
+npm install -g @lambdatest/smartui-cli@latest
 ```
 
 **Local Installation:**
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 ### **Step 2:** Configure your Project Token

--- a/docs/smartui-selenium-csharp-sdk.md
+++ b/docs/smartui-selenium-csharp-sdk.md
@@ -106,7 +106,7 @@ You can check the latest version of [<BrandName />.Selenium.Driver]( https://www
 Install required NPM modules for `TestMu AI SmartUI Selenium SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::note

--- a/docs/smartui-selenium-java-sdk.md
+++ b/docs/smartui-selenium-java-sdk.md
@@ -107,7 +107,7 @@ You can check the latest version of [lambdatest-java-sdk]( https://mvnrepository
 Install required NPM modules for `TestMu AI SmartUI Selenium SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::note

--- a/docs/smartui-selenium-js-sdk.md
+++ b/docs/smartui-selenium-js-sdk.md
@@ -92,7 +92,7 @@ cd smartui-node-sample/sdk
 Install required NPM modules for `TestMu AI SmartUI Selenium SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli @lambdatest/selenium-driver selenium-webdriver
+npm install @lambdatest/smartui-cli@latest @lambdatest/selenium-driver selenium-webdriver
 ```
 
 :::note

--- a/docs/smartui-selenium-python-sdk.md
+++ b/docs/smartui-selenium-python-sdk.md
@@ -109,7 +109,7 @@ source venv/bin/activate
 Install required NPM modules for `TestMu AI SmartUI Selenium SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::note

--- a/docs/smartui-selenium-ruby-sdk.md
+++ b/docs/smartui-selenium-ruby-sdk.md
@@ -92,7 +92,7 @@ cd smartui-ruby-selenium-sample/sdk
 Install required NPM modules for `TestMu AI SmartUI Selenium SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli
+npm install @lambdatest/smartui-cli@latest
 ```
 
 :::note

--- a/docs/smartui-testcafe-sdk.md
+++ b/docs/smartui-testcafe-sdk.md
@@ -92,7 +92,7 @@ cd smartui-testcafe-sample
 Install required NPM modules for `LambdaTest SmartUI Testcafe SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli @lambdatest/testcafe-driver testcafe
+npm install @lambdatest/smartui-cli@latest @lambdatest/testcafe-driver testcafe
 ```
 
 :::note

--- a/docs/smartui-troubleshooting-guide.md
+++ b/docs/smartui-troubleshooting-guide.md
@@ -267,7 +267,7 @@ Before diving into specific issues, run through this quick checklist:
    - Requires administrator/sudo privileges
    - Best for: Single user, consistent environment
 ```bash
-   npm install -g @lambdatest/smartui-cli
+   npm install -g @lambdatest/smartui-cli@latest
    ```
    **Local Installation (without `-g`)**:
    - Installs CLI in project's `node_modules`
@@ -275,7 +275,7 @@ Before diving into specific issues, run through this quick checklist:
    - No admin privileges needed
    - Best for: Project-specific versions, CI/CD pipelines
 ```bash
-   npm install @lambdatest/smartui-cli
+   npm install @lambdatest/smartui-cli@latest
    npx smartui --version
    ```
 2. **Installing Latest Versions**:

--- a/docs/smartui-wdio-sdk.md
+++ b/docs/smartui-wdio-sdk.md
@@ -91,7 +91,7 @@ cd smartui-wdio-sample
 Install required NPM modules for `LambdaTest SmartUI WebdriverIO SDK` in your **Frontend** project.
 
 ```bash
-npm install @lambdatest/smartui-cli @lambdatest/wdio-driver webdriverio wdio-lambdatest-service
+npm install @lambdatest/smartui-cli@latest @lambdatest/wdio-driver webdriverio wdio-lambdatest-service
 ```
 
 :::note

--- a/docs/smartui-with-azure.md
+++ b/docs/smartui-with-azure.md
@@ -96,7 +96,7 @@ jobs:
 
   - script: |
       echo "Installing dependencies"
-      npm install @lambdatest/smartui-cli
+      npm install @lambdatest/smartui-cli@latest
     displayName: 'Install Dependencies'
 
   - script: |
@@ -368,7 +368,7 @@ variables:
 3. Install SmartUI CLI explicitly:
    ```yaml
    - script: |
-       npm install -g @lambdatest/smartui-cli
+       npm install -g @lambdatest/smartui-cli@latest
    ```
 
 **Getting Help**

--- a/docs/smartui-with-bitbucket.md
+++ b/docs/smartui-with-bitbucket.md
@@ -330,7 +330,7 @@ variables:
 3. Install SmartUI CLI explicitly:
    ```yaml
    script:
-     - npm install -g @lambdatest/smartui-cli
+     - npm install -g @lambdatest/smartui-cli@latest
    ```
 
 **Getting Help**

--- a/docs/smartui-with-buildkite.md
+++ b/docs/smartui-with-buildkite.md
@@ -90,7 +90,7 @@ steps:
       - git clone <REPO_URL>
       - cd <PROJECT_DIRECTORY>
       - echo "Installing SmartUI CLI"
-      - npm install @lambdatest/smartui-cli
+      - npm install @lambdatest/smartui-cli@latest
       - echo "Running SmartUI tests"
       - npx smartui --version
       - npx smartui config:create smartui-web.json
@@ -350,7 +350,7 @@ env:
 3. Install SmartUI CLI explicitly:
    ```yaml
    commands:
-     - npm install -g @lambdatest/smartui-cli
+     - npm install -g @lambdatest/smartui-cli@latest
    ```
 
 **Getting Help**

--- a/docs/smartui-with-circle-ci.md
+++ b/docs/smartui-with-circle-ci.md
@@ -90,7 +90,7 @@ jobs:
       - checkout
       - run:
           name: Install Dependencies
-          command: npm install @lambdatest/smartui-cli
+          command: npm install @lambdatest/smartui-cli@latest
       - run:
           name: Execute SmartUI Tests
           command: |
@@ -374,7 +374,7 @@ environment:
    ```yaml
    - run:
        name: Install SmartUI CLI
-       command: npm install -g @lambdatest/smartui-cli
+       command: npm install -g @lambdatest/smartui-cli@latest
    ```
 
 **Getting Help**

--- a/docs/smartui-with-github-actions.md
+++ b/docs/smartui-with-github-actions.md
@@ -338,7 +338,7 @@ on:
 
 3. Install SmartUI CLI explicitly:
    ```yaml
-   - run: npm install -g @lambdatest/smartui-cli
+   - run: npm install -g @lambdatest/smartui-cli@latest
    ```
 
 **Getting Help**

--- a/docs/smartui-with-gitlab.md
+++ b/docs/smartui-with-gitlab.md
@@ -331,7 +331,7 @@ variables:
 3. Install SmartUI CLI explicitly:
    ```yaml
    before_script:
-     - npm install -g @lambdatest/smartui-cli
+     - npm install -g @lambdatest/smartui-cli@latest
    ```
 
 **Getting Help**

--- a/docs/smartui-with-semaphore.md
+++ b/docs/smartui-with-semaphore.md
@@ -338,7 +338,7 @@ env_vars:
 3. Install SmartUI CLI explicitly:
    ```yaml
    commands:
-     - npm install -g @lambdatest/smartui-cli
+     - npm install -g @lambdatest/smartui-cli@latest
    ```
 
 **Getting Help**

--- a/docs/smartui-with-travis-ci.md
+++ b/docs/smartui-with-travis-ci.md
@@ -89,7 +89,7 @@ env:
 
 script:
   - echo "Installing SmartUI CLI"
-  - npm install @lambdatest/smartui-cli
+  - npm install @lambdatest/smartui-cli@latest
   - echo "Running SmartUI tests"
   - npx smartui --version
   - npx smartui config:create smartui-web.json
@@ -347,7 +347,7 @@ env:
 3. Install SmartUI CLI explicitly:
    ```yaml
    before_script:
-     - npm install -g @lambdatest/smartui-cli
+     - npm install -g @lambdatest/smartui-cli@latest
    ```
 
 **Getting Help**


### PR DESCRIPTION
## Summary

Part of [TE-22391](https://lambdatest.atlassian.net/browse/TE-22391).

Tags every SmartUI CLI install command in the docs with `@latest`, and removes a stale prerelease pin that was handing users a CLI 23 minor versions behind.

## Changes

**1. `@latest` on all install commands (70 occurrences, 39 files: 33 `docs/smartui-*` + 6 `docs/hyperexecute-*`)**

Includes `smartui-selenium-java-sdk.md:110`, the page named on the ticket. After this change all 86 install commands across the docs read `npm install [-g] @lambdatest/smartui-cli@latest`.

**2. Removed the `4.1.54-beta.0` pin (7 occurrences, 1 file: the 7th `docs/hyperexecute-*` file)**

`hyperexecute-smart-ui-capture-onboarding.md` instructed users to install `@lambdatest/smartui-cli@4.1.54-beta.0` and presented it as the recommended install. Current stable is **4.1.77**, so every reader of that page was pinned to an old prerelease.

I verified the pin is no longer needed before removing it. `capture` is a registered command in the stable 4.1.77 package:

```
$ npm pack @lambdatest/smartui-cli@4.1.77
$ grep -oE "name\(['\"][a-zA-Z:_-]+['\"]\)" package/dist/index.cjs | sort -u
branch, build, capture, config:create, config:create-figma, ...
```

## Scope note

The diff is 77 changed lines across 40 files, and every changed line is an install command inside a fenced code block. No prose, links, frontmatter, or sidebar entries were touched.

## Important caveat on impact

`@latest` here is a documentation improvement, not a functional fix. `npm install <package>` with no version specifier already resolves to the `latest` dist-tag, so item 1 above installs exactly what it installed before:

```
npm i @lambdatest/smartui-cli           ->  add @lambdatest/smartui-cli 4.1.77
npm i @lambdatest/smartui-cli@latest    ->  add @lambdatest/smartui-cli 4.1.77
```

Item 2, the beta pin, is a real fix.

The actual cause of users landing on an outdated CLI is the dependency manifests in the sample repositories, where caret ranges capped below major 4 and stale committed lockfiles were resolving to CLI 2.x and 3.x. That is addressed in 19 companion PRs across the sample repos, also under TE-22391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5pDePdJgs3Ms7qpjKc4kU


[TE-22391]: https://lambdatest.atlassian.net/browse/TE-22391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
