### PR TITLE
Sync kane cli docs from testmuCom (MDX format)

### DIFF
--- a/docs/kane-cli-generate.mdx
+++ b/docs/kane-cli-generate.mdx
@@ -81,7 +81,7 @@ kane-cli generate "test the login flow described in the attached spec" --files .
 
 The files are sent along with your description and reflected in the generated scenarios and cases: attach a spec, a screenshot of the UI, a PDF or Word document, or a CSV of inputs.
 
-- **Supported types**: documents (`.txt`, `.json`, `.xml`, `.csv`, `.pdf`, `.docx`, `.xlsx`), images (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.webp`), audio (`.mp3`, `.wav`, `.m4a`), and video (`.mp4`, `.mov`, `.webm`, `.mpeg`, `.mpga`).
+- **Supported types**: documents (`.txt`, `.md`, `.json`, `.xml`, `.csv`, `.pdf`, `.docx`, `.xlsx`), images (`.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.webp`), audio (`.mp3`, `.wav`, `.m4a`), and video (`.mp4`, `.mov`, `.webm`, `.mpeg`, `.mpga`).
 - **Limits**: up to **10 files**, each **50 MB** or smaller.
 - **Checked before anything is sent**: all paths are validated as a set. If any is missing, an unsupported type, too large, or over the count, the command stops and lists the offending paths so nothing is uploaded by mistake. Files outside the current directory are allowed but flagged with a warning.
 - **Not with `--save`**: files attach to a generation or refine, not a save (`--files` with `--save` is rejected).


### PR DESCRIPTION
## Summary

- Compared all `docs/kane-cli-*.md` pages in `testmuCom` against their `docs/kane-cli-*.mdx` counterparts in `stage-mintlify` to find content that hasn't been ported over yet.
- Found one real content gap: `docs/kane-cli-generate.mdx` was missing `.md` from the list of supported file types for the Test Case Generator's `--files` flag. This was added to `testmuCom` in commit `6ddf5391` ("add .md attachment support to Test Case Generator and Kane-CLI") but never carried over to the Mintlify docs.
- All other kane-cli docs were checked and are already in sync (differences were limited to expected Docusaurus vs. Mintlify frontmatter/component syntax, not content).

## Test plan

- [x] Diffed testmuCom `docs/kane-cli-*.md` against stage-mintlify `docs/kane-cli-*.mdx`, normalizing away frontmatter/import/component syntax differences, to confirm this is the only unsynced content change.
- [ ] Reviewer to confirm the supported file types list renders correctly on the Mintlify preview.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMtie7gpjb3rx3mxrvn9ch)_