### PR TITLE
Sync kane cli docs from testmuCom (MDX format)

### DIFF
--- a/docs/kane-cli-generate.mdx
+++ b/docs/kane-cli-generate.mdx
@@ -81,7 +81,7 @@ kane-cli generate "test the login flow described in the attached spec" --files .
 
 The files are sent along with your description and reflected in the generated scenarios and cases: attach a spec, a screenshot of the UI, a PDF or Word document, or a CSV of inputs.
 
-- **Supported types**: documents (`.txt`, `.json`, `.xml`, `.csv`, `.pdf`, `.docx`, `.xlsx`), images (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.webp`), audio (`.mp3`, `.wav`, `.m4a`), and video (`.mp4`, `.mov`, `.webm`, `.mpeg`, `.mpga`).
+- **Supported types**: documents (`.txt`, `.md`, `.json`, `.xml`, `.csv`, `.pdf`, `.docx`, `.xlsx`), images (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.webp`), audio (`.mp3`, `.wav`, `.m4a`), and video (`.mp4`, `.mov`, `.webm`, `.mpeg`, `.mpga`).
 - **Limits**: up to **10 files**, each **50 MB** or smaller.
 - **Checked before anything is sent**: all paths are validated as a set. If any is missing, an unsupported type, too large, or over the count, the command stops and lists the offending paths so nothing is uploaded by mistake. Files outside the current directory are allowed but flagged with a warning.
 - **Not with `--save`**: files attach to a generation or refine, not a save (`--files` with `--save` is rejected).


### PR DESCRIPTION
## Summary

Scheduled parity check of Kane CLI docs on `testmuCom` vs `stage-mintlify`. One real content drift found and ported to MDX:

- **`docs/kane-cli-generate.mdx`** — the `--files` attachment "Supported types" list was missing `.md` from the documents group. `testmuCom` commit `6ddf5391` ("docs: add .md attachment support to Test Case Generator and Kane-CLI") added it to `docs/kane-cli-generate.md`; this brings the Mintlify page to parity.

## Method

- Diffed commits unique to `testmuCom` (not reachable from `stage-mintlify`) touching `docs/kane-cli-*.md`.
- Of the candidate commits, `73aa2a91` (code-language javascript support) was already ported via #3328, and `a1b0ba62` was a history-divergence artifact with no real content delta once formatting (frontmatter, imports, admonitions) is normalized.
- Only `6ddf5391` introduced an un-ported content change, confirmed by direct diff of current file content on both branches.

## Test plan

- [ ] `mint validate` / local preview renders the updated line correctly on `kane-cli-generate.mdx`

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjDspD6ZRjNFb9uwsD5Bbk)_