### PR TITLE
docs(smartui): Layout Regions for web and PDF comparisons (TE-20611)

### DIFF
--- a/docs/smartui-draw-on-ui.md
+++ b/docs/smartui-draw-on-ui.md
@@ -58,7 +58,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 Web applications often have dynamic elements that can cause unnecessary noise in your visual testing. Take a social media platform, for instance. The number of unread notifications displayed might change with each test run. While these variations are expected, you don't necessarily want them to trigger alerts as potential regressions.
 
-The SmartUI Annotation tool allows you to interact directly with your screenshots through detailed annotations. You can draw over screenshots, define regions with boxes, and choose to ignore or select these regions for current and future comparisons. With advanced features like **Ignore Colors**, **Floating Regions**, and **Select Ignore**, you can handle even the most complex dynamic content scenarios.
+The SmartUI Annotation tool allows you to interact directly with your screenshots through detailed annotations. You can draw over screenshots, define regions with boxes, and choose to ignore or select these regions for current and future comparisons. With advanced features like **Ignore Colors**, **Floating Regions**, **Layout Regions**, and **Select Ignore**, you can handle even the most complex dynamic content scenarios.
 
 By utilizing ignored/selected regions, you can keep your test results focused on the truly important changes, streamlining your workflow and saving you time from chasing irrelevant discrepancies.
 
@@ -83,7 +83,7 @@ By utilizing ignored/selected regions, you can keep your test results focused on
 
 1. **Click the annotation icon** to open the annotation tool
 2. **Click "Add Region"** and draw a box around the area you want to annotate
-3. **Select the annotation type** (Ignore Region, Select Region, Floating Region, or Ignore Colors)
+3. **Select the annotation type** (Ignore Region, Select Region, Floating Region, Ignore Colors, or Layout Region)
 4. **Click "Save"** to apply the annotation
 5. **Choose application scope**: Apply to current screenshot only or all browser variants
 
@@ -91,7 +91,7 @@ By utilizing ignored/selected regions, you can keep your test results focused on
 
 ## Annotation Methods
 
-All four annotation methods are accessible from the same **Actions** button (annotation icon). Click on the annotation icon to open the annotation tool, then select your desired annotation type from the available options.
+All annotation methods are accessible from the same **Actions** button (annotation icon). Click on the annotation icon to open the annotation tool, then select your desired annotation type from the available options.
 
 <Tabs className='docs__val' groupId='annotation-methods'>
 <TabItem value='ignore-region' label='Ignore Region' default>
@@ -249,6 +249,43 @@ Testing a notification badge that may appear in different positions based on con
 Ignoring color differences in a themed navigation bar while testing its structure and layout across different theme configurations.
 
 </TabItem>
+
+<TabItem value='layout-region' label='Layout Region'>
+
+**What is Layout Region?**
+
+**Layout Region** compares a single area for structure only. Inside the region SmartUI reports elements that were added, removed, or moved, while text, values, and colors inside those elements are not compared. Everything outside the region keeps the build's normal comparison mode.
+
+This sits between Ignore Region, which drops the area from validation completely, and [Layout Comparison](/support/docs/smartui-layout-testing/), which applies structure-only matching to the whole capture.
+
+**When to Use**
+
+- Validating that a section with live data still has its rows, cards, or columns intact
+- Regulated PDF documents where timestamps and generated IDs change every run but the structure must stay fixed
+- Localized pages where translated text varies in length and the surrounding structure has to hold
+- Any area you are ignoring today only because the content is noisy, when you still want to know if it breaks
+
+**How to Use**
+
+**Step 1:** Click on the **Actions** button (annotation icon) to open the annotation tool.
+
+**Step 2:** Click on the **Add Region** button and draw a box around the section whose structure you want to validate.
+
+**Step 3:** Select **Layout Region** from the annotation type dropdown and click **Save**.
+
+**Step 4:** Choose whether to apply to the current screenshot only or all browser variants.
+
+**What Happens:** Inside the region only structural differences are highlighted, and content churn is suppressed. Outside the region the comparison is unchanged.
+
+> **Note:** The Layout Region option is available for web captures and PDF comparisons. It is not offered for real device tests, app SDK tests, Storybook projects, Figma projects, or single image uploads through the API.
+
+**Example**
+
+Validating that an order summary table still has all of its rows and columns, while the order numbers and timestamps inside it change on every run.
+
+See [Layout Regions](/support/docs/smartui-layout-regions/) for how the matching works and what it does not catch.
+
+</TabItem>
 </Tabs>
 
 ## Advanced: Select Ignore
@@ -376,10 +413,11 @@ To propagate more than one region, select each region and choose **Apply to all 
 
 When viewing annotations, different colors indicate their type:
 - **Red boxes:** Ignore regions
-- **Green boxes:** Select regions
+- **Grey boxes:** Select regions
 - **Blue boxes:** Floating area boundaries
 - **Yellow boxes:** Elements within floating regions
-- **Purple boxes:** Ignore colors regions
+- **Light blue boxes:** Ignore colors regions
+- **Green boxes:** Layout regions
 
 ## Keyboard Shortcuts
 
@@ -404,6 +442,7 @@ Follow these best practices to get the most out of the annotation tool:
 - **Use Select Region** when you only care about specific UI components
 - **Use Floating Region** for elements that move within a boundary
 - **Use Ignore Colors** when structure matters more than color variations
+- **Use Layout Region** when the content in a section is expected to change but its structure must stay intact
 - **Use Select Ignore** for granular control within larger components
 
 ### General Guidelines
@@ -480,6 +519,20 @@ Follow these best practices to get the most out of the annotation tool:
 - Verify you're viewing the correct screenshot variant
 
 </TabItem>
+
+<TabItem value='layout-region-not-flagging' label='Layout Region Not Flagging Changes'>
+
+**Layout Region Not Flagging Changes**
+
+**Issue:** Content changed inside a layout region and nothing was reported.
+
+**Solutions:**
+- This is expected for content only changes. A layout region reports elements that were added, removed, or moved, not text or value changes
+- Verify the region covers the elements you expect. An element belongs to the region when its center falls inside the box
+- Reduce very large regions. A region drawn over an element heavy page falls back to plain ignore behavior
+- See [Layout Regions](/support/docs/smartui-layout-regions/) for the full behavior and limitations
+
+</TabItem>
 </Tabs>
 
 For more comprehensive troubleshooting, refer to the [SmartUI Troubleshooting Guide](/support/docs/smartui-troubleshooting-guide).
@@ -487,6 +540,7 @@ For more comprehensive troubleshooting, refer to the [SmartUI Troubleshooting Gu
 
 ## Additional Resources
 
+- [Layout Regions](/support/docs/smartui-layout-regions/) - Compare a single area for structure only
 - [SmartUI Project Settings](/support/docs/smartui-project-settings) - Configure comparison settings
 - [Handling Dynamic Data](/support/docs/smartui-handle-dynamic-data) - Code-based solutions for dynamic content
 - [Smart Ignore](/support/docs/smartui-smartignore) - Automatic layout shift handling

--- a/docs/smartui-draw-on-ui.md
+++ b/docs/smartui-draw-on-ui.md
@@ -279,6 +279,8 @@ This sits between Ignore Region, which drops the area from validation completely
 
 > **Note:** The Layout Region option is available for web captures and PDF comparisons. It is not offered for real device tests, app SDK tests, Storybook projects, Figma projects, or single image uploads through the API.
 
+> **Important:** On **web** comparisons this works only when the DOM was recorded at capture time. SmartUI CLI and SDK captures record it automatically. Captures taken inside an automation session need DOM recording enabled for your organization, and builds made from an uploaded image never carry a DOM. When it is missing the region quietly behaves like an Ignore Region. See [DOM Recording Requirement](/support/docs/smartui-layout-regions/#dom-recording-requirement-for-web-comparisons). PDF comparisons are not affected.
+
 **Example**
 
 Validating that an order summary table still has all of its rows and columns, while the order numbers and timestamps inside it change on every run.
@@ -528,6 +530,7 @@ Follow these best practices to get the most out of the annotation tool:
 
 **Solutions:**
 - This is expected for content only changes. A layout region reports elements that were added, removed, or moved, not text or value changes
+- On a web comparison, confirm the DOM was recorded for the build. Without it the region can only behave like an ignore region. See [DOM Recording Requirement](/support/docs/smartui-layout-regions/#dom-recording-requirement-for-web-comparisons)
 - Verify the region covers the elements you expect. An element belongs to the region when its center falls inside the box
 - Reduce very large regions. A region drawn over an element heavy page falls back to plain ignore behavior
 - See [Layout Regions](/support/docs/smartui-layout-regions/) for the full behavior and limitations

--- a/docs/smartui-layout-comparison.md
+++ b/docs/smartui-layout-comparison.md
@@ -152,6 +152,12 @@ If you are using the SmartUI SDK (`smartui exec`), you need to set the `ignoreTy
   </TabItem>
 </Tabs>
 
+## Applying Layout Comparison to One Region Only
+
+Layout comparison as described above applies to the entire capture, so content and color regressions anywhere on the page stop being reported. When only part of the page has dynamic content, draw a **Layout Region** on that area in the SmartUI dashboard instead. Inside the region SmartUI reports structural changes only, and the rest of the capture keeps its normal comparison mode.
+
+Layout Regions work for both web captures and PDF comparisons, and they persist across builds like any other annotated region. See [Layout Regions](/support/docs/smartui-layout-regions/) for the full workflow.
+
 ## Known Limitations
 
 The Layout Comparison feature has the following limitations:

--- a/docs/smartui-layout-comparison.md
+++ b/docs/smartui-layout-comparison.md
@@ -156,7 +156,7 @@ If you are using the SmartUI SDK (`smartui exec`), you need to set the `ignoreTy
 
 Layout comparison as described above applies to the entire capture, so content and color regressions anywhere on the page stop being reported. When only part of the page has dynamic content, draw a **Layout Region** on that area in the SmartUI dashboard instead. Inside the region SmartUI reports structural changes only, and the rest of the capture keeps its normal comparison mode.
 
-Layout Regions work for both web captures and PDF comparisons, and they persist across builds like any other annotated region. See [Layout Regions](/support/docs/smartui-layout-regions/) for the full workflow.
+Layout Regions work for both web captures and PDF comparisons, and they persist across builds like any other annotated region. For web comparisons they need the DOM to have been recorded at capture time, which SmartUI CLI and SDK captures do automatically. See [Layout Regions](/support/docs/smartui-layout-regions/) for the full workflow.
 
 ## Known Limitations
 

--- a/docs/smartui-layout-regions.md
+++ b/docs/smartui-layout-regions.md
@@ -1,0 +1,210 @@
+---
+id: smartui-layout-regions
+title: Layout Regions in SmartUI
+hide_title: true
+sidebar_label: Layout Regions
+description: Learn how to draw a Layout Region in the SmartUI annotation tool so a single area of a web page or PDF is compared for structure only, while the rest of the capture keeps its normal comparison mode.
+keywords:
+  - Layout Region
+  - Layout Regions
+  - Visual Regression
+  - Visual Regression Testing Guide
+  - Annotation Tool
+  - Ignore Regions
+  - Select Regions
+  - Floating Regions
+  - Ignore Colors
+  - Layout Comparison
+  - Structural Comparison
+  - PDF Visual Testing
+  - Dynamic Content
+
+url: https://www.testmuai.com/support/docs/smartui-layout-regions/
+site_name: TestMu AI
+slug: smartui-layout-regions/
+canonical: https://www.testmuai.com/support/docs/smartui-layout-regions/
+
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import NewTag from '../src/component/newTag';
+import CodeBlock from '@theme/CodeBlock';
+import {YOUR_LAMBDATEST_USERNAME, YOUR_LAMBDATEST_ACCESS_KEY} from "@site/src/component/keys";
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "TestMu AI",
+          "item": BRAND_URL
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": `${BRAND_URL}/support/docs/`
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Smart Visual Testing",
+          "item": `${BRAND_URL}/support/docs/smartui-layout-regions/`
+        }]
+      })
+    }}
+></script>
+
+# Layout Regions <NewTag value="New" />
+
+A **Layout Region** is an annotation you draw on a capture to compare that one area for **structure only**. Inside the region SmartUI checks whether elements were added, removed, or moved. Changes to the content inside those elements, such as text, values, and colors, do not raise a difference. Everything outside the region continues to use the build's normal comparison mode.
+
+This gives you a middle ground that the existing options do not cover:
+
+- [Layout Comparison](/support/docs/smartui-layout-testing/) applies structure-only matching to the **whole** capture, so genuine content and color regressions elsewhere on the page stop being reported.
+- An [Ignore Region](/support/docs/smartui-draw-on-ui/) removes the area from validation **entirely**, so a section that disappears or collapses is never flagged.
+- A Layout Region keeps the section under validation, checks that its structure is intact, and tolerates the content churn inside it.
+
+## When to Use
+
+- Regulated or generated documents where timestamps, run IDs, and batch values change on every run but the document structure must stay fixed
+- Dashboards, feeds, and listings whose rows and cards carry live data while the arrangement is expected to hold
+- Localized pages where translated strings vary in length and the surrounding structure has to survive
+- Any section you are currently ignoring purely because the content is noisy, when you still want to know if the section breaks or disappears
+
+## Comparing the Region Types
+
+| Region type | Structure checked | Content checked | Colors checked | Typical use |
+| --- | --- | --- | --- | --- |
+| Ignore Region | No | No | No | Fully dynamic areas you do not need validated |
+| Select Region | Yes | Yes | Yes | Restrict the comparison to a critical component |
+| Ignore Colors | Yes | Yes | No | Themed or A/B tested areas |
+| Floating Region | Yes | Yes | Yes | Elements that shift position inside a boundary |
+| **Layout Region** | **Yes** | **No** | **No** | **Dynamic content in a section whose structure must hold** |
+
+## How to Use
+
+**Step 1:** Open a screenshot comparison in your SmartUI project and click the **Actions** button (annotation icon) to open the annotation tool.
+
+**Step 2:** Click **Add Region** and draw a box around the section whose structure you want to validate.
+
+**Step 3:** Select **Layout Region** from the annotation type dropdown.
+
+**Step 4:** Click **Save**, then choose whether the region applies to the current screenshot only or to all browser variants.
+
+**What Happens:** The comparison re-runs. Inside the region SmartUI reports only structural changes. Outside the region the comparison is unchanged. Layout Regions persist to later builds for the same screenshot exactly like Ignore Regions do, and they appear in the annotation overlay in **green**.
+
+:::note
+You can draw more than one Layout Region on a capture, and you can mix Layout Regions with Ignore, Select, Floating, and Ignore Colors regions on the same screenshot. For PDF comparisons, regions are drawn per page.
+:::
+
+## How It Works
+
+SmartUI does not read pixels inside a Layout Region. It compares a structural description of the region taken from the baseline against the same description taken from the comparison capture, then highlights only the elements that do not line up.
+
+<Tabs className='docs__val' groupId='layout-region-mode'>
+<TabItem value='web' label='Web comparisons' default>
+
+For web captures, SmartUI uses the DOM element data recorded alongside each screenshot.
+
+1. Elements whose center point falls inside the region are collected from the baseline capture and from the comparison capture.
+2. Each pair is scored on DOM path, classes, applied styles, element id, size, and tag name. Pairs above the match threshold are treated as the same element and are not reported.
+3. Elements left without a match on the other side are highlighted as structural differences. An element present in the baseline but missing in the comparison is highlighted on the baseline, and the reverse case is highlighted on the comparison.
+4. Elements that drifted slightly outside the box are still considered for matching, so a small shift across the edge does not produce a false difference. Highlights themselves stay inside the region you drew.
+5. Page level wrapper containers that merely overlap the region are excluded, so the region reports the elements you framed rather than the layout of the whole page.
+
+Because the match is structural, a text or value change inside an element that is otherwise unchanged does not raise a difference. That is the intended behavior of the region.
+
+</TabItem>
+
+<TabItem value='pdf' label='PDF comparisons'>
+
+For PDF comparisons, SmartUI extracts the text lines and table cells on the page and matches them between the baseline document and the comparison document within the region you drew.
+
+1. Lines and table structures inside the region are extracted from both documents for the page you are viewing.
+2. Matched entries are treated as unchanged.
+3. Lines or cells present on only one side are highlighted as structural differences on that side.
+
+A value that changes inside an otherwise matching cell is not reported, which is what lets generated identifiers and timestamps pass while a missing row or a shifted table is still caught.
+
+</TabItem>
+</Tabs>
+
+## Where the Option Is Available
+
+The **Layout Region** option appears in the region dropdown for web captures and PDF comparisons. It is not offered for:
+
+- Real device web and app tests
+- Espresso and XCUI tests
+- App SDK tests
+- Storybook projects
+- Figma projects
+- Single image uploads through the API
+
+For these test types the dropdown shows the Ignore, Select, Floating, and Ignore Colors options only.
+
+## Behavior Notes and Limitations
+
+- **Content changes are not reported inside the region.** If you need value changes flagged, a Layout Region is the wrong tool for that area. Use the normal comparison, or scope it with a [Select Region](/support/docs/smartui-draw-on-ui/).
+- **Select and Ignore regions win.** If a Layout Region overlaps an Ignore Region, the ignored area stays ignored. If Select Regions are in use, anything outside them is still excluded.
+- **Structural data has to exist for both captures.** If the element data for a web capture is missing or cannot be read, the region falls back to behaving like a plain Ignore Region and the comparison still completes. Nothing fails.
+- **Very dense regions fall back too.** A region drawn over an extremely large number of elements is skipped rather than analyzed, and behaves like an Ignore Region for that build. Draw the region around the section you care about rather than the whole page.
+- **Highlights count towards the mismatch percentage.** Structural differences found inside a Layout Region are treated as differences in the build result, the same as any other highlighted change.
+- **Region scope works as it does everywhere else.** A Layout Region belongs to the screenshot variant you drew it on until you choose [Apply to all variants](/support/docs/smartui-draw-on-ui/#applying-annotations).
+
+## Troubleshooting
+
+<Tabs className='docs__val' groupId='layout-region-troubleshooting'>
+<TabItem value='option-missing' label='Layout Region Not in the Dropdown' default>
+
+**Issue:** The annotation type dropdown does not list **Layout Region**.
+
+**Solutions:**
+- Confirm the test type supports it. See [Where the Option Is Available](#where-the-option-is-available).
+- Make sure you are on a screenshot comparison view and not on a build listing.
+- Refresh the page so the annotation tool reloads with the current screenshot's test type.
+
+</TabItem>
+
+<TabItem value='nothing-flagged' label='Nothing Is Flagged Inside the Region'>
+
+**Issue:** Content clearly changed inside the region and no difference is reported.
+
+**Solutions:**
+- This is expected when only the content changed. A Layout Region reports elements that were added, removed, or moved, not text or value changes.
+- If the section did change structurally, check that the region actually covers the elements. An element is considered part of the region when its center falls inside the box.
+- If you need the content validated, use the normal comparison for that area instead.
+
+</TabItem>
+
+<TabItem value='behaves-like-ignore' label='The Region Behaves Like an Ignore Region'>
+
+**Issue:** The region suppresses everything and never reports a structural change.
+
+**Solutions:**
+- The region falls back to ignore behavior when the structural data for the capture is unavailable. Re-run the build so the capture is recorded again.
+- Reduce the size of the region. Very large regions over element heavy pages are skipped and fall back to ignore behavior.
+- For PDF comparisons, confirm you are annotating the page that actually contains the section.
+
+</TabItem>
+
+<TabItem value='too-many-highlights' label='Too Many Highlights Inside the Region'>
+
+**Issue:** The region highlights far more elements than expected.
+
+**Solutions:**
+- Tighten the region so it frames one section rather than a large part of the page.
+- Check whether the section really was rebuilt between the two captures. A container that is re-rendered with a different structure legitimately produces many unmatched elements.
+- If the area is genuinely rebuilt on every run and you do not need it validated, an Ignore Region is the better fit.
+
+</TabItem>
+</Tabs>
+
+## Additional Resources
+
+- [Ignore or Select Annotated Regions](/support/docs/smartui-draw-on-ui/) - All annotation types in the SmartUI dashboard
+- [Layout Comparison in SmartUI SDK](/support/docs/smartui-layout-testing/) - Apply structure-only comparison to a whole capture
+- [Handling Dynamic Data](/support/docs/smartui-handle-dynamic-data/) - Code based options for dynamic content
+- [Smart Ignore](/support/docs/smartui-smartignore/) - Automatic layout shift handling
+- [SmartUI Troubleshooting Guide](/support/docs/smartui-troubleshooting-guide/) - Comprehensive issue resolution

--- a/docs/smartui-layout-regions.md
+++ b/docs/smartui-layout-regions.md
@@ -85,6 +85,14 @@ This gives you a middle ground that the existing options do not cover:
 
 ## How to Use
 
+### Prerequisites
+
+:::info
+For **web** comparisons, a Layout Region works only when the DOM was recorded at capture time. SmartUI compares the recorded structure of the two captures, so a build that carries a screenshot image alone has nothing to analyze. See [DOM Recording Requirement](#dom-recording-requirement-for-web-comparisons) for which capture flows record it.
+
+**PDF** comparisons are not affected. They read the structure out of the document itself, so no DOM is involved.
+:::
+
 **Step 1:** Open a screenshot comparison in your SmartUI project and click the **Actions** button (annotation icon) to open the annotation tool.
 
 **Step 2:** Click **Add Region** and draw a box around the section whose structure you want to validate.
@@ -106,7 +114,7 @@ SmartUI does not read pixels inside a Layout Region. It compares a structural de
 <Tabs className='docs__val' groupId='layout-region-mode'>
 <TabItem value='web' label='Web comparisons' default>
 
-For web captures, SmartUI uses the DOM element data recorded alongside each screenshot.
+For web captures, SmartUI uses the DOM element data recorded alongside each screenshot. This requires the capture flow to have recorded the DOM, as described in [DOM Recording Requirement](#dom-recording-requirement-for-web-comparisons).
 
 1. Elements whose center point falls inside the region are collected from the baseline capture and from the comparison capture.
 2. Each pair is scored on DOM path, classes, applied styles, element id, size, and tag name. Pairs above the match threshold are treated as the same element and are not reported.
@@ -131,6 +139,24 @@ A value that changes inside an otherwise matching cell is not reported, which is
 </TabItem>
 </Tabs>
 
+## DOM Recording Requirement for Web Comparisons
+
+The structural analysis behind a web Layout Region reads the DOM that was recorded alongside each screenshot. That recording happens at capture time, not at comparison time, so it cannot be added to a build after the fact. If a build was captured without it, drawing a Layout Region on that build gives you plain ignore behavior instead of structural analysis.
+
+| Capture flow | DOM recorded | Layout Region behavior |
+| --- | --- | --- |
+| SmartUI CLI and SDK web captures | Yes, on every snapshot | Full structural analysis |
+| SmartUI in test automation, using Lambda Hooks or full page automation captures | Only when DOM recording is enabled for your organization | Structural analysis once enabled, plain ignore until then |
+| Screenshot API uploads and static image uploads | No | Plain ignore |
+| Real device web and app captures | No | Option not offered |
+| PDF comparisons | Not applicable | Full structural analysis from the document |
+
+DOM recording is on by default for SmartUI CLI and SDK web captures, because those flows capture the page structure and render it on the TestMu AI cloud. It is **not** on by default for captures taken inside an automation session. If you are running SmartUI through Lambda Hooks or through your automation suite and want Layout Regions to analyze structure, contact [support](mailto:support@testmuai.com) to have DOM recording enabled for your organization.
+
+:::warning
+When the DOM was not recorded, the region does not fail or error. It quietly behaves like an [Ignore Region](/support/docs/smartui-draw-on-ui/), which means the area stops being validated at all. If you drew a Layout Region and it never reports anything, check the capture flow first.
+:::
+
 ## Where the Option Is Available
 
 The **Layout Region** option appears in the region dropdown for web captures and PDF comparisons. It is not offered for:
@@ -148,7 +174,7 @@ For these test types the dropdown shows the Ignore, Select, Floating, and Ignore
 
 - **Content changes are not reported inside the region.** If you need value changes flagged, a Layout Region is the wrong tool for that area. Use the normal comparison, or scope it with a [Select Region](/support/docs/smartui-draw-on-ui/).
 - **Select and Ignore regions win.** If a Layout Region overlaps an Ignore Region, the ignored area stays ignored. If Select Regions are in use, anything outside them is still excluded.
-- **Structural data has to exist for both captures.** If the element data for a web capture is missing or cannot be read, the region falls back to behaving like a plain Ignore Region and the comparison still completes. Nothing fails.
+- **The DOM has to have been recorded for both captures.** A web Layout Region cannot analyze a build that carries only a screenshot image. See [DOM Recording Requirement](#dom-recording-requirement-for-web-comparisons). If the recorded data is missing or cannot be read, the region falls back to behaving like a plain Ignore Region and the comparison still completes. Nothing fails.
 - **Very dense regions fall back too.** A region drawn over an extremely large number of elements is skipped rather than analyzed, and behaves like an Ignore Region for that build. Draw the region around the section you care about rather than the whole page.
 - **Highlights count towards the mismatch percentage.** Structural differences found inside a Layout Region are treated as differences in the build result, the same as any other highlighted change.
 - **Region scope works as it does everywhere else.** A Layout Region belongs to the screenshot variant you drew it on until you choose [Apply to all variants](/support/docs/smartui-draw-on-ui/#applying-annotations).
@@ -183,9 +209,11 @@ For these test types the dropdown shows the Ignore, Select, Floating, and Ignore
 **Issue:** The region suppresses everything and never reports a structural change.
 
 **Solutions:**
-- The region falls back to ignore behavior when the structural data for the capture is unavailable. Re-run the build so the capture is recorded again.
-- Reduce the size of the region. Very large regions over element heavy pages are skipped and fall back to ignore behavior.
-- For PDF comparisons, confirm you are annotating the page that actually contains the section.
+- Check the capture flow first. On a web comparison the region falls back to ignore behavior whenever the DOM was not recorded for the build. See [DOM Recording Requirement](#dom-recording-requirement-for-web-comparisons)
+- If the build came from an automation session, DOM recording may not be enabled for your organization yet. Contact [support](mailto:support@testmuai.com) to have it enabled, then re-run the build
+- Builds created from an uploaded image never carry a DOM, so a Layout Region on them can only behave like an Ignore Region
+- Reduce the size of the region. Very large regions over element heavy pages are skipped and fall back to ignore behavior
+- For PDF comparisons, confirm you are annotating the page that actually contains the section
 
 </TabItem>
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -2984,6 +2984,11 @@ module.exports = {
           },
           {
             type: "doc",
+            label: "Layout Regions",
+            id: "smartui-layout-regions",
+          },
+          {
+            type: "doc",
             label: "customCSS",
             id: "smartui-custom-css",
           },


### PR DESCRIPTION
Documents the **Layout Region** annotation type shipped in [TE-20611](https://lambdatest.atlassian.net/browse/TE-20611) / `smartui-comparison-service#309`.

A Layout Region is a box you draw on a capture that is compared for **structure only**. Inside the region SmartUI reports elements that were added, removed, or moved, and content churn such as text, values, and colours is suppressed. Everything outside the region keeps the build's normal comparison mode. It fills the gap between global Layout Comparison (all or nothing for the whole capture) and an Ignore Region (validates nothing).

## What changed

**New page** `docs/smartui-layout-regions.md` (slug `smartui-layout-regions/`)
- What a Layout Region is and how it differs from Layout Comparison and from an Ignore Region
- Comparison table across all five region types
- Dashboard workflow
- How matching works, in two tabs: web captures match DOM element data between the baseline and the comparison, PDF comparisons match extracted text lines and table structures
- Where the option is available, and the test types where it is not offered
- Behavior notes and limitations, including the fall back to plain ignore behavior when structural data is unavailable
- Troubleshooting

**`docs/smartui-draw-on-ui.md`**
- Layout Region added as a fifth tab under Annotation Methods
- Basic Workflow step, Best Practices entry, Annotation Color Coding entry, a Troubleshooting tab, and a link under Additional Resources

**`docs/smartui-layout-comparison.md`**
- New section pointing readers at per-region scoping when only part of the page is dynamic

**`sidebars.js`**
- Layout Regions entry added after Draw on UI in the SmartUI Core Features group

## Note on the colour coding list

The Annotation Color Coding list had two entries that no longer match the dashboard. Select regions render grey and ignore colors regions render light blue, not green and purple. Both are corrected here so the list stays consistent with the new green Layout Region entry.

## Verification

- Production `npm run build` equivalent completes with exit 0 and no broken links
- Dev server compiles clean, new page and updated tabs checked in the browser
- `sidebars.js` parses and the new id resolves in the VisualRegressionTestingSidebar tree
- All internal links are site relative and resolve in `.docusaurus/routes.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHr81wFBFJYbZ8sYBMxF3R

[TE-20611]: https://lambdatest.atlassian.net/browse/TE-20611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ