### PR TITLE
docs(kane-cli): code export supports javascript, not python only (Mintlify parity)

### DIFF
--- a/docs/kane-cli-cli-reference.mdx
+++ b/docs/kane-cli-cli-reference.mdx
@@ -49,7 +49,7 @@ kane-cli run "<objective>" [options]
 | `--agent` | Output structured NDJSON (for AI coding agents) | Off |
 | `--mode <name>` | Run mode: `action` (strict) or `testing` (lenient) | Config value, otherwise `testing` |
 | `--code-export` | Generate code export after run uploads | Off |
-| `--code-language <lang>` | Code export language (currently `python`) | `python` |
+| `--code-language <lang>` | Code export language: `python` or `javascript` | `python` |
 | `--skip-code-validation` | Skip post-codegen worker-side validation | On |
 | `--no-skip-code-validation` | Force post-codegen worker-side validation | Off |
 | `--username <user>` | Basic auth username (overrides stored profile) | N/A |

--- a/docs/kane-cli-configuration.mdx
+++ b/docs/kane-cli-configuration.mdx
@@ -68,7 +68,7 @@ Empty fields are shown as `(none)`. The `chrome` path is empty by default, in wh
 | `folder_name` | string \| null | `null` | Display name of the selected folder | Set by `kane-cli config folder` |
 | `mode` | `"action"` \| `"testing"` | `"testing"` | Agent behaviour on auth walls, blocked pages, or error pages. | `kane-cli config set-mode <action\|testing>` |
 | `code_export.enabled` | boolean | `false` | Generate code export after upload completes. | TUI menu, or `--code-export` flag |
-| `code_export.language` | `"python"` | `"python"` | Output language for generated code. Only `python` is supported. | `--code-language <lang>` |
+| `code_export.language` | `"python"` \| `"javascript"` | `"python"` | Output language for generated code. Accepts `python` or `javascript`. | `--code-language <lang>` |
 | `code_export.skip_validation` | boolean | `true` | Skip post-codegen worker-side validation. | TUI menu, or `--skip-code-validation` |
 
 ---
@@ -140,7 +140,7 @@ The `code_export` block enables and configures generated code output produced af
 - **The TUI** — open the config menu, choose Code Export, and toggle the `enabled` and `skip_validation` switches.
 - **Per-run flags** on `kane-cli run`:
   - `--code-export` to enable for this run only
-  - `--code-language <lang>` to pick the output language (only `python` is supported)
+  - `--code-language <lang>` to pick the output language (`python` or `javascript`)
   - `--skip-code-validation` / `--no-skip-code-validation` to control post-codegen validation
 
 Code export requires a Test Manager upload, so it is only meaningful when a project is configured. See [Test Manager Integration](/docs/kane-cli-tms-integration/) for the full upload pipeline.

--- a/docs/kane-cli-tms-integration.mdx
+++ b/docs/kane-cli-tms-integration.mdx
@@ -82,7 +82,7 @@ Code export converts a completed test case into runnable Playwright code that yo
 
 ### What It Produces
 
-Currently the only supported language is **Python with Playwright**. Code export runs server-side after the test case is finalised. Kane CLI polls Test Manager until generation is complete, then downloads the resulting files.
+The supported languages are **Python with Playwright** and **JavaScript with Playwright**. Code export runs server-side after the test case is finalised. Kane CLI polls Test Manager until generation is complete, then downloads the resulting files.
 
 ### Enabling Code Export
 
@@ -109,7 +109,7 @@ kane-cli run "Add an item to the cart" \
   --skip-code-validation
 ```
 
-`--no-skip-code-validation` forces validation on for that run. `--code-language` only accepts `python`.
+`--no-skip-code-validation` forces validation on for that run. `--code-language` accepts `python` or `javascript`.
 
 ### Where to Find the Output
 


### PR DESCRIPTION
Mintlify parity for #3302, which made this same correction on the Docusaurus side (already merged and live).

Three Kane CLI pages claimed `--code-language` only accepts `python`. It also accepts `javascript`.

## Why

Kane CLI 0.6.7 reports:

```
--code-language <lang>       Code export language: python (default) | javascript
```

The TUI Code Export menu lists both `python` and `javascript`. `kane-cli-testmd.mdx` already documented both, so the Mintlify docs contradicted each other and the product.

## What changed

| Page | Was | Now |
|---|---|---|
| CLI Reference | "Code export language (currently `python`)" | "Code export language: `python` or `javascript`" |
| Configuration | "Only `python` is supported." | "Accepts `python` or `javascript`." plus the type column now shows both |
| Configuration | run flags: "(only `python` is supported)" | "(`python` or `javascript`)" |
| Test Manager Integration | "`--code-language` only accepts `python`." | "accepts `python` or `javascript`." |
| Test Manager Integration | "Currently the only supported language is **Python with Playwright**." | "The supported languages are **Python with Playwright** and **JavaScript with Playwright**." |

Defaults are untouched, `python` remains the default everywhere, including the `--code-language python` example on the Test Manager Integration page.

Three files here versus six in #3302: `static/docs/` is a Docusaurus build artifact and does not exist on this branch. `kane-cli-testmd.mdx` needed no change, it was already correct.

## Verification

Repo-wide grep confirms no python-only claim remains on `stage-mintlify`. All three pages render correctly on a local `mint dev` preview:

- The `code_export.language` row parses into exactly five cells with `"python" | "javascript"` intact, the escaped pipe does not split the column.
- The Test Manager Integration sentence renders both languages as separate bold elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
