### PR TITLE
docs: update data retention period from 60 days to 30 days

### DIFF
--- a/docs/data-retention-policy.md
+++ b/docs/data-retention-policy.md
@@ -47,7 +47,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 # Data Retention Policy
 * * *
 
-This page provides a comprehensive overview of how long your data is retained across all <BrandName /> products. Unless stated otherwise, the default retention period is **60 days** from the date of creation.
+This page provides a comprehensive overview of how long your data is retained across all <BrandName /> products. Unless stated otherwise, the default retention period is **30 days** from the date of creation.
 
 :::info Enterprise Retention
 Enterprise customers can request extended retention periods for most data types. Contact your account manager or [support@testmuai.com](mailto:support@testmuai.com) for details.
@@ -74,10 +74,10 @@ Enterprise customers can request extended retention periods for most data types.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Builds & Tests | 60 days | Build and test metadata, status, and execution data |
-| Videos | 60 days | Test session video recordings |
-| Logs | 60 days | Console, network, and command logs |
-| Screenshots | 60 days | Captured during test execution |
+| Builds & Tests | 30 days | Build and test metadata, status, and execution data |
+| Videos | 30 days | Test session video recordings |
+| Logs | 30 days | Console, network, and command logs |
+| Screenshots | 30 days | Captured during test execution |
 
 ---
 
@@ -85,10 +85,10 @@ Enterprise customers can request extended retention periods for most data types.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Builds & Tests | 60 days | Build and test metadata, status, and execution data |
-| Videos | 60 days | Test session video recordings |
-| Logs | 60 days | Console, network, and command logs |
-| Screenshots | 60 days | Captured during test execution |
+| Builds & Tests | 30 days | Build and test metadata, status, and execution data |
+| Videos | 30 days | Test session video recordings |
+| Logs | 30 days | Console, network, and command logs |
+| Screenshots | 30 days | Captured during test execution |
 
 ---
 
@@ -96,8 +96,8 @@ Enterprise customers can request extended retention periods for most data types.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Uploaded apps (APK/IPA) | 60 days | Apps uploaded for testing |
-| App Profiling data | 60 days | Performance profiling reports |
+| Uploaded apps (APK/IPA) | 30 days | Apps uploaded for testing |
+| App Profiling data | 30 days | Performance profiling reports |
 
 ---
 
@@ -105,7 +105,7 @@ Enterprise customers can request extended retention periods for most data types.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Uploaded apps (APK/IPA) | 60 days | Apps uploaded for manual testing |
+| Uploaded apps (APK/IPA) | 30 days | Apps uploaded for manual testing |
 
 ---
 
@@ -113,13 +113,13 @@ Enterprise customers can request extended retention periods for most data types.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Test execution logs & records | 60 days | Execution data and test results |
-| Test scripts | 60 days | Deleted permanently after retention period |
-| Job artifacts & reports | 60 days | Stored automatically after job completion |
-| Shareable links | 2-60 days | Configurable via `linkValidity` in YAML; default is 2 days |
+| Test execution logs & records | 30 days | Execution data and test results |
+| Test scripts | 30 days | Deleted permanently after retention period |
+| Job artifacts & reports | 30 days | Stored automatically after job completion |
+| Shareable links | 2-30 days | Configurable via `linkValidity` in YAML; default is 2 days |
 
 :::tip
-Use the `linkValidity` key in your HyperExecute YAML to set how long shareable artifact links remain active (2-60 days).
+Use the `linkValidity` key in your HyperExecute YAML to set how long shareable artifact links remain active (2-30 days).
 :::
 
 ---
@@ -131,7 +131,7 @@ Use the `linkValidity` key in your HyperExecute YAML to set how long shareable a
 | Projects / Builds | Retained until deleted | Stays active as long as the account is active |
 | Screenshots (baseline, compared, captured) | 1 year | Baseline, comparison, and captured screenshots |
 | Shareable links | Retained until build/project deleted | Linked to the lifecycle of the parent build/project |
-| Audit logs | 60 days | Dependent on internal log retention policies |
+| Audit logs | 30 days | Dependent on internal log retention policies |
 
 ---
 
@@ -145,7 +145,7 @@ Use the `linkValidity` key in your HyperExecute YAML to set how long shareable a
 | Insights | No retention limit | Retained as long as the account is active |
 
 :::note
-Test Manager entities (projects, test cases, test runs) have no retention limit. However, if a test case is linked to an automation run, the **linked automation data** inherits the retention policy of the corresponding automation product (e.g., Web Automation = 60 days).
+Test Manager entities (projects, test cases, test runs) have no retention limit. However, if a test case is linked to an automation run, the **linked automation data** inherits the retention policy of the corresponding automation product (e.g., Web Automation = 30 days).
 :::
 
 ---
@@ -165,8 +165,8 @@ Test Manager entities (projects, test cases, test runs) have no retention limit.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Automation scan reports (App/Web) | 60 days | Higher retention available on request for Enterprise |
-| Manual scan reports (App/Web) | 60 days | Higher retention available on request for Enterprise |
+| Automation scan reports (App/Web) | 30 days | Higher retention available on request for Enterprise |
+| Manual scan reports (App/Web) | 30 days | Higher retention available on request for Enterprise |
 
 ---
 
@@ -175,8 +175,8 @@ Test Manager entities (projects, test cases, test runs) have no retention limit.
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
 | Dashboards | No retention limit | User-created dashboards are retained indefinitely |
-| Build & Test Insights data | 60 days | Historical analytics data |
-| App Profiling reports | 60 days | Performance profiling data |
+| Build & Test Insights data | 30 days | Historical analytics data |
+| App Profiling reports | 30 days | Performance profiling data |
 | Shareable dashboard links | 7, 15, 30 days, or Never | Links set to "Never" require a password for access |
 
 ---
@@ -194,13 +194,13 @@ Test Manager entities (projects, test cases, test runs) have no retention limit.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Audit logs | 60 days | Enterprise customers can request higher retention |
+| Audit logs | 30 days | Enterprise customers can request higher retention |
 
 ---
 
 ## Key Points
 
-- **Default retention**: 60 days from the date of creation unless otherwise specified.
+- **Default retention**: 30 days from the date of creation unless otherwise specified.
 - **Permanent data**: Test Manager, KaneAI, and Analytics dashboards have no retention limit and are retained as long as your account is active.
 - **Extended retention**: SmartUI screenshots (1 year) and Web Scanner schedules (1 year) have longer retention periods.
 - **Enterprise flexibility**: Enterprise customers can negotiate custom retention periods for most data types.

--- a/static/docs/data-retention-policy.md
+++ b/static/docs/data-retention-policy.md
@@ -2,7 +2,7 @@
 
 > For the full site index for AI agents, see [llms.txt](https://www.testmuai.com/support/docs/llms.txt).
 
-This page provides a comprehensive overview of how long your data is retained across all TestMu AI products. Unless stated otherwise, the default retention period is **60 days** from the date of creation.
+This page provides a comprehensive overview of how long your data is retained across all TestMu AI products. Unless stated otherwise, the default retention period is **30 days** from the date of creation.
 
 **Enterprise Retention**
 Enterprise customers can request extended retention periods for most data types. Contact your account manager or [support@testmuai.com](mailto:support@testmuai.com) for details.
@@ -24,43 +24,43 @@ Enterprise customers can request extended retention periods for most data types.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Builds & Tests | 60 days | Build and test metadata, status, and execution data |
-| Videos | 60 days | Test session video recordings |
-| Logs | 60 days | Console, network, and command logs |
-| Screenshots | 60 days | Captured during test execution |
+| Builds & Tests | 30 days | Build and test metadata, status, and execution data |
+| Videos | 30 days | Test session video recordings |
+| Logs | 30 days | Console, network, and command logs |
+| Screenshots | 30 days | Captured during test execution |
 
 ## App Automation
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Builds & Tests | 60 days | Build and test metadata, status, and execution data |
-| Videos | 60 days | Test session video recordings |
-| Logs | 60 days | Console, network, and command logs |
-| Screenshots | 60 days | Captured during test execution |
+| Builds & Tests | 30 days | Build and test metadata, status, and execution data |
+| Videos | 30 days | Test session video recordings |
+| Logs | 30 days | Console, network, and command logs |
+| Screenshots | 30 days | Captured during test execution |
 
 ## Real Device Cloud
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Uploaded apps (APK/IPA) | 60 days | Apps uploaded for testing |
-| App Profiling data | 60 days | Performance profiling reports |
+| Uploaded apps (APK/IPA) | 30 days | Apps uploaded for testing |
+| App Profiling data | 30 days | Performance profiling reports |
 
 ## Real-Time Testing
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Uploaded apps (APK/IPA) | 60 days | Apps uploaded for manual testing |
+| Uploaded apps (APK/IPA) | 30 days | Apps uploaded for manual testing |
 
 ## HyperExecute
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Test execution logs & records | 60 days | Execution data and test results |
-| Test scripts | 60 days | Deleted permanently after retention period |
-| Job artifacts & reports | 60 days | Stored automatically after job completion |
-| Shareable links | 2-60 days | Configurable via `linkValidity` in YAML; default is 2 days |
+| Test execution logs & records | 30 days | Execution data and test results |
+| Test scripts | 30 days | Deleted permanently after retention period |
+| Job artifacts & reports | 30 days | Stored automatically after job completion |
+| Shareable links | 2-30 days | Configurable via `linkValidity` in YAML; default is 2 days |
 
-Use the `linkValidity` key in your HyperExecute YAML to set how long shareable artifact links remain active (2-60 days).
+Use the `linkValidity` key in your HyperExecute YAML to set how long shareable artifact links remain active (2-30 days).
 
 ## SmartUI
 
@@ -69,7 +69,7 @@ Use the `linkValidity` key in your HyperExecute YAML to set how long shareable a
 | Projects / Builds | Retained until deleted | Stays active as long as the account is active |
 | Screenshots (baseline, compared, captured) | 1 year | Baseline, comparison, and captured screenshots |
 | Shareable links | Retained until build/project deleted | Linked to the lifecycle of the parent build/project |
-| Audit logs | 60 days | Dependent on internal log retention policies |
+| Audit logs | 30 days | Dependent on internal log retention policies |
 
 ## Test Manager
 
@@ -80,7 +80,7 @@ Use the `linkValidity` key in your HyperExecute YAML to set how long shareable a
 | Test Runs | No retention limit | Retained as long as the account is active |
 | Insights | No retention limit | Retained as long as the account is active |
 
-Test Manager entities (projects, test cases, test runs) have no retention limit. However, if a test case is linked to an automation run, the **linked automation data** inherits the retention policy of the corresponding automation product (e.g., Web Automation = 60 days).
+Test Manager entities (projects, test cases, test runs) have no retention limit. However, if a test case is linked to an automation run, the **linked automation data** inherits the retention policy of the corresponding automation product (e.g., Web Automation = 30 days).
 
 ## KaneAI
 
@@ -95,16 +95,16 @@ Test Manager entities (projects, test cases, test runs) have no retention limit.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Automation scan reports (App/Web) | 60 days | Higher retention available on request for Enterprise |
-| Manual scan reports (App/Web) | 60 days | Higher retention available on request for Enterprise |
+| Automation scan reports (App/Web) | 30 days | Higher retention available on request for Enterprise |
+| Manual scan reports (App/Web) | 30 days | Higher retention available on request for Enterprise |
 
 ## Analytics / Insights
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
 | Dashboards | No retention limit | User-created dashboards are retained indefinitely |
-| Build & Test Insights data | 60 days | Historical analytics data |
-| App Profiling reports | 60 days | Performance profiling data |
+| Build & Test Insights data | 30 days | Historical analytics data |
+| App Profiling reports | 30 days | Performance profiling data |
 | Shareable dashboard links | 7, 15, 30 days, or Never | Links set to "Never" require a password for access |
 
 ## Web Scanner
@@ -118,11 +118,11 @@ Test Manager entities (projects, test cases, test runs) have no retention limit.
 
 | Data Type | Retention Period | Notes |
 |-----------|-----------------|-------|
-| Audit logs | 60 days | Enterprise customers can request higher retention |
+| Audit logs | 30 days | Enterprise customers can request higher retention |
 
 ## Key Points
 
-- **Default retention**: 60 days from the date of creation unless otherwise specified.
+- **Default retention**: 30 days from the date of creation unless otherwise specified.
 - **Permanent data**: Test Manager, KaneAI, and Analytics dashboards have no retention limit and are retained as long as your account is active.
 - **Extended retention**: SmartUI screenshots (1 year) and Web Scanner schedules (1 year) have longer retention periods.
 - **Enterprise flexibility**: Enterprise customers can negotiate custom retention periods for most data types.


### PR DESCRIPTION
Replace all 60-day retention references with 30 days across the Data Retention Policy page, including the default retention statement, all product tables, the HyperExecute linkValidity range (now 2-30 days), the Test Manager linked-data note, and the Key Points summary.