### PR TITLE
Sync kane cli docs from testmuCom (MDX format)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -50,6 +50,7 @@
               {
                 "group": "Getting Started",
                 "pages": [
+                  "docs/kane-cli-introduction",
                   "docs/kane-cli-installation",
                   "docs/kane-cli-quickstart",
                   "docs/kane-cli-authentication"

--- a/docs/kane-cli-introduction.mdx
+++ b/docs/kane-cli-introduction.mdx
@@ -1,0 +1,62 @@
+---
+title: "Kane CLI Documentation - Getting Started"
+sidebarTitle: "Introduction"
+description: "Kane CLI is an AI-powered command-line tool that runs browser automation tests in plain English: from your terminal, IDE, or CI pipeline."
+keywords: ['kane cli', 'kaneai', 'browser automation', 'testmu ai', 'ai cli', 'natural language testing']
+"og:description": "Kane CLI is an AI-powered command-line tool that runs browser automation tests in plain English: from your terminal, IDE, or CI pipeline."
+---
+
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
+---
+
+<AgentSkillCallout />
+
+**Kane CLI** `kane-cli` is an AI-powered browser automation tool that runs from your terminal. Describe what you want to test in plain English: Kane CLI navigates websites, clicks elements, fills forms, extracts data, and validates outcomes in a real Chrome browser.
+
+- **Run browser tests from any terminal or IDE**: no test scripts, no selectors, no framework boilerplate
+- **Integrate into CI/CD pipelines**: headless mode with structured JSON output and standard exit codes
+- **Use as a skill in AI coding agents**: Claude Code, Codex CLI, and Gemini CLI can invoke Kane CLI directly to test and verify web UIs on your behalf
+
+```bash
+# Install
+npm install -g @testmuai/kane-cli
+
+# Authenticate
+kane-cli login
+
+# Run your first test
+kane-cli run --url https://example.com "Click the 'More information' link and verify the page loads"
+```
+
+## Supported IDEs
+
+Kane CLI runs from the integrated terminal of your editor, so you can drive browser tests without leaving your development environment. It is supported in:
+
+- Cursor
+- Antigravity
+- VS Code
+- Codex
+- Kiro (AWS)
+- Eclipse-based IDEs
+- Web-based IDEs
+
+## Three Modes
+
+| Mode | Command | Best For |
+|------|---------|----------|
+| **Interactive TUI** | `kane-cli --tui` | Development, exploration, chained multi-run sessions |
+| **Non-Interactive CLI Mode** | `kane-cli run "..." --headless --agent` | CI/CD pipelines, shell scripts |
+| **Agent Mode** | `kane-cli run "..." --agent` | AI coding agents (Claude, Codex, Gemini) |
+
+## Next Steps
+
+- [Installation](/docs/kane-cli-installation/): Install Kane CLI and verify your setup
+- [Quick Start](/docs/kane-cli-quickstart/): Authenticate and run your first test in 5 minutes
+- [Authentication](/docs/kane-cli-authentication/): OAuth, basic auth, and profile management
+- [Writing Objectives](/docs/kane-cli-writing-objectives/): Learn how to write effective natural language objectives
+- [Configuration](/docs/kane-cli-configuration/): Window size, Chrome profiles, Test Manager project, and run mode
+- [Test Manager Integration](/docs/kane-cli-tms-integration/): Uploads, share links, code export, and session history
+- [Agent Mode](/docs/kane-cli-agent-mode/): Use Kane CLI with AI coding agents
+- [CI/CD Integration](/docs/kane-cli-cicd/): Add Kane CLI to your pipeline
+- [Skills](/docs/kane-cli-skills/): Install the Kane CLI skill for Claude, Codex, or Gemini


### PR DESCRIPTION
## Summary

Daily sync check of Kane CLI docs (`docs/kane-cli-*`) between `testmuCom` and `stage-mintlify`.

All 42 existing Kane CLI pages on `stage-mintlify` already match their `testmuCom` counterparts content-wise (only expected Mintlify-vs-Docusaurus formatting differences: frontmatter shape, `/docs/` vs `/support/docs/` links, `AgentSkillCallout` snippet). The one genuine gap found: **`docs/kane-cli-introduction.md`**, present on `testmuCom` since Jul 28 (commit `974e68ac`), had no Mintlify counterpart and wasn't linked from anywhere in `stage-mintlify`'s nav.

## Changes

- Added `docs/kane-cli-introduction.mdx`, converted from `docs/kane-cli-introduction.md`:
  - Rewrote frontmatter to Mintlify conventions (`title`, `sidebarTitle`, `description`, `keywords` array, `og:description`)
  - Removed Docusaurus-only imports (`Tabs`/`TabItem`/`BrandName` React imports) and the JSON-LD breadcrumb `<script>` block
  - Added the `AgentSkillCallout` snippet import used by all sibling Kane CLI pages
  - Rewrote internal links from `/support/docs/...` to `/docs/...`
  - Content and structure otherwise preserved as-is
- Updated `docs.json`: added `docs/kane-cli-introduction` as the first page in the Kane CLI → **Getting Started** nav group (before Installation)

## Verification

- Compared every `docs/kane-cli-*.md` file on `testmuCom` against its `.mdx` counterpart on `stage-mintlify`, body content ignoring frontmatter — no other content drift found
- `docs.json` validated as well-formed JSON after the nav edit

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019U1kQKSNbdX82yz7ujkBdv)_