### PR TITLE
adding test copy button for IP lists

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,6 +13,7 @@ module.exports = {
   trailingSlash: true,
   clientModules: [
     require.resolve('./custom.js'),
+    require.resolve('./src/js/copy-ips.js')
   ],
   scripts: [
   

--- a/src/js/copy-ips.css
+++ b/src/js/copy-ips.css
@@ -1,0 +1,59 @@
+.copy-ips-bar {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  vertical-align: middle;
+}
+
+/* Sits on the heading line, right-aligned */
+h1 > .copy-ips-bar,
+h2 > .copy-ips-bar,
+h3 > .copy-ips-bar {
+  float: right;
+  margin-top: 4px;
+}
+
+/* Standalone bar above a table that has no heading of its own */
+.markdown > .copy-ips-bar {
+  margin: 0 0 8px;
+}
+
+.copy-ips {
+  font-family: var(--ifm-font-family-base);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-color-emphasis-800);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.copy-ips:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.copy-ips:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
+.copy-ips--done {
+  border-color: var(--ifm-color-success);
+  background: var(--ifm-color-success-contrast-background);
+  color: var(--ifm-color-success-darkest);
+}
+
+@media (max-width: 640px) {
+  h1 > .copy-ips-bar,
+  h2 > .copy-ips-bar,
+  h3 > .copy-ips-bar {
+    float: none;
+    display: flex;
+    margin-top: 8px;
+  }
+}

--- a/src/js/copy-ips.css
+++ b/src/js/copy-ips.css
@@ -1,59 +1,88 @@
-.copy-ips-bar {
+/* Mirrors @docusaurus/theme-classic CodeBlock/Buttons styles so the button is
+   indistinguishable from the one on code snippets. */
+
+.copy-ips {
   display: inline-flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  align-items: center;
+  vertical-align: middle;
+  margin-left: 0.4em;
+  padding: 0.4rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  line-height: 0;
+  opacity: 0.4;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+}
+
+/* Code blocks reveal on .theme-code-block:hover — same idea, keyed to the
+   heading or the table's header row instead. */
+h1:hover .copy-ips,
+h2:hover .copy-ips,
+h3:hover .copy-ips,
+thead:hover .copy-ips {
+  opacity: 0.6;
+}
+
+.copy-ips:hover,
+.copy-ips:focus-visible,
+.copy-ips--copied {
+  opacity: 1 !important;
+}
+
+.copy-ips__icons {
+  position: relative;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.copy-ips__icon,
+.copy-ips__icon-success {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: inherit;
+  height: inherit;
+  fill: currentColor;
+  opacity: inherit;
+  transition: all var(--ifm-transition-fast) ease;
+}
+
+.copy-ips__icon-success {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #00d600;
+}
+
+.copy-ips--copied .copy-ips__icon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copy-ips--copied .copy-ips__icon-success {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.075s;
+}
+
+/* Keep the button off the heading's bold/size inheritance */
+h1 .copy-ips,
+h2 .copy-ips,
+h3 .copy-ips,
+thead th .copy-ips {
+  font-weight: 400;
+  font-size: 1rem;
+}
+
+thead th {
   vertical-align: middle;
 }
 
-/* Sits on the heading line, right-aligned */
-h1 > .copy-ips-bar,
-h2 > .copy-ips-bar,
-h3 > .copy-ips-bar {
-  float: right;
-  margin-top: 4px;
-}
-
-/* Standalone bar above a table that has no heading of its own */
-.markdown > .copy-ips-bar {
-  margin: 0 0 8px;
-}
-
-.copy-ips {
-  font-family: var(--ifm-font-family-base);
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 1.4;
-  padding: 4px 10px;
-  border-radius: 6px;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  background: var(--ifm-background-surface-color);
-  color: var(--ifm-color-emphasis-800);
-  cursor: pointer;
-  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
-}
-
-.copy-ips:hover {
-  border-color: var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
-}
-
-.copy-ips:focus-visible {
-  outline: 2px solid var(--ifm-color-primary);
-  outline-offset: 2px;
-}
-
-.copy-ips--done {
-  border-color: var(--ifm-color-success);
-  background: var(--ifm-color-success-contrast-background);
-  color: var(--ifm-color-success-darkest);
-}
-
-@media (max-width: 640px) {
-  h1 > .copy-ips-bar,
-  h2 > .copy-ips-bar,
-  h3 > .copy-ips-bar {
-    float: none;
-    display: flex;
-    margin-top: 8px;
+@media (hover: none) {
+  .copy-ips {
+    opacity: 0.7;
   }
 }

--- a/src/js/copy-ips.js
+++ b/src/js/copy-ips.js
@@ -1,24 +1,41 @@
 /**
  * copy-ips.js — Docusaurus client module
  *
- * Adds a "Copy all" button to every IP table on the public-IP doc, placed
- * inside the section heading. Values are read from the rendered table at
- * click time, so the markdown never has to be touched and the button can
- * never drift out of sync with the table.
+ * Adds a copy button that is visually identical to the built-in code-block
+ * copy button (same Material icon paths, same clean-btn class, same
+ * scale-crossfade to a green tick, same 1000ms reset) next to IP tables.
+ *
+ * Placement:
+ *   - Tables with ✅ / ❌ product columns: one button per column header,
+ *     copying only that column's ticked rows, plus a copy-all on the first cell.
+ *   - Every other table: one button inline after the section heading.
+ *
+ * Values are read from the rendered table at click time, so the markdown never
+ * changes and the buttons can't drift out of sync.
  *
  * Install:
- *   1. Save as src/js/copy-ips.js and copy-ips.css next to it.
+ *   1. Save as src/js/copy-ips.js with copy-ips.css beside it.
  *   2. In docusaurus.config.js:
- *        clientModules: [require.resolve('./src/js/copy-ips.js')],
+ *        clientModules: [
+ *          require.resolve('./custom.js'),
+ *          require.resolve('./src/js/copy-ips.js'),
+ *        ],
  */
 
 import './copy-ips.css';
 
-// Limit the feature to the public IP page. Set to null to run site-wide.
+// Limit to the public IP page. Set to null to run site-wide.
 const PATH_MATCH = /testmu-public-ip/;
 
 const TICK = '✅';
 const clean = (s) => s.replace(/`/g, '').trim();
+
+// Icon paths lifted verbatim from @theme/Icon/Copy and @theme/Icon/Success.
+const ICONS = `
+<span class="copy-ips__icons" aria-hidden="true">
+  <svg class="copy-ips__icon" viewBox="0 0 24 24"><path fill="currentColor" d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"/></svg>
+  <svg class="copy-ips__icon-success" viewBox="0 0 24 24"><path fill="currentColor" d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/></svg>
+</span>`;
 
 function tableRows(table) {
   return [...table.querySelectorAll('tbody tr')];
@@ -36,78 +53,76 @@ function valuesFor(table, colIndex) {
   return out;
 }
 
-async function writeClipboard(text) {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch {
-    const ta = document.createElement('textarea');
-    ta.value = text;
-    ta.style.cssText = 'position:fixed;top:0;left:0;opacity:0';
-    document.body.appendChild(ta);
-    ta.select();
-    document.execCommand('copy');
-    ta.remove();
-  }
-}
-
-function makeButton(label, tooltip, getValues) {
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.className = 'copy-ips';
-  btn.textContent = label;
-  btn.title = tooltip;
-  btn.dataset.label = label;
-
-  btn.addEventListener('click', async (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const values = getValues();
-    if (!values.length) return;
-    await writeClipboard(values.join('\n'));
-    btn.textContent = `Copied ${values.length}`;
-    btn.classList.add('copy-ips--done');
-    setTimeout(() => {
-      btn.textContent = btn.dataset.label;
-      btn.classList.remove('copy-ips--done');
-    }, 1600);
-  });
-
-  return btn;
+async function copyToClipboard(text) {
+  if (navigator.clipboard) return navigator.clipboard.writeText(text);
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.cssText = 'position:fixed;top:0;left:0;opacity:0';
+  document.body.appendChild(ta);
+  ta.select();
+  document.execCommand('copy');
+  ta.remove();
+  return undefined;
 }
 
 /** "Real Time (Virtual Device)(Desktop & Mobile - Automation)" -> "Automation" */
 function shortLabel(header, index) {
   const tail = header.split('-').pop().replace(/[()]/g, '').trim();
-  if (tail && tail.length <= 22 && tail !== header) return tail;
+  if (tail && tail.length <= 24 && tail !== header) return tail;
   const head = header.split('(')[0].trim();
-  return head || `Column ${index}`;
+  return head || `column ${index}`;
+}
+
+function makeButton(table, colIndex, label) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'clean-btn copy-ips';
+  btn.title = label;
+  btn.setAttribute('aria-label', label);
+  btn.innerHTML = ICONS;
+
+  let timer;
+  btn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const values = valuesFor(table, colIndex);
+    if (!values.length) return;
+    await copyToClipboard(values.join('\n'));
+    btn.classList.add('copy-ips--copied');
+    btn.setAttribute('aria-label', `Copied ${values.length}`);
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      btn.classList.remove('copy-ips--copied');
+      btn.setAttribute('aria-label', label);
+    }, 1000);
+  });
+
+  return btn;
 }
 
 function decorateTable(table) {
   if (table.dataset.copyIps) return;
   table.dataset.copyIps = '1';
 
-  const headers = [...table.querySelectorAll('thead th')].map((th) => th.textContent.trim());
+  const ths = [...table.querySelectorAll('thead th')];
+  const headers = ths.map((th) => th.textContent.trim());
   const rows = tableRows(table);
-  if (!rows.length) return;
+  if (!rows.length || !ths.length) return;
 
-  // Columns that use ✅ / ❌ flags get their own filtered copy button.
+  // Columns using ✅ / ❌ flags each get their own filtered button.
   const flagCols = headers
-    .map((_, i) => i)
-    .filter((i) => i > 0 && rows.some((r) => /[✅❌]/.test(r.children[i]?.textContent || '')));
+      .map((_, i) => i)
+      .filter((i) => i > 0 && rows.some((r) => /[✅❌]/.test(r.children[i]?.textContent || '')));
 
-  const bar = document.createElement('span');
-  bar.className = 'copy-ips-bar';
-  bar.appendChild(
-    makeButton('Copy all', 'Copy every entry in this table', () => valuesFor(table, -1))
-  );
-  flagCols.forEach((i) => {
-    bar.appendChild(
-      makeButton(`Copy ${shortLabel(headers[i], i)}`, headers[i], () => valuesFor(table, i))
-    );
-  });
+  if (flagCols.length) {
+    ths[0].appendChild(makeButton(table, -1, 'Copy all IPs'));
+    flagCols.forEach((i) => {
+      ths[i].appendChild(makeButton(table, i, `Copy ${shortLabel(headers[i], i)} IPs`));
+    });
+    return;
+  }
 
-  // Prefer the nearest preceding h2/h3 in the same section; else sit above the table.
+  // Plain table: prefer the nearest preceding h2/h3, else the first header cell.
   const block = table.closest('.markdown > *') || table;
   let prev = block.previousElementSibling;
   let heading = null;
@@ -120,8 +135,9 @@ function decorateTable(table) {
     prev = prev.previousElementSibling;
   }
 
-  if (heading && !heading.querySelector('.copy-ips-bar')) heading.appendChild(bar);
-  else block.parentNode.insertBefore(bar, block);
+  const btn = makeButton(table, -1, 'Copy all IPs');
+  if (heading && !heading.querySelector('.copy-ips')) heading.appendChild(btn);
+  else ths[0].appendChild(btn);
 }
 
 function decorate() {
@@ -132,7 +148,6 @@ function decorate() {
 }
 
 export function onRouteDidUpdate() {
-  // Run after hydration paints the markdown body.
   requestAnimationFrame(decorate);
   setTimeout(decorate, 300);
 }

--- a/src/js/copy-ips.js
+++ b/src/js/copy-ips.js
@@ -1,0 +1,138 @@
+/**
+ * copy-ips.js — Docusaurus client module
+ *
+ * Adds a "Copy all" button to every IP table on the public-IP doc, placed
+ * inside the section heading. Values are read from the rendered table at
+ * click time, so the markdown never has to be touched and the button can
+ * never drift out of sync with the table.
+ *
+ * Install:
+ *   1. Save as src/js/copy-ips.js and copy-ips.css next to it.
+ *   2. In docusaurus.config.js:
+ *        clientModules: [require.resolve('./src/js/copy-ips.js')],
+ */
+
+import './copy-ips.css';
+
+// Limit the feature to the public IP page. Set to null to run site-wide.
+const PATH_MATCH = /testmu-public-ip/;
+
+const TICK = '✅';
+const clean = (s) => s.replace(/`/g, '').trim();
+
+function tableRows(table) {
+  return [...table.querySelectorAll('tbody tr')];
+}
+
+/** First-column values. colIndex > 0 keeps only rows ticked in that column. */
+function valuesFor(table, colIndex) {
+  const out = [];
+  for (const tr of tableRows(table)) {
+    const cells = tr.children;
+    if (colIndex > 0 && !(cells[colIndex]?.textContent || '').includes(TICK)) continue;
+    const value = clean(cells[0]?.textContent || '');
+    if (value && !out.includes(value)) out.push(value); // dedupe repeated ranges
+  }
+  return out;
+}
+
+async function writeClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.cssText = 'position:fixed;top:0;left:0;opacity:0';
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand('copy');
+    ta.remove();
+  }
+}
+
+function makeButton(label, tooltip, getValues) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'copy-ips';
+  btn.textContent = label;
+  btn.title = tooltip;
+  btn.dataset.label = label;
+
+  btn.addEventListener('click', async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const values = getValues();
+    if (!values.length) return;
+    await writeClipboard(values.join('\n'));
+    btn.textContent = `Copied ${values.length}`;
+    btn.classList.add('copy-ips--done');
+    setTimeout(() => {
+      btn.textContent = btn.dataset.label;
+      btn.classList.remove('copy-ips--done');
+    }, 1600);
+  });
+
+  return btn;
+}
+
+/** "Real Time (Virtual Device)(Desktop & Mobile - Automation)" -> "Automation" */
+function shortLabel(header, index) {
+  const tail = header.split('-').pop().replace(/[()]/g, '').trim();
+  if (tail && tail.length <= 22 && tail !== header) return tail;
+  const head = header.split('(')[0].trim();
+  return head || `Column ${index}`;
+}
+
+function decorateTable(table) {
+  if (table.dataset.copyIps) return;
+  table.dataset.copyIps = '1';
+
+  const headers = [...table.querySelectorAll('thead th')].map((th) => th.textContent.trim());
+  const rows = tableRows(table);
+  if (!rows.length) return;
+
+  // Columns that use ✅ / ❌ flags get their own filtered copy button.
+  const flagCols = headers
+    .map((_, i) => i)
+    .filter((i) => i > 0 && rows.some((r) => /[✅❌]/.test(r.children[i]?.textContent || '')));
+
+  const bar = document.createElement('span');
+  bar.className = 'copy-ips-bar';
+  bar.appendChild(
+    makeButton('Copy all', 'Copy every entry in this table', () => valuesFor(table, -1))
+  );
+  flagCols.forEach((i) => {
+    bar.appendChild(
+      makeButton(`Copy ${shortLabel(headers[i], i)}`, headers[i], () => valuesFor(table, i))
+    );
+  });
+
+  // Prefer the nearest preceding h2/h3 in the same section; else sit above the table.
+  const block = table.closest('.markdown > *') || table;
+  let prev = block.previousElementSibling;
+  let heading = null;
+  while (prev) {
+    if (/^H[1-3]$/.test(prev.tagName)) {
+      heading = prev;
+      break;
+    }
+    if (prev.tagName === 'TABLE' || prev.querySelector?.('table')) break; // section already has a table
+    prev = prev.previousElementSibling;
+  }
+
+  if (heading && !heading.querySelector('.copy-ips-bar')) heading.appendChild(bar);
+  else block.parentNode.insertBefore(bar, block);
+}
+
+function decorate() {
+  if (PATH_MATCH && !PATH_MATCH.test(window.location.pathname)) return;
+  const root = document.querySelector('.markdown');
+  if (!root) return;
+  root.querySelectorAll('table').forEach(decorateTable);
+}
+
+export function onRouteDidUpdate() {
+  // Run after hydration paints the markdown body.
+  requestAnimationFrame(decorate);
+  setTimeout(decorate, 300);
+}


### PR DESCRIPTION
<html><head></head><body><h1>Add copy-to-clipboard buttons to the Public IP page</h1>
<p><strong>Target branch:</strong> <code>stage</code>
<strong>Page affected:</strong> <a href="https://www.testmuai.com/support/docs/testmu-public-ip/">TestMu AI Public IP Ranges</a> (<code>docs/lambdatest-public-ip.md</code>)</p>
<h2>What this changes</h2>
<p>Customers whitelisting our infrastructure currently select IP ranges by hand, row by row, across eight tables on this page. The firewall table is the worst case — a Real Device customer has to visually filter 17 rows by a ✅/❌ column before copying, and a missed row becomes a support ticket.</p>
<p>This adds a copy button to every IP table on the page. Each copies its section's full list as newline-separated values, ready to paste into a firewall rule. On the firewall table, each product column gets its own button copying <strong>only</strong> the ranges ticked for that product.</p>
<h2>Doc changes</h2>
<p><code>docs/lambdatest-public-ip.md</code> — <strong>comment only.</strong> No content, table, IP, frontmatter, or sidebar changes. An MDX comment was added after the <code>BrandName</code> import explaining that the buttons are injected at runtime, which files own them, and the two ways a future edit silently breaks them (slug rename, unsupported value format).</p>
<p>No new page, so <code>sidebars.js</code> is untouched. No images added, so there are no image links for the build to fail on.</p>
<h2>Supporting files</h2>

File | Status
-- | --
src/js/copy-ips.js | new — injects buttons, extracts values, handles clipboard
src/js/copy-ips.css | new — styling, every selector scoped to .copy-ips
docusaurus.config.js | modified — one line added to clientModules


<p>Buttons read their values from the <strong>rendered table</strong> at click time; there is no hardcoded IP list in the JS. The tables stay the single source of truth, so future IP updates to this page need no code change. Visually the button matches the built-in code-block copy button exactly — icon paths are taken verbatim from <code>@theme/Icon/Copy</code> and <code>@theme/Icon/Success</code>, with the same sizing, border, tick colour and animation timing as <code>docusaurus-theme-classic</code>.</p>
<h2>Scope</h2>
<p>Renders on this page only — every CSS selector requires a <code>.copy-ips</code> element, and those are created solely on the gated path. Other docs pages are visually unaffected. The module does ship in the site-wide bundle (~2 KB CSS, ~6.8 KB JS) and its route hook runs on every navigation, returning immediately on non-matching paths.</p>
<h2>Reviewer notes</h2>
<ul>
<li><strong>Slug and gate are coupled.</strong> If this page's slug changes, <code>PATH_MATCH</code> in <code>copy-ips.js</code> must be updated or the buttons silently stop appearing. Flagged in the MDX comment.</li>
<li><strong>Values are validated before reaching the clipboard.</strong> Only IPv4, CIDR and hostnames pass; anything else is skipped with a console warning. Extend <code>VALID_VALUE</code> before adding IPv6 or range syntax to this page.</li>
<li><strong>Validation checks shape, not correctness.</strong> A syntactically valid but wrong IP passes, so diff review stays the only control against a bad range reaching customers — unchanged from today, but the button makes bulk consumption easier.</li>
</ul>
<h2>Verification</h2>
<ul>
<li>[ ] <code>npm run build</code> passes (no broken links or images)</li>
<li>[ ] Each section's button copies that section's complete list</li>
<li>[ ] Firewall column buttons copy only ticked rows</li>
<li>[ ] Several unrelated docs pages: clean console, no visual change</li>
<li>[ ] Sidebar navigation away and back leaves one button per table</li>
<li>[ ] Dark mode and mobile viewport</li>
</ul>
<h2>Rollback</h2>
<p>Remove the <code>require.resolve('./src/js/copy-ips.js')</code> line from <code>clientModules</code>. The page renders exactly as it does today.</p></body></html>