### PR TITLE
docs(kaneai): scope module editing and import restrictions to the Classic experience

### DIFF
--- a/docs/create-modules.md
+++ b/docs/create-modules.md
@@ -103,7 +103,7 @@ Modules support duplication, editing and versioning; however, a new version is o
 <img loading="lazy" src={require('../assets/images/mobile-app-testing/modules_page.png').default} alt="module-page" className="doc_img"/>
 
 :::note
-For modules authored in KaneAI, steps that use a variable or parameter and If-Else or While Loop blocks cannot be edited, deleted, or reordered from the Modules page. Edit them from the KaneAI test case the module was authored from.
+In the Classic experience, for modules authored in KaneAI, steps that use a variable or parameter and If-Else or While Loop blocks cannot be edited, deleted, or reordered from the Modules page. Edit them from the KaneAI test case the module was authored from.
 :::
 
 ## 3. Module Versions

--- a/docs/kane-ai-modules.md
+++ b/docs/kane-ai-modules.md
@@ -109,7 +109,7 @@ Type a **slash (/)** to invoke the command menu and select **Add Module**.
 Browse the list of available modules and select the one you need.
 
 :::note
-Modules that contain KaneAI instructions, such as variable steps, If-Else blocks, or While Loops, can be imported only into KaneAI test cases, not into manual test cases in Test Manager. See [Importing Modules into Test Cases](/support/docs/modules-in-manual-testcases/).
+Modules that contain KaneAI instructions, such as variable steps, If-Else blocks, or While Loops, can be imported only into KaneAI test cases, not into manual test cases in Test Manager. This applies to the Classic experience. See [Importing Modules into Test Cases](/support/docs/modules-in-manual-testcases/).
 :::
 
 <img loading="lazy" src={require('../assets/images/kane-ai/features/modules/6.png').default} alt="import-module" className="doc_img"/>
@@ -133,6 +133,10 @@ Editing a step opens it inline, where you can change the test step and its expec
 When you save changes to a module, a new version is created automatically. See [Versioning and Enhancements](/support/docs/kaneai-modules-versions-and-enhancement/) for details on how version history works.
 
 ### Editing Restrictions
+
+:::note
+The editing, reordering, and deletion restrictions described in this section and in [Deleting Steps Inside a Module](#deleting-steps-inside-a-module) apply to the Classic experience.
+:::
 
 Some steps carry a **Read-Only** label on the module's step listing. Editing, deleting, and reordering are all disabled for:
 

--- a/docs/kaneai-conditional-logic.md
+++ b/docs/kaneai-conditional-logic.md
@@ -180,7 +180,7 @@ To add a module inside a branch:
 
 - **Nested conditions are not supported.** You cannot place an If / Else‑If / Else block inside another conditional block.
 - **New conditional blocks cannot be created while a test is paused.** The **/** slash command menu and the **+ Add step** option do not offer **Add If-Else** in the Draft state. Conditional blocks that already exist in the test can still be extended while paused.
-- **Conditional blocks are read-only on the Modules page.** A module can contain a conditional block, but changes to it must be made in the KaneAI test case it was authored from. Modules containing conditional blocks cannot be added to manual test cases in Test Manager.
+- **Conditional blocks are read-only on the Modules page.** In the Classic experience, a module can contain a conditional block, but changes to it must be made in the KaneAI test case it was authored from. Modules containing conditional blocks cannot be added to manual test cases in Test Manager.
 
 ## FAQ
 

--- a/docs/kaneai-modules-versions-and-enhancement.md
+++ b/docs/kaneai-modules-versions-and-enhancement.md
@@ -57,7 +57,7 @@ For an overview of creating, using, and managing modules, see [Modules](/support
 
 When you edit an existing module (for example, by adding, removing, or modifying a test step), KaneAI automatically increments the version number (e.g., from 1.1 to 1.2). You do not need to manually create versions.
 
-Some steps are locked on the Modules page and must be changed from the test case the module was authored from. See [Editing Restrictions](/support/docs/kane-ai-modules/#editing-restrictions). Editing them there still increments the module version in the same way.
+In the Classic experience, some steps are locked on the Modules page and must be changed from the test case the module was authored from. See [Editing Restrictions](/support/docs/kane-ai-modules/#editing-restrictions). Editing them there still increments the module version in the same way.
 
 <img loading="lazy" src={require('../assets/images/kane-ai/knowledge-base/modules-versioning/image8.png').default} alt="version-increment" className="doc_img img_center"/>
 

--- a/docs/kaneai-while-loops.md
+++ b/docs/kaneai-while-loops.md
@@ -258,7 +258,7 @@ Once a While Loop has been finalized, you can still change it. The loop itself s
 - **Add, remove, or reorder body steps.** Use the edit instruction action on any step inside the loop; the loop updates automatically to reflect the change.
 - **Change the condition.** Edit the While Loop step directly. The new condition applies on the next test run.
 - **Finalize later.** If you closed the authoring view before clicking **End While**, the loop remains unfinalized. Re‑open the test, add the remaining body steps, and click **End While** when ready.
-- **Loops inside modules.** When a While Loop is part of a [module](/support/docs/kane-ai-modules/), any change to the loop condition or body creates a new module version. Other tests using that module stay on the version they already reference until they accept the new one. The loop is read-only on the module's Overview tab. Make changes from the test case the module was authored from. Modules containing While Loops cannot be added to manual test cases in Test Manager.
+- **Loops inside modules.** When a While Loop is part of a [module](/support/docs/kane-ai-modules/), any change to the loop condition or body creates a new module version. Other tests using that module stay on the version they already reference until they accept the new one. In the Classic experience, the loop is read-only on the module's Overview tab. Make changes from the test case the module was authored from, and modules containing While Loops cannot be added to manual test cases in Test Manager.
 
 ## Nesting Rules
 

--- a/docs/manual-test-case-creation.md
+++ b/docs/manual-test-case-creation.md
@@ -106,7 +106,7 @@ The Test Manager offers a comprehensive Steps section with a rich text editor an
 To know more about how to use Modules refer the [Modules doc](/support/docs/create-modules/).
 
 :::note
-Modules that contain KaneAI instructions, such as variable steps, If-Else blocks, or While Loops, run only in KaneAI test cases. Selecting one in the **Add Module** dialog leaves **Add in step** disabled. See [Importing Modules into Test Cases](/support/docs/modules-in-manual-testcases/).
+In the Classic experience, modules that contain KaneAI instructions, such as variable steps, If-Else blocks, or While Loops, run only in KaneAI test cases. Selecting one in the **Add Module** dialog leaves **Add in step** disabled. See [Importing Modules into Test Cases](/support/docs/modules-in-manual-testcases/).
 :::
 
 #### Add New Step:

--- a/docs/modules-in-manual-testcases.md
+++ b/docs/modules-in-manual-testcases.md
@@ -57,7 +57,7 @@ From there, you'll be able to select and import the specific module you need.
 :::
 
 :::note
-Modules that contain KaneAI instructions run only in KaneAI test cases. This covers steps that create or use a variable or parameter, If-Else blocks, and While Loops.
+In the Classic experience, modules that contain KaneAI instructions run only in KaneAI test cases. This covers steps that create or use a variable or parameter, If-Else blocks, and While Loops.
 :::
 
 The **Add Module** dialog lists the modules available to the test case and selects the first one by default. When the selected module contains KaneAI instructions, the dialog shows *This module can't be imported as it contains a few specific KaneAI instructions* and **Add in step** stays disabled. **Edit Module** is locked for the same module.
@@ -71,7 +71,7 @@ Notice that imported modules will appear visually distinct from other individual
 You can also edit or delete imported modules directly from this view. Making changes creates a new version of that module.
 
 :::note
-**Edit Module** is disabled for modules that contain variables, an If-Else block, or a While Loop. Edit these from the KaneAI test case they were authored from.
+In the Classic experience, **Edit Module** is disabled for modules that contain variables, an If-Else block, or a While Loop. Edit these from the KaneAI test case they were authored from.
 :::
 
 :::note


### PR DESCRIPTION
Follow-up to #3336.

That PR documented the module changes: how If-Else and While Loop blocks render on the Modules page, the editing, reordering and deletion restrictions on variable and control-flow steps, and the rule that modules containing KaneAI instructions cannot be imported into manual test cases. It did not state that those behaviours apply to the **Classic experience**.

Modules themselves are supported in both authoring experiences, so this PR only qualifies the sentences that describe those restrictions. There are no page-level banners and no other module content is changed.

### Changes

| Page | Change |
|---|---|
| Modules | Note under **Editing Restrictions** covering that section and **Deleting Steps Inside a Module**; import restriction sentence qualified |
| Modules - Creation and Management | Editing restriction for KaneAI-authored modules qualified |
| Module Versioning and Enhancements | Locked-steps sentence qualified |
| Conditional Logic | Qualified on the "read-only on the Modules page" bullet only |
| While Loops | Qualified on the "Loops inside modules" bullet only |
| Manual Test Case Creation | KaneAI-instruction import restriction qualified |
| Importing Modules into Test Cases | Import restriction and disabled **Edit Module** qualified |

On Conditional Logic and While Loops the wording is scoped to the module bullets deliberately, so it cannot be read as If-Else or While Loops themselves being limited to one experience.

Verified locally on the dev server: all seven pages render the new wording, and no page mentions the other experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
