### PR TITLE
docs(kane-cli): mobile testing (iOS Simulator, Android Emulator)

### DIFF
--- a/docs/kane-cli-cli-reference.md
+++ b/docs/kane-cli-cli-reference.md
@@ -84,6 +84,30 @@ kane-cli run "<objective>" [options]
 | `--access-key <key>` | Basic auth access key (overrides stored profile) | N/A |
 | `--env <name>` | Environment (`prod`) | Active profile's env |
 
+**Mobile run flags** (macOS Apple Silicon only):
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--target <name>` | Which target to run against: `desktop`, `emulator`, or `simulator` | Saved session target, otherwise `desktop` |
+| `--device <id>` | Pick a device by name, serial, `ip:port`, or udid | TTY opens a one-time picker and saves the choice; non-interactive runs require it |
+| `--app <path\|APPid>` | The app under test. A build (emulator `.apk`, simulator `.zip`) or an uploaded app id | Config value. Required for every mobile run |
+
+On the `desktop` target, `--device` and `--app` are ignored. See [Mobile Testing](/support/docs/kane-cli-mobile/) for setup.
+
+---
+
+### `kane-cli doctor`
+
+Check the mobile tooling on this machine, and install the tooling Kane CLI manages.
+
+```bash
+kane-cli doctor              # required checks, each with a fix if it fails
+kane-cli doctor --install    # install the test tooling Kane CLI manages
+kane-cli doctor --targets    # also list the emulators and simulators available
+```
+
+`doctor` prints one line per required check. Run `kane-cli login` before `--install`. See [Mobile Testing](/support/docs/kane-cli-mobile/).
+
 ---
 
 ### `kane-cli login`
@@ -159,6 +183,9 @@ kane-cli config set-mode <action|testing>  # Set run mode
 kane-cli config chrome-profile [path]      # Set Chrome profile (interactive picker if no path)
 kane-cli config project [id]               # Set Test Manager project (interactive picker if no id)
 kane-cli config folder [id]                # Set Test Manager folder (interactive picker if no id)
+kane-cli config set-target <target>        # Set run target: desktop | emulator | simulator
+kane-cli config set-device <id>            # Set default mobile device
+kane-cli config set-app <path|APPid>       # Set default app under test for mobile runs
 ```
 
 :::note
@@ -204,6 +231,9 @@ kane-cli feedback \
 | `/balance` | | Show credit balance |
 | `/profiles` | `list\|switch\|delete` | Manage profiles |
 | `/config` | `show\|set-window\|set-mode\|chrome-profile\|project\|folder` | Manage configuration |
+| `/mobile` | | Switch the session to an emulator or simulator |
+| `/desktop` | | Switch the session back to desktop (Chrome) |
+| `/doctor` | | Check mobile tooling and devices |
 | `/new` | | Start a fresh session (uploads current session first) |
 | `/summary` | `[index]` | View detailed run summaries |
 | `/cancel` | | Abort the current run |

--- a/docs/kane-cli-configuration.md
+++ b/docs/kane-cli-configuration.md
@@ -102,6 +102,9 @@ Empty fields are shown as `(none)`. The `chrome` path is empty by default, in wh
 | `folder_id` | string \| null | `null` | <BrandName /> Test Manager folder ID for upload | `kane-cli config folder [id]` |
 | `folder_name` | string \| null | `null` | Display name of the selected folder | Set by `kane-cli config folder` |
 | `mode` | `"action"` \| `"testing"` | `"testing"` | Agent behaviour on auth walls, blocked pages, or error pages. | `kane-cli config set-mode <action\|testing>` |
+| `target` | `"desktop"` \| `"emulator"` \| `"simulator"` | `"desktop"` | Default run target. `desktop` runs the Chrome browser; `emulator` and `simulator` run against a virtual Android or iOS device (macOS Apple Silicon only). See [Mobile Target](#mobile-target). | `kane-cli config set-target <desktop\|emulator\|simulator>` |
+| `device` | string \| null | `null` | Default mobile device, by name, serial, `ip:port`, or udid. When empty, a TTY run prompts once and saves the choice; a non-interactive run needs `--device` or this key set. Ignored on the `desktop` target. | `kane-cli config set-device <id>` |
+| `app` | string \| null | `null` | Default app under test for mobile runs: a build path (`.apk` or `.zip`) or an uploaded app id. Ignored on the `desktop` target. | `kane-cli config set-app <path\|APPid>` |
 | `code_export.enabled` | boolean | `false` | Generate code export after upload completes. | TUI menu, or `--code-export` flag |
 | `code_export.language` | `"python"` \| `"javascript"` | `"python"` | Output language for generated code. Accepts `python` or `javascript`. | `--code-language <lang>` |
 | `code_export.skip_validation` | boolean | `true` | Skip post-codegen worker-side validation. | TUI menu, or `--skip-code-validation` |
@@ -167,6 +170,22 @@ kane-cli config set-mode testing
 - **`action`**: the agent hard-stops on authentication, blocked, and error pages so you can intervene manually before the run proceeds.
 
 You can override the saved mode for a single run with `--mode <action|testing>` on `kane-cli run`.
+
+### Mobile Target
+
+On macOS Apple Silicon, Kane CLI can run against a virtual mobile device instead of the desktop browser. Three settings persist the default target and how to reach it. They are a **separate axis** from `mode` above: `mode` tunes agent behaviour, while these choose *what device* a run drives.
+
+```bash
+kane-cli config set-target emulator          # desktop | emulator | simulator
+kane-cli config set-device pixel-7           # name, serial, ip:port, or udid
+kane-cli config set-app ./builds/app-debug.apk
+```
+
+- **`target`**: `desktop`, the default, runs Chrome. `emulator` runs a virtual Android device and `simulator` a virtual iOS device. Existing web runs are unaffected.
+- **`device`**: the device a mobile run selects, by name, serial, `ip:port`, or udid. When unset, a TTY run prompts once and saves the choice. Non-interactive runs need it set, either here or with `--device`.
+- **`app`**: the app under test for a mobile run, a build path (emulator `.apk`, simulator `.zip`) or an uploaded app id, `APP` followed by six or more digits. Required for every mobile run. On the `desktop` target, `device` and `app` are ignored.
+
+A run reads these as its defaults. Override any of them for a single run with `--target`, `--device`, and `--app`. Setup and the full list of accepted app formats are in [Mobile Testing](/support/docs/kane-cli-mobile/).
 
 ### Code Export
 

--- a/docs/kane-cli-installation.md
+++ b/docs/kane-cli-installation.md
@@ -95,6 +95,10 @@ If the command is not found, your shell is not seeing the npm global `bin` direc
 | Linux | x64 | ✅ |
 | Windows | x64 | ✅ |
 
+:::note
+**Mobile testing**, the iOS Simulator and the Android Emulator, is supported on **macOS Apple Silicon (arm64) only** for the initial release. See [Mobile Testing](/support/docs/kane-cli-mobile/) for the simulator and emulator prerequisites.
+:::
+
 ## Update
 
 Kane CLI checks the npm registry once every 24 hours when you launch it. When a newer version is available, the CLI prints a one-line notification on startup with the current and latest versions. The check runs in the background and never blocks startup.

--- a/docs/kane-cli-introduction.md
+++ b/docs/kane-cli-introduction.md
@@ -2,7 +2,7 @@
 id: kane-cli-introduction
 title: Kane CLI Documentation - Getting Started
 sidebar_label: Introduction
-description: "Kane CLI is an AI-powered command-line tool that runs browser automation tests in plain English: from your terminal, IDE, or CI pipeline."
+description: "Kane CLI is an AI-powered command-line tool that runs browser and native mobile app tests in plain English: from your terminal, IDE, or CI pipeline."
 keywords:
   - kane cli
   - kaneai
@@ -44,11 +44,12 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
     }}
 ></script>
 
-**Kane CLI** `kane-cli` is an AI-powered browser automation tool that runs from your terminal. Describe what you want to test in plain English: Kane CLI navigates websites, clicks elements, fills forms, extracts data, and validates outcomes in a real Chrome browser.
+**Kane CLI** `kane-cli` is an AI-powered test automation tool that runs from your terminal. Describe what you want to test in plain English: Kane CLI navigates, clicks elements, fills forms, extracts data, and validates outcomes in a real Chrome browser, or in a native mobile app on a virtual device.
 
-- **Run browser tests from any terminal or IDE**: no test scripts, no selectors, no framework boilerplate
+- **Run tests from any terminal or IDE**: no test scripts, no selectors, no framework boilerplate
+- **Test the web and native mobile apps**: the default target is the desktop browser, and on macOS Apple Silicon you can point the same objective at an Android Emulator or iOS Simulator. See [Mobile Testing](/support/docs/kane-cli-mobile/)
 - **Integrate into CI/CD pipelines**: headless mode with structured JSON output and standard exit codes
-- **Use as a skill in AI coding agents**: Claude Code, Codex CLI, and Gemini CLI can invoke Kane CLI directly to test and verify web UIs on your behalf
+- **Use as a skill in AI coding agents**: Claude Code, Codex CLI, and Gemini CLI can invoke Kane CLI directly to test and verify UIs on your behalf
 
 ```bash
 # Install
@@ -88,6 +89,7 @@ Kane CLI runs from the integrated terminal of your editor, so you can drive brow
 - [Authentication](/support/docs/kane-cli-authentication/): OAuth, basic auth, and profile management
 - [Writing Objectives](/support/docs/kane-cli-writing-objectives/): Learn how to write effective natural language objectives
 - [Configuration](/support/docs/kane-cli-configuration/): Window size, Chrome profiles, Test Manager project, and run mode
+- [Mobile Testing](/support/docs/kane-cli-mobile/): Run tests against a native app on the Android Emulator or iOS Simulator
 - [Test Manager Integration](/support/docs/kane-cli-tms-integration/): Uploads, share links, code export, and session history
 - [Agent Mode](/support/docs/kane-cli-agent-mode/): Use Kane CLI with AI coding agents
 - [CI/CD Integration](/support/docs/kane-cli-cicd/): Add Kane CLI to your pipeline

--- a/docs/kane-cli-mobile-emulator.md
+++ b/docs/kane-cli-mobile-emulator.md
@@ -1,0 +1,133 @@
+---
+id: kane-cli-mobile-emulator
+title: Android Emulator Setup for Kane CLI
+sidebar_label: Android Emulator Setup
+description: Set up Google's Android Emulator so Kane CLI can run mobile tests against a virtual Android device on macOS Apple Silicon. Install Android Studio, add an arm64-v8a system image and an AVD, then let Kane CLI install its test tooling.
+keywords:
+  - kane cli android emulator
+  - android emulator setup
+  - arm64-v8a system image
+  - avdmanager
+  - kane cli doctor
+  - mobile app testing
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-mobile-emulator/
+site_name: TestMu AI
+slug: kane-cli-mobile-emulator/
+canonical: https://www.testmuai.com/support/docs/kane-cli-mobile-emulator/
+---
+
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Android Emulator Setup for Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-mobile-emulator/"
+        }]
+      })}}
+></script>
+
+Set up Google's Android Emulator once, and Kane CLI can run mobile tests against it. This guide targets **macOS on Apple Silicon (arm64)**, the only supported host for this release. See [Mobile Testing](/support/docs/kane-cli-mobile/) for the full picture.
+
+:::warning
+On Apple Silicon, always use an **`arm64-v8a`** system image. The x86 and x86_64 images do not run natively and are effectively unusable. This is the single most common setup mistake.
+:::
+
+:::note
+The exact Android API levels and device profiles in the supported matrix are pinned by the product team. The values shown below, API 35 and Pixel, are current, working examples. Confirm the officially supported set before you rely on a specific one.
+:::
+
+## 1. Install Android Studio
+
+Kane CLI does not ship an Android SDK, emulator, or system image. Install **Android Studio**, which bundles the Android SDK, the emulator, the system image manager, and the Device Manager. Download it from the Android developer site and run the first-launch setup wizard, which installs the SDK and `platform-tools`.
+
+If you prefer a headless setup, install the command line SDK tools and use `sdkmanager` and `avdmanager` directly.
+
+## 2. Install an arm64 System Image
+
+Install a system image with the **`arm64-v8a`** ABI. In the Android Studio SDK Manager, tick an API level image whose ABI is `arm64-v8a`. From the command line:
+
+```bash
+sdkmanager "system-images;android-35;google_apis;arm64-v8a"
+```
+
+## 3. Create a Virtual Device
+
+Kane CLI runs against an existing AVD. It does not create one for you. Create an Android Virtual Device from that image. In Android Studio, use **Device Manager → Create Device** and pick the arm64 image. From the command line:
+
+```bash
+avdmanager create avd -n kane_pixel \
+  -k "system-images;android-35;google_apis;arm64-v8a" \
+  -d pixel
+```
+
+## 4. Point Kane CLI at a Non-Default SDK Location
+
+This step is only needed if your SDK is not in the default location.
+
+Kane CLI uses its own managed `adb`, so you do not need `platform-tools` or `adb` on your `PATH`. It only needs to find the **emulator binary and your AVDs**, which it looks for in the default SDK location `~/Library/Android/sdk`. If your SDK lives somewhere else, point Kane CLI at it:
+
+```bash
+export ANDROID_HOME="/path/to/your/Android/sdk"
+```
+
+If your SDK is at the default path, skip this step.
+
+## 5. Install the Kane CLI Test Tooling
+
+Sign in and let Kane CLI install the tooling it manages for the emulator:
+
+```bash
+kane-cli login
+kane-cli doctor --install
+```
+
+You do not need to boot the emulator or run `adb` yourself. Kane CLI discovers the AVD, boots it, installs your app, and runs the test.
+
+## Ready Check
+
+Confirm Kane CLI sees a ready Android toolchain and, optionally, the AVDs on your machine:
+
+```bash
+kane-cli doctor              # required checks, each with a fix if it fails
+kane-cli doctor --targets    # also list the emulators Kane CLI can run against
+```
+
+When the Android checks pass and your AVD is listed, your emulator setup is complete.
+
+## Run a Test
+
+```bash
+kane-cli run "Add the first item to the cart" --target emulator --app ./builds/app-debug.apk
+```
+
+The emulator target accepts an `.apk` build or an uploaded app id, `APP` followed by six or more digits.
+
+## Common Failures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Emulator boots extremely slowly or hangs | An x86 or x86_64 image on Apple Silicon | Recreate the AVD from an `arm64-v8a` system image |
+| `doctor` cannot find the emulator, or "No Android emulator found" when picking a device | SDK in a non-default location, or no AVD created yet | Set `ANDROID_HOME`, and create an AVD in **Android Studio → Device Manager** |
+| Prompts to install Intel HAXM | Following an Intel Mac guide | Not needed on Apple Silicon. It uses the built-in Hypervisor framework, so skip HAXM |
+
+## Next Steps
+
+- [iOS Simulator setup](/support/docs/kane-cli-mobile-simulator/)
+- [Mobile Testing overview](/support/docs/kane-cli-mobile/)

--- a/docs/kane-cli-mobile-simulator.md
+++ b/docs/kane-cli-mobile-simulator.md
@@ -1,0 +1,117 @@
+---
+id: kane-cli-mobile-simulator
+title: iOS Simulator Setup for Kane CLI
+sidebar_label: iOS Simulator Setup
+description: Set up Apple's iOS Simulator so Kane CLI can run mobile tests against a virtual iOS device on macOS Apple Silicon. Install Xcode 16 or newer, point the command line tools at it, then let Kane CLI install its test tooling.
+keywords:
+  - kane cli ios simulator
+  - ios simulator setup
+  - xcode simctl
+  - kane cli doctor
+  - mobile app testing
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-mobile-simulator/
+site_name: TestMu AI
+slug: kane-cli-mobile-simulator/
+canonical: https://www.testmuai.com/support/docs/kane-cli-mobile-simulator/
+---
+
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "iOS Simulator Setup for Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-mobile-simulator/"
+        }]
+      })}}
+></script>
+
+Set up Apple's iOS Simulator once, and Kane CLI can run mobile tests against it. This guide targets **macOS on Apple Silicon (arm64)**, the only supported host for this release. See [Mobile Testing](/support/docs/kane-cli-mobile/) for the full picture.
+
+:::note
+The exact iOS runtime versions and simulator device models in the supported matrix are pinned by the product team. The versions shown below are current, working examples. Confirm the officially supported set before you rely on a specific one.
+:::
+
+## 1. Install Xcode 16 or Newer
+
+Install the full **Xcode** app from the Mac App Store. The standalone Command Line Tools are not enough. Kane CLI requires Xcode 16 or newer, which bundles the iOS Simulator, the `simctl` tool, and at least one iOS runtime. The download is large, several GB, so allow time on the first install.
+
+Launch Xcode once after installing so it can finish installing its additional components.
+
+## 2. Point the Command Line Tools at Xcode
+
+Kane CLI talks to the simulator through Apple's `simctl`, which ships inside Xcode. Make sure the developer directory resolves to the full Xcode install, not the standalone Command Line Tools:
+
+```bash
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+sudo xcodebuild -license accept   # accept the license non-interactively
+```
+
+Confirm Xcode and `simctl` are reachable:
+
+```bash
+xcodebuild -version                # should report 16.x or newer
+xcrun simctl list devices available
+```
+
+You should see one or more iOS devices grouped under an iOS runtime. Xcode ships with default simulators. If none are listed, add one from **Xcode → Settings → Platforms**, or **Xcode → Window → Devices and Simulators**.
+
+## 3. Install the Kane CLI Test Tooling
+
+Sign in and let Kane CLI install the tooling it manages for the simulator:
+
+```bash
+kane-cli login
+kane-cli doctor --install
+```
+
+You do not need to boot a simulator yourself. Kane CLI discovers the simulator, boots it, installs your app, and runs the test.
+
+## Ready Check
+
+Confirm Kane CLI sees a ready iOS toolchain and, optionally, the simulators on your machine:
+
+```bash
+kane-cli doctor              # required checks, each with a fix if it fails
+kane-cli doctor --targets    # also list the simulators Kane CLI can run against
+```
+
+When the iOS checks pass, your simulator setup is complete.
+
+## Run a Test
+
+```bash
+kane-cli run "Sign in and open the account tab" --target simulator --app ./builds/MyApp.zip
+```
+
+The simulator target accepts a `.zip` build or an uploaded app id, `APP` followed by six or more digits.
+
+## Common Failures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `doctor` reports Xcode is too old | Xcode older than 16 | Update Xcode to 16 or newer from the App Store |
+| `xcrun: error: unable to find utility "simctl"` | Developer directory points at the standalone Command Line Tools, not Xcode | Run `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer` |
+| `doctor` reports no developer directory | Full Xcode not installed, or never launched | Install Xcode from the App Store, launch it once, then run `xcode-select --install` |
+| "No iOS simulator found" when picking a device | No simulator device exists yet | Add one in **Xcode → Window → Devices and Simulators**, then reopen the list |
+
+## Next Steps
+
+- [Android Emulator setup](/support/docs/kane-cli-mobile-emulator/)
+- [Mobile Testing overview](/support/docs/kane-cli-mobile/)

--- a/docs/kane-cli-mobile.md
+++ b/docs/kane-cli-mobile.md
@@ -1,0 +1,119 @@
+---
+id: kane-cli-mobile
+title: Mobile Testing with Kane CLI
+sidebar_label: Overview
+description: Run Kane CLI tests against local mobile virtual devices. Drive a native Android app on the Android Emulator or a native iOS app on the iOS Simulator, on macOS Apple Silicon.
+keywords:
+  - kane cli mobile
+  - kane cli emulator
+  - kane cli simulator
+  - mobile app testing
+  - android emulator testing
+  - ios simulator testing
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-mobile/
+site_name: TestMu AI
+slug: kane-cli-mobile/
+canonical: https://www.testmuai.com/support/docs/kane-cli-mobile/
+---
+
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Mobile Testing with Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-mobile/"
+        }]
+      })}}
+></script>
+
+Kane CLI can run tests against local mobile virtual devices: Apple's **iOS Simulator** and Google's **Android Emulator**. You author and run mobile tests the same way you already do for the browser. The differences are that a mobile test runs against an **app you provide**, and that the target device is a simulator or emulator on your machine.
+
+:::note
+This release supports **macOS on Apple Silicon (arm64) only**. Mobile testing is not yet available on Intel Macs, Linux, or Windows. Everything below assumes a mac-arm64 host.
+:::
+
+## What Mobile Means Here
+
+**Native app testing.** A mobile test drives an installed app. You pass a build, or an app id from a previous upload, with `--app`. Kane CLI installs it on the device and runs your objective against it. WebViews inside the app under test are handled.
+
+:::warning
+Pointing a mobile run at a website is not supported yet. Mobile runs target a native app, not a mobile web page.
+:::
+
+**Two targets.** `emulator` is a virtual Android device and `simulator` is a virtual iOS device. The default target stays **desktop**, the browser, so nothing changes for your existing web runs.
+
+## Why a Single Architecture
+
+Apple Silicon runs both mobile stacks natively. The iOS Simulator is a first-class Apple target, and Android ships `arm64-v8a` emulator images that run on the Mac's built-in hypervisor with hardware acceleration.
+
+Standardising on one host architecture for the first release keeps setup predictable and runs fast, with no cross-architecture translation in the path. Support for other hosts will follow in a later release.
+
+## How Setup Works
+
+There are two halves, and Kane CLI owns the second.
+
+**1. You provide the virtual device.** Install Apple's or Google's tooling, Xcode or Android Studio, and for Android create one virtual device. These are the same tools Apple and Google already ship for building simulators and emulators.
+
+**2. Kane CLI installs its own test tooling and drives the device.** Sign in and run one command:
+
+```bash
+kane-cli login
+kane-cli doctor --install
+```
+
+This downloads the test tooling Kane CLI manages for you. From then on, Kane CLI discovers the device, boots it, installs your app, and runs the test. You do not boot the simulator or emulator by hand.
+
+Run `kane-cli doctor` at any time to check what is ready and what is missing. It prints one line per required check, each with a fix.
+
+## Prerequisites at a Glance
+
+| Target | Virtual device | You install | Setup guide |
+|--------|----------------|-------------|-------------|
+| iOS | iOS Simulator | Xcode, the full app, version 16 or newer | [iOS Simulator setup](/support/docs/kane-cli-mobile-simulator/) |
+| Android | Android Emulator | Android Studio or the Android SDK, plus one `arm64-v8a` AVD | [Android Emulator setup](/support/docs/kane-cli-mobile-emulator/) |
+
+Both require macOS on Apple Silicon and a one-time `kane-cli doctor --install`. You only need to set up the platform you intend to test. Set up both if you test on both.
+
+## Running a Mobile Test
+
+Once a target is set up, point a run at it:
+
+```bash
+# one-off, from the command line
+kane-cli run "Sign in and open the account tab" --target simulator --app ./builds/MyApp.zip
+
+# or set a default target once, then just run
+kane-cli config set-target emulator
+kane-cli run "Add the first item to the cart" --app ./builds/app-debug.apk
+```
+
+In the interactive TUI, switch targets with `/mobile` and `/desktop`, and run `/doctor` to check mobile tooling and devices.
+
+For the full flag list and the app formats each target accepts, see the [CLI Reference](/support/docs/kane-cli-cli-reference/#kane-cli-run). To save a default target, device, and app instead of passing flags every time, see [Configuration](/support/docs/kane-cli-configuration/#mobile-target). To run a mobile test from a file, see [Test.md](/support/docs/kane-cli-testmd/#mobile-target).
+
+## Evidence for a Mobile Run
+
+The result summary records the **device** in the run environment, for example the device model and OS version, and the per-step logs include **device logs** from the emulator or simulator alongside the usual browser logs.
+
+## Next Steps
+
+- [iOS Simulator setup](/support/docs/kane-cli-mobile-simulator/)
+- [Android Emulator setup](/support/docs/kane-cli-mobile-emulator/)
+- [CLI Reference](/support/docs/kane-cli-cli-reference/) for the full flag and command list

--- a/docs/kane-cli-modes.md
+++ b/docs/kane-cli-modes.md
@@ -96,6 +96,9 @@ Typing `/` in chat mode opens an autocomplete palette. Continue typing to filter
 | `/balance` | | Show credit balance |
 | `/profiles` | `list\|switch\|delete` | Manage profiles |
 | `/config` | `show\|set-window\|set-url\|set-mode\|chrome-profile\|project\|folder` | Manage configuration |
+| `/mobile` | | Switch the session to an emulator or simulator |
+| `/desktop` | | Switch the session back to desktop (Chrome) |
+| `/doctor` | | Check mobile tooling and devices |
 | `/new` | | Start a fresh session (uploads the current session first) |
 | `/summary` | `[index]` | View detailed run summaries |
 | `/cancel` | | Abort the current run |

--- a/docs/kane-cli-quickstart.md
+++ b/docs/kane-cli-quickstart.md
@@ -173,4 +173,5 @@ Run `kane-cli --tui` to open the interactive TUI: a full terminal UI where you c
 - [Modes of Operation](/support/docs/kane-cli-modes/): Understand Interactive TUI, Headless CLI, and Agent Mode
 - [Authentication](/support/docs/kane-cli-authentication/): Manage profiles and credential methods
 - [Variables & Context](/support/docs/kane-cli-variables-and-context/): Parameterize tests with credentials and project-specific context
+- [Mobile Testing](/support/docs/kane-cli-mobile/): Point the same objective at an Android Emulator or iOS Simulator
 - [CI/CD Integration](/support/docs/kane-cli-cicd/): Add Kane CLI to your pipeline

--- a/docs/kane-cli-testmd.md
+++ b/docs/kane-cli-testmd.md
@@ -118,6 +118,31 @@ headless: true
 | `code_export` | root + step | Generate Playwright code after the run |
 | `code_language` | root + step | `python` or `javascript` for code export |
 | `global_context` / `local_context` | root + step | Inline Markdown or file path for agent context |
+| `target` | root | Where the test runs: a browser transport (`chrome`, the default, `cdp`, or `ws`) or a mobile target (`emulator` or `simulator`, macOS Apple Silicon). See [Mobile Target](#mobile-target). |
+| `app` | root | Mobile only. The app under test: a build path (emulator `.apk`, simulator `.zip`) or an uploaded `APP…` id. Required with a mobile target, rejected with a browser target. |
+| `no_reset` | root | Mobile only. Keep the app's existing state between runs instead of resetting it. |
+
+### Mobile Target
+
+On macOS Apple Silicon, `target:` also accepts the two mobile values, `emulator` for a virtual Android device and `simulator` for a virtual iOS device, with the app under test as its own root key:
+
+```yaml
+---
+target: emulator             # emulator (Android) | simulator (iOS)
+app: ./builds/app-debug.apk
+no_reset: false              # optional
+---
+```
+
+- **`target`**: `emulator` runs on an Android emulator, `simulator` on an iOS simulator. The platform never appears separately, the target implies it.
+- **`app`**: the app under test, required with a mobile target and rejected with a browser one. A build path (emulator `.apk`, simulator `.zip`) or an uploaded app id, `APP` followed by six or more digits. On-device package ids are not accepted.
+- **`no_reset`**: optional. Keep the app's existing state between runs instead of resetting it.
+
+:::warning
+The nested form, `target: {platform, app}`, is not accepted. The parser refuses it and spells out the flat shape above.
+:::
+
+Mobile tests run with `kane-cli testmd run`. A batch run does not support mobile members: a `_test.md` with a mobile target is rejected up front, before the suite runs. Setup is covered in [Mobile Testing](/support/docs/kane-cli-mobile/).
 
 ### Title and Steps
 

--- a/docs/kane-cli-troubleshooting.md
+++ b/docs/kane-cli-troubleshooting.md
@@ -304,6 +304,23 @@ Two other triggers: npm configured to skip optional dependencies (`npm config ge
 
 ---
 
+## Mobile Issues
+
+Mobile testing is supported on **macOS Apple Silicon (arm64) only**. Start every mobile problem with `doctor`, which prints one line per required check, each with a fix:
+
+```bash
+kane-cli doctor              # required checks, each with a fix if it fails
+kane-cli doctor --install    # install the test tooling Kane CLI manages
+kane-cli doctor --targets    # list the emulators and simulators available
+```
+
+The common setup failures for each platform, and their fixes, are listed on the setup pages:
+
+- [iOS Simulator setup](/support/docs/kane-cli-mobile-simulator/#common-failures)
+- [Android Emulator setup](/support/docs/kane-cli-mobile-emulator/#common-failures)
+
+---
+
 ## "Update available" Notice
 
 Kane CLI checks the public npm registry for a newer release once every 24 hours. The result is cached locally so the check itself is non-blocking and silent on failure. When a newer version exists, Kane CLI surfaces an "update available" notification with the current and latest versions and a severity label (`major`, `minor`, or `patch`).

--- a/docs/kane-cli-writing-objectives.md
+++ b/docs/kane-cli-writing-objectives.md
@@ -203,6 +203,16 @@ kane-cli run \
 
 ---
 
+## Objectives on Mobile
+
+Objectives are written the same way for a native mobile app as for the browser. The difference is what the run points at: a mobile run installs an **app you supply** with `--app`, so the objective describes app screens and controls rather than a URL.
+
+```bash
+kane-cli run "Sign in and open the account tab" --target simulator --app ./builds/MyApp.zip
+```
+
+Pointing a mobile run at a website is not supported yet. WebViews inside the app under test are handled. See [Mobile Testing](/support/docs/kane-cli-mobile/).
+
 ## Splitting Long Objectives
 
 Objectives with more than 15 steps drift and become unreliable. Split them into multiple runs.

--- a/sidebars.js
+++ b/sidebars.js
@@ -4425,11 +4425,6 @@ module.exports = {
           },
           {
             type: "doc",
-            label: "UI Testing",
-            id: "ui-testing-with-kane-cli",
-          },
-          {
-            type: "doc",
             label: "AI Coding Agents",
             id: "kane-cli-with-ai-coding-agents",
           },

--- a/sidebars.js
+++ b/sidebars.js
@@ -4391,6 +4391,27 @@ module.exports = {
       {
         type: "category",
         collapsed: true,
+        label: "Mobile Testing",
+        link: {
+          type: "doc",
+          id: "kane-cli-mobile",
+        },
+        items: [
+          {
+            type: "doc",
+            label: "iOS Simulator Setup",
+            id: "kane-cli-mobile-simulator",
+          },
+          {
+            type: "doc",
+            label: "Android Emulator Setup",
+            id: "kane-cli-mobile-emulator",
+          },
+        ],
+      },
+      {
+        type: "category",
+        collapsed: true,
         label: "Use Cases",
         link: {
           type: "doc",


### PR DESCRIPTION
Documents mobile testing in Kane CLI, ported from the mobile docs engineering added in [`LambdaTest/kane-cli`](https://github.com/LambdaTest/kane-cli/tree/main/docs/user-guide/mobile) (commits `fd456427` and `ea0d91e8`).

Mobile runs a **native app you supply** on a local virtual device. The default target stays `desktop`, so existing web runs are unaffected. This release is **macOS Apple Silicon (arm64) only**.

## New pages

A new **Mobile Testing** category in the Kane CLI sidebar, after Core Concepts:

| Page | Covers |
|---|---|
| `kane-cli-mobile` | What mobile covers, why mac-arm64 only, setup, running a mobile test |
| `kane-cli-mobile-simulator` | iOS Simulator setup: Xcode 16+, `xcode-select`, `simctl` |
| `kane-cli-mobile-emulator` | Android Emulator setup: `arm64-v8a` system image, AVD, `ANDROID_HOME` |

## Updated pages

- **introduction**: web and mobile-app framing, matching the reframed upstream README
- **installation**: mobile is mac-arm64 only
- **configuration**: `target` / `device` / `app` settings, plus a Mobile Target section
- **testmd**: flat `target:` / `app:` / `no_reset:` frontmatter; the nested form is rejected; batch runs reject mobile members
- **cli-reference**: `kane-cli doctor`, mobile run flags, mobile config setters, slash commands
- **modes**: `/mobile`, `/desktop`, `/doctor` added to the second slash-command table so it does not drift
- **writing-objectives**: mobile objectives describe app screens and use `--app`, not a URL
- **troubleshooting**: a mobile section pointing at `doctor` and the two setup guides
- **quickstart**: link to mobile testing

## Sourcing

Every statement is traceable to the upstream user guide. Two deliberate omissions:

- **Nothing about mobile in CI.** Upstream does not document it, so none was written.
- **Nothing about checkpoint behaviour on mobile.** Upstream does not state it.

The later upstream commit (`ea0d91e8`) is reflected: the testmd frontmatter is the **flat** `target` / `app` / `no_reset` shape, not the earlier nested mapping, and `--device` opens a one-time picker in a TTY rather than being auto-selected.

## Second commit: a pre-existing build fix

`sidebars.js` referenced `ui-testing-with-kane-cli`, but `docs/ui-testing-with-kane-cli.md` exists on neither `stage` nor `main`. Docusaurus validates sidebar ids at load, so `npx docusaurus build` fails on `stage` today:

```
Invalid sidebar file at "sidebars-unified.js".
These sidebar document ids do not exist:
- ui-testing-with-kane-cli
```

This is unrelated to the mobile docs but blocks the build check on any docs PR, so it is fixed in its own commit. **If that page is being written, drop this commit and add the file instead.**

## Verification

- Previewed locally; all new and changed pages render, sidebar order correct
- Production build: sidebar validation passes, **0 broken links**, both bundles compile, and no error names any Kane CLI page
- The local build's only remaining failure is `/support/search/` (`MissingConfigurationError` from Typesense), an environment issue on my machine, not from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
