### PR TITLE
docs(home): point Kane CLI cards on the docs home page to the Mintlify site

### DIFF
--- a/src/pages/docs.js
+++ b/src/pages/docs.js
@@ -179,14 +179,14 @@ export default function Home() {
           <div className="home_inners_box">
             <h2 className="homeMain_h2"><Icon light="Realtime-light-icon.svg" dark="Realtime-dark-icon.svg" alt="" />Kane CLI &nbsp;<NewTag value="NEW" /></h2>
             <div className="home_inners">
-              <a href="/support/docs/kane-cli-introduction/"><p className="p_home_inners">Getting Started</p></a>
-              <a href="/support/docs/kane-cli-installation/"><p className="p_home_inners">Installation</p></a>
-              <a href="/support/docs/kane-cli-quickstart/"><p className="p_home_inners">Quick Start</p></a>
-              <a href="/support/docs/kane-cli-writing-objectives/"><p className="p_home_inners">Writing Objectives</p></a>
-              <a href="/support/docs/kane-cli-generate/"><p className="p_home_inners">Generate Test Cases</p></a>
-              <a href="/support/docs/kane-cli-checkpoints/"><p className="p_home_inners">Checkpoints</p></a>
-              <a href="/support/docs/kane-cli-agent-mode/"><p className="p_home_inners">Agent Mode</p></a>
-              <a href="/support/docs/kane-cli-cli-reference/"><p className="p_home_inners">CLI Reference</p></a>
+              <a href="/docs/kane-cli-introduction"><p className="p_home_inners">Getting Started</p></a>
+              <a href="/docs/kane-cli-installation"><p className="p_home_inners">Installation</p></a>
+              <a href="/docs/kane-cli-quickstart"><p className="p_home_inners">Quick Start</p></a>
+              <a href="/docs/kane-cli-writing-objectives"><p className="p_home_inners">Writing Objectives</p></a>
+              <a href="/docs/kane-cli-generate"><p className="p_home_inners">Generate Test Cases</p></a>
+              <a href="/docs/kane-cli-checkpoints"><p className="p_home_inners">Checkpoints</p></a>
+              <a href="/docs/kane-cli-agent-mode"><p className="p_home_inners">Agent Mode</p></a>
+              <a href="/docs/kane-cli-cli-reference"><p className="p_home_inners">CLI Reference</p></a>
             </div>
           </div>
           <div className="home_inners_box">


### PR DESCRIPTION
### What

Repoints all eight **Kane CLI** cards in the product grid on the docs home page (`src/pages/docs.js`) from `/support/docs/<slug>/` to `/docs/<slug>`.

### Why

Kane CLI documentation is served by the **Mintlify** stack at `/docs/`, not by Docusaurus at `/support/docs/`. The home page still linked to the Docusaurus copies, so anyone clicking a Kane CLI card landed on the wrong stack.

### Changes

| Card | Before | After |
| --- | --- | --- |
| Getting Started | `/support/docs/kane-cli-introduction/` | `/docs/kane-cli-introduction` |
| Installation | `/support/docs/kane-cli-installation/` | `/docs/kane-cli-installation` |
| Quick Start | `/support/docs/kane-cli-quickstart/` | `/docs/kane-cli-quickstart` |
| Writing Objectives | `/support/docs/kane-cli-writing-objectives/` | `/docs/kane-cli-writing-objectives` |
| Generate Test Cases | `/support/docs/kane-cli-generate/` | `/docs/kane-cli-generate` |
| Checkpoints | `/support/docs/kane-cli-checkpoints/` | `/docs/kane-cli-checkpoints` |
| Agent Mode | `/support/docs/kane-cli-agent-mode/` | `/docs/kane-cli-agent-mode` |
| CLI Reference | `/support/docs/kane-cli-cli-reference/` | `/docs/kane-cli-cli-reference` |

No trailing slash, which is the canonical form on the Mintlify site. Only the Kane CLI card changed — the other 105 `/support/docs/` links on the page are untouched.

### Testing

Verified on a local Docusaurus dev server (`:3001`); the compiled home page renders all eight hrefs as `/docs/kane-cli-*`.

Live status of the targets on `www.testmuai.com`: seven of eight return **200**.

### ⚠️ One follow-up needed

`/docs/kane-cli-introduction` currently returns **404** in production. On `stage-mintlify` the Kane CLI introduction is `docs/index.mdx` with `slug: /`, so it is served at `/docs` — there is no `kane-cli-introduction` page on that stack.

The **Getting Started** card will not resolve until either that page is added on the Mintlify side or a redirect `/docs/kane-cli-introduction` → `/docs` is configured. Happy to raise that separately.
