### PR TITLE
feat(api-doc): add Agent Testing API to the API Reference

### DIFF
--- a/scripts/build-api-data.js
+++ b/scripts/build-api-data.js
@@ -28,6 +28,7 @@ const API_SPECS = [
   { name: 'Analytics',                         url: 'https://swagger-api-support.lambdatest.com/analytics/openapi.yaml' },
   { name: 'Performance Testing',               url: 'https://swagger-api-support.lambdatest.com/performance_testing/openapi.yaml' },
   { name: 'Audit logs',                        url: 'https://swagger-api-support.lambdatest.com/audit-logs/openapi.yaml' },
+  { name: 'Agent Testing API',                 url: 'https://agent-testing.lambdatest.com/api/openapi.portal.yaml' },
 ];
 
 // Fetch a URL and return the body as a string (follows redirects)

--- a/src/pages/api-doc/_ApiDocPage.jsx
+++ b/src/pages/api-doc/_ApiDocPage.jsx
@@ -58,6 +58,7 @@ const API_YAML_FILE_MAP = {
   'Analytics': 'analytics-openapi.yaml',
   'Performance Testing': 'performance.yaml',
   'Audit logs': 'audit-logs.yaml',
+  'Agent Testing API': 'agent-testing.yaml',
 };
 
 const NAV_SECTIONS = [


### PR DESCRIPTION
Adds the Agent Testing API to the generated API Reference at /support/api-doc/.

## What

- `scripts/build-api-data.js`: one entry in `API_SPECS` pointing at the curated portal spec served live by the service at https://agent-testing.lambdatest.com/api/openapi.portal.yaml
- `src/pages/api-doc/_ApiDocPage.jsx`: the matching display-name entry in `API_YAML_FILE_MAP`

2 files, +2 lines. No sidebar or markdown changes needed — the build fetches the spec and generates one page per endpoint (54 curated operations, grouped by tag) at `/support/api-doc/agent-testing-api/{group}/{endpoint}/`.

## ⚠️ Do not merge yet

The spec URL goes public with the agentic-testing-service production deploy (service PR #570, merged, deploy pending). Until then the URL returns 401 and merging would publish an **empty** Agent Testing section. This PR will be marked ready once the URL returns 200 anonymously.

## Verification

Ran `scripts/build-api-data.js` locally with the repo-pinned js-yaml@3.14.0: all 12 existing specs fetch OK (224 endpoints), and the new entry correctly attempts the portal URL (currently the expected 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)