### PR TITLE
fix(docs): correct broken Python SmartUI hook samples and unclosed code fence in Appium docs

### DIFF
--- a/docs/smartui-appium-hooks.md
+++ b/docs/smartui-appium-hooks.md
@@ -348,7 +348,7 @@ ignoreBoxes.put("xpath", new String[]{
 });
 
 configIgnore.put("ignoreBoxes", ignoreBoxes);
-((JavaScriptExecutor) driver).executeScript("smartui.takeScreenshot", configIgnore);
+((JavascriptExecutor) driver).executeScript("smartui.takeScreenshot", configIgnore);
 
 ```
 </TabItem>
@@ -415,7 +415,7 @@ driver.execute("smartui.takeScreenshot=<Name of your screenshot>");
 </TabItem><TabItem value='python-1' label='Python' default>
 
 ```python
-driver.execute("smartui.takeScreenshot=<Your Screenshot Name>")
+driver.execute_script("smartui.takeScreenshot=<Your Screenshot Name>")
 ```
 
 </TabItem>
@@ -436,7 +436,7 @@ driver.Execute("smartui.takeScreenshot=<Your Screenshot Name>");
 <TabItem value='java-1' label='Java' default>
 
 ```java
-((JavaScriptExecutor)driver).executeScript("smartui.takeScreenshot=<Your Screenshot Name>");
+((JavascriptExecutor)driver).executeScript("smartui.takeScreenshot=<Your Screenshot Name>");
 ```
 
 </TabItem>
@@ -468,7 +468,10 @@ config = {
   'fullPage': True,
   'pageCount': 15 # Enter the number of pages for the Full Page screenshot (Minimum 1, Maximum 20)
 }
-driver.execute("smartui.takeScreenshot", config)
+driver.execute_script("smartui.takeScreenshot", config)
+```
+
+</TabItem>
 <TabItem value='ruby-2' label='Ruby' default>
 
 ```ruby
@@ -500,7 +503,7 @@ Map<String, Object> config = new HashMap<>();
 config.put("screenshotName", "<Your Screenshot Name>");
 config.put("fullPage", true);
 config.put("pageCount", 15); // Enter the number of pages for the Full Page screenshot (Minimum 1, Maximum 20)
-((JavaScriptExecutor)driver).executeScript("smartui.takeScreenshot", config);
+((JavascriptExecutor)driver).executeScript("smartui.takeScreenshot", config);
 ```
 
 </TabItem>
@@ -564,15 +567,6 @@ await driver.execute("smartui.takeScreenshot=Screen Loaded");
 
 </TabItem>
 <TabItem value='test-organization' label='Test Organization'>
-
-**Test Organization**
-
-- Group related screenshots in the same build
-- Use meaningful build names
-- Run tests on consistent device configurations
-
-</TabItem>
-<TabItem value='test-organization-1' label='Test Organization'>
 
 **Test Organization**
 

--- a/docs/smartui-appium-sdk.md
+++ b/docs/smartui-appium-sdk.md
@@ -143,7 +143,7 @@ driver.execute("smartui.takeScreenshot=<Name of your screenshot>");
 <TabItem value='python' label='Python'>
 
 ```python
-driver.execute("smartui.takeScreenshot=<Your Screenshot Name>")
+driver.execute_script("smartui.takeScreenshot=<Your Screenshot Name>")
 ```
 
 </TabItem>
@@ -188,7 +188,7 @@ config = {
   'fullPage': True,
   'pageCount': 15  # Minimum 1, Maximum 20
 }
-driver.execute("smartui.takeScreenshot", config)
+driver.execute_script("smartui.takeScreenshot", config)
 ```
 
 </TabItem>


### PR DESCRIPTION
## Summary

The Python code samples for the SmartUI screenshot hook are broken. They tell users to call `driver.execute()`, which cannot work. Raised from **LTPM-3532**, where a customer asked whether SmartUI supports Pytest plus Appium on real devices and was told it was not supported. It is supported. These samples are the likely reason it appeared not to be.

## Why `driver.execute()` cannot work

In Appium-Python-Client, `driver.execute()` is the raw command dispatcher. It looks the command name up in a local registry, so an unregistered name fails on the developer's machine before a single request reaches the grid:

```
AssertionError: Unrecognised command smartui.takeScreenshot=repro-execute_legacy
```

The assertion is at `selenium/webdriver/remote/remote_connection.py:396`. No backend change can fix this. The correct call is `driver.execute_script()`.

This is Python-specific. The NodeJS samples are **correct as written** because WebdriverIO's `execute()` is `executeScript`. The Python, and likely the Ruby and C#, samples appear to have been copied from the NodeJS one without adjusting the method name.

## Verification

Run live against the LambdaTest real device cloud, not reasoned about:

| Dialect | Result |
| --- | --- |
| `driver.execute_script("smartui.takeScreenshot=<name>")` | works |
| `driver.execute_script("smartui.takeScreenshot", config)` | works |
| `driver.execute("smartui.takeScreenshot=<name>")` | **fails** |

Also verified working through `execute_script` on real devices: `fullPage` with `pageCount`, `ignoreBoxes`, and `fullPage` combined with `ignoreBoxes`. Covered Android (Galaxy S24/14, Pixel 8/14, Galaxy S23/13) and iOS (iPhone 14/16, iPhone 15/17). Screenshots landed in SmartUI and produced real baseline comparisons.

## Changes

1. **Four Python samples** in `smartui-appium-hooks.md` and `smartui-appium-sdk.md` switched from `driver.execute()` to `driver.execute_script()`.

2. **Unclosed code fence** in `smartui-appium-hooks.md`. The Python full page block was missing its closing fence and closing `</TabItem>`. This is worse than a single broken tab: it inverted fence polarity for the entire remainder of the page, so the Ruby tab was swallowed into the Python code block and the Best Practices section rendered incorrectly. Fence count for the file goes from 51 (odd, unbalanced) to 52.

3. **`JavaScriptExecutor` to `JavascriptExecutor`** in three Java samples. The former does not exist in Selenium and will not compile. The rest of the docs already use the correct casing in 121 places against 47 incorrect.

4. **Removed a duplicated "Test Organization" tab** under Best Practices, which appeared twice with identical content.

## Not changed, flagged for a follow-up

The Ruby and C# samples use the same `driver.execute()` / `driver.Execute()` pattern and are likely broken for the same reason. I did not test Ruby or C#, so I have not changed code I cannot verify. Worth a separate check by someone who can run those stacks.

## Testing

- Dev server compiles clean.
- Confirmed in the rendered DOM that the full page screenshot section now exposes all five language tabs including Ruby, which it did not before.
- No link changes, so no broken-link risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S1LdrsqkyAKy1XtsHRDvB7