### PR TITLE
chore: add api-specs folder for local OpenAPI specs

### DIFF
--- a/api-specs/api.yaml
+++ b/api-specs/api.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /ping:
+    get:
+      tags:
+        - sample
+      summary: Ping
+      description: Placeholder endpoint. Replace this file with a real spec.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok


### PR DESCRIPTION
## What

Adds an `api-specs/` directory at the repo root to hold the OpenAPI YAML specs locally, instead of relying solely on the remote Swagger URLs that `scripts/build-api-data.js` fetches at build time.

`api-specs/api.yaml` is a minimal placeholder spec so the directory is tracked by git. Real specs will be added in follow-ups.

## Impact

None yet — the build is unchanged. `scripts/build-api-data.js` still fetches all 12 specs from their remote URLs; nothing reads `api-specs/` so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)