### PR TITLE
docs(smartui): add Omni Projects page

### DIFF
--- a/docs/smartui-omni-projects.md
+++ b/docs/smartui-omni-projects.md
@@ -23,7 +23,7 @@ canonical: https://www.testmuai.com/support/docs/smartui-omni-projects/
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import NewTag from '../src/component/newTag';
-import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+import { BRAND_URL } from '@site/src/component/BrandName';
 
 <script type="application/ld+json"
       dangerouslySetInnerHTML={{ __html: JSON.stringify({
@@ -63,12 +63,8 @@ Standard project types work the other way around. A standard project is created 
 | Sending another source type | Accepted | Rejected with a project type mismatch error |
 | Projects needed for a web + mobile + PDF release | One | One per source |
 | Configuration screen | One tab per capture source | Instructions for the project's own source |
-| Baseline selection | Per git branch | One baseline for the project |
+| Baseline selection | Per git branch | One baseline for the project, except CLI projects, which are also per git branch |
 | Build list | One chronological list across all sources | Grouped into **Baseline Build** and **Non Baseline Build** |
-| Status tabs inside a build | **All** and **New** | **All** and **Added To Baseline** |
-| How PDF pages are counted | As variants of a screenshot | As pages of a PDF |
-| Region propagation on a PDF | **Apply to this page** or **Apply to all the pages of this PDF** | Not offered; a region applies to the page it was drawn on |
-| Element Based Anchoring on a PDF | Available, with a configurable search area | Not available |
 
 The practical difference is consolidation. A team shipping a feature across a web app, a mobile app and a generated PDF statement can run all three into one Omni project and read one build list, instead of aggregating status by hand from three projects.
 
@@ -78,7 +74,12 @@ For an enterprise team weighing a move, the differences that actually change day
 
 **Fewer projects, and one place to look.** A release that spans a web app, a mobile app and generated documents needs one Omni project rather than three. Approvers, tags and settings are configured once rather than kept in step across projects, and the release status is read from one build list.
 
-**Branch aware baselines.** This is the change most likely to affect an existing pipeline. Omni resolves the baseline per git branch, in the same way CLI projects already do, so a feature branch compares against its own branch's baseline rather than against whatever the project's single baseline happens to be. Standard Website, App and PDF projects resolve against one baseline for the whole project. If your runs do not currently send branch information, add it before migrating, because Omni treats a build with no branch as being on the default branch.
+**Branch aware baselines.** This is the change most likely to affect an existing pipeline, and how much it affects you depends on where you are coming from.
+
+- Coming from a **CLI** project, nothing changes. CLI projects already resolve baselines per git branch, and Omni behaves the same way.
+- Coming from a **Website**, **App** or **PDF** project, this is new. Those resolve against one baseline for the whole project, whereas Omni resolves per branch, so a feature branch compares against its own branch's baseline rather than against whatever the project's single baseline happens to be.
+
+If your runs do not currently send branch information, add it before migrating, because Omni treats a build with no branch as being on the default branch.
 
 **A different baseline mental model in the dashboard.** A standard project separates its build list into a **Baseline Build** and **Non Baseline Build** section, so the baseline is a specific build you can point at. An Omni project shows one chronological list, and the baseline is resolved per branch rather than being a single pinned build. Teams with a documented approval process that references "the baseline build" will want to revisit that wording.
 
@@ -198,19 +199,25 @@ Annotations behave the same way in an Omni project as anywhere else, and the [re
 - On a **PDF** artifact, a region can be applied to every page of that PDF, and [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring-for-pdf-regions) places it on the anchored content page by page. Both controls are specific to Omni; in a standard PDF project a region stays on the page it was drawn on.
 - On a **website or app** artifact, a region can be applied to every browser and viewport variant of that screenshot.
 
-## Enabling Omni Projects
+## Availability and Access
 
-Omni is enabled for your organisation as a whole. Once it is on, projects you create are Omni projects regardless of which creation flow you use, and they accept every capture source from the start.
+Omni projects are released behind a feature flag and are rolled out progressively.
 
-Existing projects created before Omni was enabled keep their original type and continue to behave exactly as they did, accepting the single source they were created for.
+:::info Enabled per organisation
+Omni is switched on for an organisation as a whole, not per user or per project. Once it is enabled, every project you create is an Omni project regardless of which creation flow you use, and it accepts all six capture sources from the start.
+:::
 
-If you would like Omni enabled for your organisation, get in touch over the <span className="doc_content_link" onClick={() => { window.openLTChatWidget(); }}>24/7 Chat Support</span> or write to <BrandName type="support-email" />.
+- **Existing projects are not converted.** Projects created before Omni was enabled keep their original type and continue to behave exactly as they did, accepting the single source they were created for. There is no in place conversion, so plan for new projects rather than a switch on existing ones.
+- **You can tell the two apart from the dashboard URL.** An Omni project opens under `/test/omni/`, while a standard project opens under its own platform, for example `/test/pdf/`.
+- **If you expect Omni and do not see it**, your organisation may not be enabled yet.
+
+To have Omni enabled for your organisation, contact support at support@testmuai.com or use [24/7 Chat Support](https://www.testmuai.com/support).
 
 ## Best Practices
 
 - **Group by release, not by source.** The value of an Omni project comes from one project covering a whole release. Splitting by source recreates the silos Omni exists to remove.
 - **Keep screenshot names stable across sources.** Names are part of every matching key, so a rename is read as a new artifact rather than a change to an existing one.
-- **Keep git branch information accurate on every run.** Omni resolves baselines per branch, so a missing or wrong branch sends a build to compare against the wrong baseline.
+- **Keep git branch information accurate on every run.** Omni resolves baselines per branch, as CLI projects do, so a missing or wrong branch sends a build to compare against the wrong baseline.
 - **Keep viewports consistent between runs.** A changed resolution produces a new entry rather than a comparison.
 
 ## Additional Resources

--- a/docs/smartui-omni-projects.md
+++ b/docs/smartui-omni-projects.md
@@ -1,0 +1,220 @@
+---
+id: smartui-omni-projects
+title: Omni Projects
+sidebar_label: Omni Projects
+description: Learn how Omni projects in TestMu AI's SmartUI let website, app, PDF, Figma, Storybook and image capture sources co-exist in a single project, and how they differ from standard single-source project types.
+keywords:
+  - Visual Regression
+  - Visual Regression Testing Guide
+  - SmartUI Project Types
+  - Omni Project
+  - Omni Projects
+  - Unified Project
+  - Multi Source Visual Testing
+  - PDF Visual Testing
+  - Figma Visual Testing
+  - Storybook Visual Testing
+
+url: https://www.testmuai.com/support/docs/smartui-omni-projects/
+slug: smartui-omni-projects/
+canonical: https://www.testmuai.com/support/docs/smartui-omni-projects/
+
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import NewTag from '../src/component/newTag';
+import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "TestMu AI",
+          "item": BRAND_URL
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": `${BRAND_URL}/support/docs/`
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Omni Projects",
+          "item": `${BRAND_URL}/support/docs/smartui-omni-projects/`
+        }]
+      })
+    }}
+></script>
+
+# Omni Projects <NewTag value="New" />
+
+An **Omni project** is a SmartUI project type in which every capture source can co-exist. A single Omni project accepts website screenshots, native app screenshots, PDFs, Figma designs, Storybook components and directly uploaded images, side by side in the same project. Each capture run still produces its own build, and builds from different sources sit together in the same build list.
+
+Standard project types work the other way around. A standard project is created for one source, and that choice is fixed: a Website project accepts website captures, a PDF project accepts PDFs, an App project accepts app screenshots. Sending a different source type to a standard project is rejected, and the run fails with a project type mismatch telling you the project already exists with a different platform type, and to either use a different project name or create a project of the platform type you are sending. Covering a release that spans web, mobile and documents therefore means creating and managing several projects side by side.
+
+## Omni vs Standard Projects
+
+| | Omni project | Standard project |
+| --- | --- | --- |
+| Capture sources accepted | Website, App, Figma, Storybook, PDF, Image | One source, fixed at creation |
+| Sending another source type | Accepted | Rejected with a project type mismatch error |
+| Projects needed for a web + mobile + PDF release | One | One per source |
+| Configuration screen | One tab per capture source | Instructions for the project's own source |
+| Baseline selection | Per git branch | One baseline for the project |
+| Build list | One chronological list across all sources | Grouped into **Baseline Build** and **Non Baseline Build** |
+| Status tabs inside a build | **All** and **New** | **All** and **Added To Baseline** |
+| How PDF pages are counted | As variants of a screenshot | As pages of a PDF |
+| Region propagation on a PDF | **Apply to this page** or **Apply to all the pages of this PDF** | Not offered; a region applies to the page it was drawn on |
+| Element Based Anchoring on a PDF | Available, with a configurable search area | Not available |
+
+The practical difference is consolidation. A team shipping a feature across a web app, a mobile app and a generated PDF statement can run all three into one Omni project and read one build list, instead of aggregating status by hand from three projects.
+
+### What this means if you are migrating
+
+For an enterprise team weighing a move, the differences that actually change day to day work are these.
+
+**Fewer projects, and one place to look.** A release that spans a web app, a mobile app and generated documents needs one Omni project rather than three. Approvers, tags and settings are configured once rather than kept in step across projects, and the release status is read from one build list.
+
+**Branch aware baselines.** This is the change most likely to affect an existing pipeline. Omni resolves the baseline per git branch, in the same way CLI projects already do, so a feature branch compares against its own branch's baseline rather than against whatever the project's single baseline happens to be. Standard Website, App and PDF projects resolve against one baseline for the whole project. If your runs do not currently send branch information, add it before migrating, because Omni treats a build with no branch as being on the default branch.
+
+**A different baseline mental model in the dashboard.** A standard project separates its build list into a **Baseline Build** and **Non Baseline Build** section, so the baseline is a specific build you can point at. An Omni project shows one chronological list, and the baseline is resolved per branch rather than being a single pinned build. Teams with a documented approval process that references "the baseline build" will want to revisit that wording.
+
+**Document annotation is materially better on Omni.** In a standard PDF project a region applies only to the page you drew it on, so a 40 page document means 40 regions placed by hand. Omni adds page level propagation plus [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring-for-pdf-regions), so one region can cover the whole document and follow the anchored content as the pages reflow. For teams testing statements, invoices or policy packs this is usually the single biggest reason to move.
+
+**Nothing changes for how you capture.** The CLI commands, SDK hooks and APIs are the same. Omni changes which project accepts the artifact and how baselines are resolved, not how the screenshot is taken, so existing test code does not need rewriting.
+
+**Existing projects are unaffected.** Projects created before Omni was enabled keep their original type and behaviour. Migration is not automatic, and there is no in place conversion of a standard project into an Omni one, so plan for new projects rather than a switch on existing ones.
+
+## Capture Sources
+
+Every source below can be used in the same Omni project. Each one keeps the workflow it already has, because Omni changes where the results land, not how you capture them.
+
+<Tabs className='docs__val' groupId='omni-sources'>
+<TabItem value='website' label='Website' default>
+
+Browser-based capture, through any of the supported routes:
+
+- **CLI exec mode**, to wrap an existing automation suite, for example `npx smartui exec -- npx cypress run`
+- **CLI capture mode**, to capture a list of static URLs with `npx smartui capture urls.json`
+- **SDK hooks**, calling `smartui.snapshot()` directly inside your test code
+- **Web Scanner**, for no-code crawling of a site
+
+</TabItem>
+
+<TabItem value='app' label='App'>
+
+Native mobile app screenshots captured through the app automation SDKs (Appium, Espresso and XCUITest), using the SmartUI screenshot hook inside your test.
+
+</TabItem>
+
+<TabItem value='figma' label='Figma'>
+
+Designs pulled straight from Figma with the CLI, so the intended design can sit in the same project as the implementation that is meant to match it.
+
+```bash
+smartui upload-figma <designs.json>
+```
+
+</TabItem>
+
+<TabItem value='storybook' label='Storybook'>
+
+Component-library validation by crawling a running Storybook instance.
+
+```bash
+npx smartui storybook <storybook-url>
+```
+
+</TabItem>
+
+<TabItem value='pdf' label='PDF'>
+
+Multi-page document verification. Each page of the PDF becomes its own comparison.
+
+```bash
+smartui upload-pdf <path-to-pdfs>
+```
+
+PDFs can also be uploaded through the SmartUI PDF API.
+
+</TabItem>
+
+<TabItem value='image' label='Image'>
+
+Raw image assets uploaded directly, for cases where the screenshot is produced outside SmartUI.
+
+```bash
+smartui upload <path-to-images>
+```
+
+</TabItem>
+</Tabs>
+
+## Where Each Source Is Set Up
+
+The project configuration screen carries one tab per capture source: **Website**, **App**, **Figma**, **Storybook**, **PDF** and **Image**. Each tab holds the integration instructions for that source, including the CLI, SDK and API routes where they apply, along with the project token to authenticate with.
+
+In a standard project this screen shows the instructions for the single source the project was created for. In an Omni project all six tabs are available, so you can add a second or third source to a project that is already running without creating a new one.
+
+## Reading Results
+
+Results for every source land in the same place. The project's build list holds builds from all sources in one chronological list, and opening a build shows the screenshots captured in that run, whether they came from a browser, an app, a design file or a PDF.
+
+Within a build, the **All** and **New** tabs filter by screenshot status rather than by source, and PDF pages are shown as variants of the document they came from.
+
+## How Artifacts Are Matched
+
+Mixing sources in one project only works if SmartUI never compares two things that should not be compared. Omni handles this by matching each artifact against a baseline of the same source, using a key appropriate to that source.
+
+### Visual sources
+
+Website, App, Figma, Storybook and Image artifacts are all raster images, and are matched on a composite key:
+
+`Screenshot Name` + `Browser` + `Resolution` + `Device Name` + `OS`
+
+Every part of the key must match for a comparison to run. This is what stops a Chrome capture being compared against a Firefox baseline, or a desktop capture against a mobile one.
+
+### PDF sources
+
+PDF artifacts are documents rather than raster screenshots, and are matched on their own key:
+
+`Screenshot Name` + `Document Name` + `Page Number` + `Resolution`
+
+PDFs are kept in a separate logical space from the visual sources, because document comparison and pixel comparison are different operations. A PDF is never compared against a website, app, Figma, Storybook or image artifact, and vice versa.
+
+### Same name, different sources
+
+Because matching is source-aware, a PDF named `Report` and a web page named `Report` can live in the same project without colliding. They stay two separate entries and neither overwrites the other.
+
+Similarly, two artifacts that share a name but were captured at different resolutions, say a page captured at 390x844 and the same page at 1920x1080, are treated as separate entries rather than compared against one another.
+
+## Working with Regions in an Omni Project
+
+Annotations behave the same way in an Omni project as anywhere else, and the [region types and scope controls](/support/docs/smartui-draw-on-ui/) are unchanged. What differs is the axis a region propagates along, which follows the source of the screenshot you drew it on:
+
+- On a **PDF** artifact, a region can be applied to every page of that PDF, and [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring-for-pdf-regions) places it on the anchored content page by page. Both controls are specific to Omni; in a standard PDF project a region stays on the page it was drawn on.
+- On a **website or app** artifact, a region can be applied to every browser and viewport variant of that screenshot.
+
+## Enabling Omni Projects
+
+Omni is enabled for your organisation as a whole. Once it is on, projects you create are Omni projects regardless of which creation flow you use, and they accept every capture source from the start.
+
+Existing projects created before Omni was enabled keep their original type and continue to behave exactly as they did, accepting the single source they were created for.
+
+If you would like Omni enabled for your organisation, get in touch over the <span className="doc_content_link" onClick={() => { window.openLTChatWidget(); }}>24/7 Chat Support</span> or write to <BrandName type="support-email" />.
+
+## Best Practices
+
+- **Group by release, not by source.** The value of an Omni project comes from one project covering a whole release. Splitting by source recreates the silos Omni exists to remove.
+- **Keep screenshot names stable across sources.** Names are part of every matching key, so a rename is read as a new artifact rather than a change to an existing one.
+- **Keep git branch information accurate on every run.** Omni resolves baselines per branch, so a missing or wrong branch sends a build to compare against the wrong baseline.
+- **Keep viewports consistent between runs.** A changed resolution produces a new entry rather than a comparison.
+
+## Additional Resources
+
+- [Ignore or Select Annotated Regions](/support/docs/smartui-draw-on-ui/)
+- [Running Your First Project](/support/docs/smartui-running-your-first-project/)
+- [SmartUI CLI Environment Variables](/support/docs/smartui-cli-env-variables/)

--- a/sidebars.js
+++ b/sidebars.js
@@ -2716,6 +2716,7 @@ module.exports = {
         },
         items: [
           "smartui-running-your-first-project",
+          "smartui-omni-projects",
           "smartui-agent-skills",
           "smartui-guided-walkthrough",
           "smartui-cli-env-variables",


### PR DESCRIPTION
## What

Adds `docs/smartui-omni-projects.md`, a new page for the **Omni** project type, listed under SmartUI, Getting Started.

Omni is the project type in which every capture source co-exists, covering website, app, Figma, Storybook, PDF and image in a single project. A standard project is fixed to the one source chosen at creation, and sending another source type is rejected with a project type mismatch error.

## Changes

The page covers what an Omni project is, a comparison against standard projects, a migration section for teams weighing a move, a tab per capture source with its capture route, where each source is configured, how results are read, how artifacts are matched, how regions propagate per source, how Omni is enabled, and best practices.

## Verification

Grounded in observed production behaviour rather than the PRD alone. A standard PDF project and an Omni project were opened side by side, and the shipped matcher was read in `dotlapse-event-service`. The differences documented are the ones that actually ship:

| | Omni | Standard |
| --- | --- | --- |
| Baseline selection | Per git branch | One baseline for the project |
| Build list | One chronological list | Grouped into Baseline Build and Non Baseline Build |
| Status tabs in a build | All, New | All, Added To Baseline |
| PDF pages counted as | Variants of a screenshot | Pages of a PDF |
| Region propagation on a PDF | Per page, with Element Based Anchoring | Not offered |

Matching keys are taken from `utils/screenshot_matcher.go` (`MatchScreenshotOmni`), and the standard project rejection from `api/validate.go`.

**Three PRD claims were dropped because they are not in the shipped product:**

1. A results dashboard with a tab per source. The build list is one flat list; the per source tabs are on the project configuration screen, not on results.
2. Multiple sources sharing a single build. Each capture run produces its own build; sources co-exist at project level.
3. A source badge on same named artifacts. Not observed, so the page says only that the entries stay separate.

## Companion PR

The anchoring cross link points at the section added in the companion Element Based Anchoring PR, so the two are best landed together.

Ref: [TE-22284](https://lambdatest.atlassian.net/browse/TE-22284)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUWrmrUTPUmy66H9bJLF2S

[TE-22284]: https://lambdatest.atlassian.net/browse/TE-22284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ