### PR TITLE
docs: use api.hyperexecute.cloud as the Global Policies API host

### DIFF
--- a/docs/hyperexecute-global-policies.md
+++ b/docs/hyperexecute-global-policies.md
@@ -201,10 +201,10 @@ Everything you can do in the UI, you can do over the API — which is usually wh
 
 ### Base URL
 
-Policy routes sit under a `/logistics` path prefix on your HyperExecute API host:
+Policy routes sit under a `/logistics` path prefix on the HyperExecute API host:
 
 ```text
-https://<your-hyperexecute-host>/logistics
+https://api.hyperexecute.cloud/logistics
 ```
 
 ### Authentication
@@ -214,10 +214,10 @@ Policy endpoints use HTTP Basic authentication with your <BrandName /> **usernam
 ```bash
 curl -u "<YOUR_USERNAME>:<YOUR_ACCESS_KEY>" \
   -H "Content-Type: application/json" \
-  "https://<your-hyperexecute-host>/logistics/v1.0/policies?limit=5"
+  "https://api.hyperexecute.cloud/logistics/v1.0/policies?limit=5"
 ```
 
-Run that list call first to confirm your host and credentials work. A `200` with a list — possibly empty — means you are set.
+Run that list call first to confirm your credentials work. A `200` with a list — possibly empty — means you are set.
 
 ### Endpoints
 

--- a/static/docs/hyperexecute-global-policies.md
+++ b/static/docs/hyperexecute-global-policies.md
@@ -141,10 +141,10 @@ Everything you can do in the UI, you can do over the API — which is usually wh
 
 ### Base URL
 
-Policy routes sit under a `/logistics` path prefix on your HyperExecute API host:
+Policy routes sit under a `/logistics` path prefix on the HyperExecute API host:
 
 ```text
-https://<your-hyperexecute-host>/logistics
+https://api.hyperexecute.cloud/logistics
 ```
 
 ### Authentication
@@ -154,10 +154,10 @@ Policy endpoints use HTTP Basic authentication with your TestMu AI **username** 
 ```bash
 curl -u "<YOUR_USERNAME>:<YOUR_ACCESS_KEY>" \
 -H "Content-Type: application/json" \
-"https://<your-hyperexecute-host>/logistics/v1.0/policies?limit=5"
+"https://api.hyperexecute.cloud/logistics/v1.0/policies?limit=5"
 ```
 
-Run that list call first to confirm your host and credentials work. A `200` with a list — possibly empty — means you are set.
+Run that list call first to confirm your credentials work. A `200` with a list — possibly empty — means you are set.
 
 ### Endpoints
 


### PR DESCRIPTION
Follow-up to #3376.

The Global Policies API section shipped with a `<your-hyperexecute-host>` placeholder in the base URL. Replaces it with the real host, `https://api.hyperexecute.cloud`.

### Changes

- **Base URL** → `https://api.hyperexecute.cloud/logistics`
- **Connectivity-check `curl`** → `https://api.hyperexecute.cloud/logistics/v1.0/policies?limit=5`
- Dropped "confirm your **host** and credentials work" → "confirm your credentials work", since the host is no longer something the reader supplies
- Regenerated `static/docs/hyperexecute-global-policies.md` to match

`npm run build` passes with no broken-link or broken-anchor warnings for this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)