### PR TITLE
docs(smartui): correct Element Based Anchoring scope, search area 0, and Delete All

### DIFF
--- a/docs/smartui-draw-on-ui.md
+++ b/docs/smartui-draw-on-ui.md
@@ -61,7 +61,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 Web applications often have dynamic elements that can cause unnecessary noise in your visual testing. Take a social media platform, for instance. The number of unread notifications displayed might change with each test run. While these variations are expected, you don't necessarily want them to trigger alerts as potential regressions.
 
-The SmartUI Annotation tool allows you to interact directly with your screenshots through detailed annotations. You can draw over screenshots, define regions with boxes, and choose to ignore or select these regions for current and future comparisons. With advanced features like **Ignore Colors**, **Floating Regions**, **Layout Regions**, **Select Ignore**, and **Element Based Anchoring** for multi-page PDFs, you can handle even the most complex dynamic content scenarios.
+The SmartUI Annotation tool allows you to interact directly with your screenshots through detailed annotations. You can draw over screenshots, define regions with boxes, and choose to ignore or select these regions for current and future comparisons. With advanced features like **Ignore Colors**, **Floating Regions**, **Layout Regions**, **Select Ignore**, and **Element Based Anchoring** for multi-page PDFs and multi-variant web screenshots, you can handle even the most complex dynamic content scenarios.
 
 By utilizing ignored/selected regions, you can keep your test results focused on the truly important changes, streamlining your workflow and saving you time from chasing irrelevant discrepancies.
 
@@ -353,97 +353,111 @@ This is useful when you already know an area is dynamic at the moment you establ
 
 > **Tip:** Use a baseline region for content you already know is dynamic before the first comparison ever runs. For areas you discover later while reviewing a comparison, a normal region on that build is the simpler choice.
 
-## Element Based Anchoring for PDF Regions <NewTag value="New" />
+## Element Based Anchoring <NewTag value="New" />
 
-When you draw a region on a PDF and apply it to every page, the region normally keeps the coordinates you drew it at. PDFs reflow, so the same heading, label or footer usually sits at a slightly different position on each page, and a region pinned to page 1's coordinates will not line up with it on the other pages.
+When you draw a region and propagate it, the region normally keeps the coordinates you drew it at. The same content rarely sits at the same coordinates on the target: a PDF reflows, so a heading or footer lands slightly differently on each page, and a web page reflows across browsers and viewports, so the same element sits somewhere else in each variant. A region pinned to the coordinates you drew it at will not line up with it there.
 
-**Element based anchoring** changes what the region is attached to. Instead of remembering *where* you drew the box, SmartUI remembers *what* was inside it, captures the text under the box as an anchor, and then locates that same content on every other page of the PDF. The region is placed wherever the anchor is actually found on that page.
+**Element based anchoring** changes what the region is attached to. Instead of remembering *where* you drew the box, SmartUI remembers *what* was inside it, captures that content as an anchor, and then locates the same content on every target. The region is placed wherever the anchor is actually found, and it is sized from the content that was matched rather than copied from the box you drew.
 
-Matching is done on the text content itself, so the font family, size, weight and style of the anchored content do not affect whether it is found.
+Anchoring works on **both PDF and web comparisons**. The mechanics of the match differ by source:
+
+- **PDF comparisons** anchor on the text under the box, and the region propagates across the pages of the document. Because the match reads the text itself, the font family, size, weight and style of the anchored content do not affect whether it is found.
+- **Web comparisons** anchor on the DOM elements under the box, scored on their path, classes, applied styles, id, size and tag, and the region propagates across the browser and viewport variants of the screenshot.
+
+> **Note:** Anchoring is not offered on real device and app screenshots, which carry neither a DOM nor an extractable document. On those the region propagates by coordinates as before.
 
 ### The Problem It Solves
 
-Teams running visual tests on generated documents such as statements, invoices, policy packs and regulatory filings all hit the same wall. The document is reviewed page by page, and the parts of it that are genuinely dynamic (a generation timestamp, an account holder's name, a running header) sit in a slightly different place on every page because the content above them reflows.
+Teams running visual tests on generated documents such as statements, invoices, policy packs and regulatory filings all hit the same wall. The document is reviewed page by page, and the parts of it that are genuinely dynamic (a generation timestamp, an account holder's name, a running header) sit in a slightly different place on every page because the content above them reflows. Web suites hit the same wall along a different axis: a region drawn on Chrome at one viewport lands beside its element on Firefox, or on a narrower viewport where the page has reflowed.
 
 Without anchoring, there are only two ways to handle that, and both cost you something:
 
 | Approach | What it costs |
 | --- | --- |
-| Draw the region once and apply it to all pages | The box lands on the coordinates from the page you drew it on, so on other pages it sits beside the content instead of on it |
-| Redraw the region manually on every page | Minutes per document, repeated every time the template changes, and it does not survive a new document with a different page count |
+| Draw the region once and propagate it | The box lands on the coordinates from the page or variant you drew it on, so elsewhere it sits beside the content instead of on it |
+| Redraw the region manually on every page or variant | Minutes per document or per screenshot, repeated every time the template or the layout changes, and it does not survive a new document with a different page count |
 
 For a 40-page statement, that is 40 manual regions to place and re-place. Teams either spend the time, or they stop annotating and accept the noise.
 
 ### Product Impact
 
-- **Annotation effort drops from per-page to per-document.** One region, drawn once, covers every page of the PDF. The saving scales with page count, so it is largest on exactly the long documents that were most painful before.
+- **Annotation effort drops from per-page to per-document, and from per-variant to per-screenshot.** One region, drawn once, covers every page of the PDF or every browser and viewport variant of the screenshot. The saving scales with the number of targets, so it is largest on exactly the long documents and wide browser matrices that were most painful before.
 - **Fewer false positives to triage.** A region that actually sits on the dynamic content suppresses the noise it was meant to suppress, so reviewers spend their time on real changes rather than dismissing the same reflow difference on every page.
 - **Fewer missed regressions.** When a mispositioned region covers the wrong part of the page, it can hide a genuine change while leaving the intended one exposed. Anchoring to content keeps the region on the thing you chose.
-- **Annotations survive template changes.** Because the region is tied to content rather than coordinates, a layout change that moves the anchored element does not require the region to be redrawn.
-- **Consistent results across renditions.** Since matching ignores font family, size, weight and style, the same annotation behaves the same way across documents rendered with different typography.
+- **Annotations survive layout changes.** Because the region is tied to content rather than coordinates, a template or layout change that moves the anchored element does not require the region to be redrawn.
+- **Consistent results across renditions.** On PDFs, matching ignores font family, size, weight and style, so the same annotation behaves the same way across documents rendered with different typography.
 
 ### When to Use
 
 - Anchoring a company name, report title or letterhead in a statement whose header shifts from page to page
 - Keeping an ignore region on a running footer or document strap line across a long PDF
 - Annotating a repeated label in an invoice, policy document or financial statement where the vertical position drifts as content reflows
-- Any multi-page PDF where you would otherwise redraw the same region page by page
+- Propagating a region across browsers or viewports where the element sits at a different position in each variant
+- Any multi-page PDF or multi-variant screenshot where you would otherwise redraw the same region target by target
 
 ### How to Use
 
-**Step 1:** Open a PDF comparison in an [Omni project](/support/docs/smartui-omni-projects/) and click on the **Actions** button (annotation icon) to open the annotation tool.
-
-> **Note:** Element based anchoring, and page level region propagation generally, are available on PDF comparisons in **Omni projects**. In a standard PDF project the region settings panel offers the region types only, and a region applies to the page it was drawn on.
+**Step 1:** Open a comparison and click on the **Actions** button (annotation icon) to open the annotation tool.
 
 **Step 2:** Draw a box around the content you want to anchor to, and pick the region type you want (for example, **Ignore Region** or **Floating Region**).
 
-**Step 3:** Under **Apply region to**, choose **Apply to all the pages of this PDF**, then tick the **Element based anchoring** checkbox.
+**Step 3:** Under **Apply region to**, choose the propagation scope for the source you are annotating, then tick the **Element based anchoring** checkbox.
+
+- On a **PDF** comparison, choose **Apply to all the pages of this PDF**.
+- On a **web** comparison, choose **Apply to all variants**.
 
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/annotation-tool/elementbasedanchoring.png').default} alt="Element based anchoring with search area in the region settings panel" width="1180" height="511" className='doc_img'/>
 
-**Step 4:** Set the **Search area** value in pixels. This is how far out from the drawn box SmartUI will look for the anchor content on each of the other pages. The default is `50` px, and you can set any value between `0` and `500` px.
+> **Note:** Page level propagation on PDFs is available in **Omni projects**. In a standard PDF project a region applies to the page it was drawn on, so there is nothing to propagate it across.
 
-**Step 5:** Click **Save**, then confirm with **Apply Changes**. SmartUI resolves the anchor on every page and reports how many pages the region was applied to.
+**Step 4:** Set the **Search area** value in pixels. This is how far out from the drawn box SmartUI will look for the anchor content on each of the other targets. The default is `50` px, and you can set any value between `0` and `500` px.
+
+**Step 5:** Click **Save**, then confirm with **Apply Changes**. SmartUI resolves the anchor on every target and reports how many of them the region was applied to.
 
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/annotation-tool/elementanchoring_sourcepage.png').default} alt="Anchored regions on the page the region was drawn on" width="1180" height="479" className='doc_img'/>
 
-**What Happens:** On each page of the PDF, SmartUI looks for the anchor content within the search area around the drawn position and places the region where that content is found. Open any other page of the PDF to see the region sitting on the same content, at that page's own position.
+**What Happens:** On each target, SmartUI looks for the anchor content within the search area around the drawn position and places the region where that content is found. Open any other page of the PDF, or any other variant of the screenshot, to see the region sitting on the same content at that target's own position.
+
+> **Important:** Where the anchor cannot be found within the search area, the region is **not placed on that target at all**, and the result is reported back to you. SmartUI never falls back to stamping the box at the drawn coordinates, because a mask in the wrong place hides real differences.
 
 <img loading="lazy" src={require('../assets/images/smart-visual-testing/annotation-tool/resultofelementanchoring.png').default} alt="Anchored region placed on the same content on a later page of the PDF" width="1180" height="511" className='doc_img'/>
 
 ### Choosing a Search Area
 
-The search area controls how far the anchor content is allowed to have moved and still be matched on a given page.
+The search area controls how far the anchor content is allowed to have moved and still be matched on a given target.
 
-- **Smaller values** keep the match close to where you drew the region. Use these when the content only shifts slightly between pages, or when similar text appears elsewhere on the page and you want to be sure the nearest occurrence is the one that is used.
-- **Larger values** let SmartUI find the anchor further from the drawn position. Use these when the content moves further down or across the page as the document reflows.
-- **`0`** turns the search off, so the region stays at the coordinates you drew it at, which is the same behaviour as a region without element based anchoring.
+- **Smaller values** keep the match close to where you drew the region. Use these when the content only shifts slightly between targets, or when similar content appears elsewhere and you want to be sure the nearest occurrence is the one that is used.
+- **Larger values** let SmartUI find the anchor further from the drawn position. Use these when the content moves further down or across the page as the document or layout reflows.
+- **`0`** turns the search off. SmartUI looks for the anchored content only inside the drawn box itself: if it is there, the region is placed, and if it is not, the region is not placed on that target. This is **not** the same as a region without element based anchoring, which is copied to the drawn coordinates on every target without checking what is there.
 
-> **Tip:** Start with the default of `50` px. If a page's content sits further from the drawn position than that, raise the search area and apply the region again.
+> **Tip:** Start with the default of `50` px. If a target's content sits further from the drawn position than that, raise the search area and apply the region again.
 
 ### Propagating Regions on PDFs and Websites
 
 Regions propagate on both PDF and website comparisons, but the axis they propagate along is different, so the control you use is different too.
 
-| | PDF comparisons | Website and app comparisons |
-| --- | --- | --- |
-| What a region propagates across | The pages of the PDF | The browser and viewport variants of the screenshot |
-| Scope control | **Apply to all the pages of this PDF** | **Apply to all variants** |
-| Available region types | Ignore, Select, Floating, Ignore Colors, Layout | Ignore, Select, Floating, Ignore Colors |
-| Element based anchoring | Available, on every region type | Not applicable |
-| Project type required | Omni | Any |
+| | PDF comparisons | Website comparisons | App and real device comparisons |
+| --- | --- | --- | --- |
+| What a region propagates across | The pages of the PDF | The browser and viewport variants of the screenshot | The variants of the screenshot |
+| Scope control | **Apply to all the pages of this PDF** | **Apply to all variants** | **Apply to all variants** |
+| Available region types | Ignore, Select, Floating, Ignore Colors, Layout | Ignore, Select, Floating, Ignore Colors, Layout | Ignore, Select, Floating, Ignore Colors |
+| Element based anchoring | Available, on every region type | Available, on every region type | Not offered |
+| What the anchor matches on | The text under the drawn box | The DOM elements under the drawn box | Not applicable |
+| Project type required | Omni, for page level propagation | Any | Any |
 
-**On a PDF**, the same document flows across many pages, so the same element lands at a different position on each one. This is what element based anchoring is for: tick the checkbox, set a search area, and the region is placed on the anchored content page by page.
+**On a PDF**, the same document flows across many pages, so the same element lands at a different position on each one. Tick the checkbox, set a search area, and the region is placed on the anchored content page by page.
 
-**On a website or app screenshot**, a region propagates across the browser and viewport variants of that screenshot instead. Draw the region, choose [**Apply to all variants**](/support/docs/smartui-draw-on-ui/#applying-annotations), and it is copied to every browser and viewport combination for that screenshot. Each region carries its own scope, so applying one region to all variants leaves your other annotations untouched.
+**On a website screenshot**, a region propagates across the browser and viewport variants of that screenshot instead. Draw the region, choose [**Apply to all variants**](/support/docs/smartui-draw-on-ui/#applying-annotations), and tick **Element based anchoring** so that it lands on its element in each variant rather than at the coordinates from the variant you drew it on. Each region carries its own scope, so applying one region to all variants leaves your other annotations untouched.
 
-> **Tip:** If you are annotating a multi-page PDF, reach for **Apply to all the pages of this PDF** with **Element based anchoring**. If you are annotating a website across Chrome, Firefox and Safari or across desktop and mobile viewports, reach for **Apply to all variants**.
+> **Note:** Anchoring on web reads the DOM element data recorded alongside the screenshot, the same data that [Layout Regions](/support/docs/smartui-layout-regions/#dom-recording-requirement-for-web-comparisons) use. A build made from an uploaded image carries no DOM, so there is nothing to anchor to. PDF comparisons are not affected, since they read the structure out of the document itself.
 
-> **Note:** In an [Omni project](/support/docs/smartui-omni-projects/), where PDF, website, app, Figma, Storybook and image sources all co-exist in one project, both propagation controls are available in the same place. The one you see for a given comparison follows the source of the screenshot you are annotating: PDF artifacts offer **Apply to all the pages of this PDF** together with **Element based anchoring**, and website and app artifacts offer **Apply to all variants**.
+> **Note:** In an [Omni project](/support/docs/smartui-omni-projects/), where PDF, website, app, Figma, Storybook and image sources all co-exist in one project, both propagation controls are available in the same place. The one you see for a given comparison follows the source of the screenshot you are annotating: PDF artifacts offer **Apply to all the pages of this PDF**, and website and app artifacts offer **Apply to all variants**.
 
 ### Example
 
 A six-page quarterly statement where the company name in the header sits at a slightly different position on every page. Draw an ignore region around the company name on page 1, choose **Apply to all the pages of this PDF**, tick **Element based anchoring**, and the region lands on the company name on each page rather than on the blank space where page 1's header used to be.
+
+The web equivalent is a cookie banner or a promo strip that sits at a different height on Chrome and Firefox, or at a different position once the page reflows on a narrow viewport. Draw the ignore region on one variant, choose **Apply to all variants** with **Element based anchoring**, and it lands on the banner in each variant.
 
 ## Managing Annotations
 
@@ -480,9 +494,11 @@ You can always edit or delete pre-configured areas or add new ones according to 
 
 **Step 1:** Click on the **Actions** button (annotation icon).
 
-**Step 2:** Click on the annotation box you want to delete, or click **Delete All** to remove all annotations.
+**Step 2:** Click on the annotation box you want to delete, then remove it with the `Delete` or `Backspace` key.
 
 **Step 3:** Click on the **Save** button to confirm deletion.
+
+> **Note:** Annotations are deleted one at a time. There is no control that removes every annotation on a screenshot in a single action, so repeat the steps above for each box you want to remove.
 
 > **Note:** Deleting annotations will trigger a re-run of the comparison, and the previously ignored/selected areas will be included in future comparisons.
 

--- a/docs/smartui-omni-projects.md
+++ b/docs/smartui-omni-projects.md
@@ -83,7 +83,7 @@ If your runs do not currently send branch information, add it before migrating, 
 
 **A different baseline mental model in the dashboard.** A standard project separates its build list into a **Baseline Build** and **Non Baseline Build** section, so the baseline is a specific build you can point at. An Omni project shows one chronological list, and the baseline is resolved per branch rather than being a single pinned build. Teams with a documented approval process that references "the baseline build" will want to revisit that wording.
 
-**Document annotation is materially better on Omni.** In a standard PDF project a region applies only to the page you drew it on, so a 40 page document means 40 regions placed by hand. Omni adds page level propagation plus [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring-for-pdf-regions), so one region can cover the whole document and follow the anchored content as the pages reflow. For teams testing statements, invoices or policy packs this is usually the single biggest reason to move.
+**Document annotation is materially better on Omni.** In a standard PDF project a region applies only to the page you drew it on, so a 40 page document means 40 regions placed by hand. Omni adds page level propagation plus [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring), so one region can cover the whole document and follow the anchored content as the pages reflow. For teams testing statements, invoices or policy packs this is usually the single biggest reason to move.
 
 **Nothing changes for how you capture.** The CLI commands, SDK hooks and APIs are the same. Omni changes which project accepts the artifact and how baselines are resolved, not how the screenshot is taken, so existing test code does not need rewriting.
 
@@ -196,7 +196,7 @@ Similarly, two artifacts that share a name but were captured at different resolu
 
 Annotations behave the same way in an Omni project as anywhere else, and the [region types and scope controls](/support/docs/smartui-draw-on-ui/) are unchanged. What differs is the axis a region propagates along, which follows the source of the screenshot you drew it on:
 
-- On a **PDF** artifact, a region can be applied to every page of that PDF, and [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring-for-pdf-regions) places it on the anchored content page by page. Both controls are specific to Omni; in a standard PDF project a region stays on the page it was drawn on.
+- On a **PDF** artifact, a region can be applied to every page of that PDF, and [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring) places it on the anchored content page by page. Page level propagation is specific to Omni: in a standard PDF project a region stays on the page it was drawn on. Anchoring itself is not limited to Omni, and is available on web comparisons in any project.
 - On a **website or app** artifact, a region can be applied to every browser and viewport variant of that screenshot.
 
 ## Availability and Access

--- a/static/docs/smartui-draw-on-ui.md
+++ b/static/docs/smartui-draw-on-ui.md
@@ -4,7 +4,7 @@
 
 Web applications often have dynamic elements that can cause unnecessary noise in your visual testing. Take a social media platform, for instance. The number of unread notifications displayed might change with each test run. While these variations are expected, you don't necessarily want them to trigger alerts as potential regressions.
 
-The SmartUI Annotation tool allows you to interact directly with your screenshots through detailed annotations. You can draw over screenshots, define regions with boxes, and choose to ignore or select these regions for current and future comparisons. With advanced features like **Ignore Colors**, **Floating Regions**, **Layout Regions**, **Select Ignore**, and **Element Based Anchoring** for multi-page PDFs, you can handle even the most complex dynamic content scenarios.
+The SmartUI Annotation tool allows you to interact directly with your screenshots through detailed annotations. You can draw over screenshots, define regions with boxes, and choose to ignore or select these regions for current and future comparisons. With advanced features like **Ignore Colors**, **Floating Regions**, **Layout Regions**, **Select Ignore**, and **Element Based Anchoring** for multi-page PDFs and multi-variant web screenshots, you can handle even the most complex dynamic content scenarios.
 
 By utilizing ignored/selected regions, you can keep your test results focused on the truly important changes, streamlining your workflow and saving you time from chasing irrelevant discrepancies.
 
@@ -249,91 +249,105 @@ This is useful when you already know an area is dynamic at the moment you establ
 
 > **Tip:** Use a baseline region for content you already know is dynamic before the first comparison ever runs. For areas you discover later while reviewing a comparison, a normal region on that build is the simpler choice.
 
-## Element Based Anchoring for PDF Regions
+## Element Based Anchoring
 
-When you draw a region on a PDF and apply it to every page, the region normally keeps the coordinates you drew it at. PDFs reflow, so the same heading, label or footer usually sits at a slightly different position on each page, and a region pinned to page 1's coordinates will not line up with it on the other pages.
+When you draw a region and propagate it, the region normally keeps the coordinates you drew it at. The same content rarely sits at the same coordinates on the target: a PDF reflows, so a heading or footer lands slightly differently on each page, and a web page reflows across browsers and viewports, so the same element sits somewhere else in each variant. A region pinned to the coordinates you drew it at will not line up with it there.
 
-**Element based anchoring** changes what the region is attached to. Instead of remembering *where* you drew the box, SmartUI remembers *what* was inside it, captures the text under the box as an anchor, and then locates that same content on every other page of the PDF. The region is placed wherever the anchor is actually found on that page.
+**Element based anchoring** changes what the region is attached to. Instead of remembering *where* you drew the box, SmartUI remembers *what* was inside it, captures that content as an anchor, and then locates the same content on every target. The region is placed wherever the anchor is actually found, and it is sized from the content that was matched rather than copied from the box you drew.
 
-Matching is done on the text content itself, so the font family, size, weight and style of the anchored content do not affect whether it is found.
+Anchoring works on **both PDF and web comparisons**. The mechanics of the match differ by source:
+
+- **PDF comparisons** anchor on the text under the box, and the region propagates across the pages of the document. Because the match reads the text itself, the font family, size, weight and style of the anchored content do not affect whether it is found.
+- **Web comparisons** anchor on the DOM elements under the box, scored on their path, classes, applied styles, id, size and tag, and the region propagates across the browser and viewport variants of the screenshot.
+
+> **Note:** Anchoring is not offered on real device and app screenshots, which carry neither a DOM nor an extractable document. On those the region propagates by coordinates as before.
 
 ### The Problem It Solves
 
-Teams running visual tests on generated documents such as statements, invoices, policy packs and regulatory filings all hit the same wall. The document is reviewed page by page, and the parts of it that are genuinely dynamic (a generation timestamp, an account holder's name, a running header) sit in a slightly different place on every page because the content above them reflows.
+Teams running visual tests on generated documents such as statements, invoices, policy packs and regulatory filings all hit the same wall. The document is reviewed page by page, and the parts of it that are genuinely dynamic (a generation timestamp, an account holder's name, a running header) sit in a slightly different place on every page because the content above them reflows. Web suites hit the same wall along a different axis: a region drawn on Chrome at one viewport lands beside its element on Firefox, or on a narrower viewport where the page has reflowed.
 
 Without anchoring, there are only two ways to handle that, and both cost you something:
 
 | Approach | What it costs |
 | --- | --- |
-| Draw the region once and apply it to all pages | The box lands on the coordinates from the page you drew it on, so on other pages it sits beside the content instead of on it |
-| Redraw the region manually on every page | Minutes per document, repeated every time the template changes, and it does not survive a new document with a different page count |
+| Draw the region once and propagate it | The box lands on the coordinates from the page or variant you drew it on, so elsewhere it sits beside the content instead of on it |
+| Redraw the region manually on every page or variant | Minutes per document or per screenshot, repeated every time the template or the layout changes, and it does not survive a new document with a different page count |
 
 For a 40-page statement, that is 40 manual regions to place and re-place. Teams either spend the time, or they stop annotating and accept the noise.
 
 ### Product Impact
 
-- **Annotation effort drops from per-page to per-document.** One region, drawn once, covers every page of the PDF. The saving scales with page count, so it is largest on exactly the long documents that were most painful before.
+- **Annotation effort drops from per-page to per-document, and from per-variant to per-screenshot.** One region, drawn once, covers every page of the PDF or every browser and viewport variant of the screenshot. The saving scales with the number of targets, so it is largest on exactly the long documents and wide browser matrices that were most painful before.
 - **Fewer false positives to triage.** A region that actually sits on the dynamic content suppresses the noise it was meant to suppress, so reviewers spend their time on real changes rather than dismissing the same reflow difference on every page.
 - **Fewer missed regressions.** When a mispositioned region covers the wrong part of the page, it can hide a genuine change while leaving the intended one exposed. Anchoring to content keeps the region on the thing you chose.
-- **Annotations survive template changes.** Because the region is tied to content rather than coordinates, a layout change that moves the anchored element does not require the region to be redrawn.
-- **Consistent results across renditions.** Since matching ignores font family, size, weight and style, the same annotation behaves the same way across documents rendered with different typography.
+- **Annotations survive layout changes.** Because the region is tied to content rather than coordinates, a template or layout change that moves the anchored element does not require the region to be redrawn.
+- **Consistent results across renditions.** On PDFs, matching ignores font family, size, weight and style, so the same annotation behaves the same way across documents rendered with different typography.
 
 ### When to Use
 
 - Anchoring a company name, report title or letterhead in a statement whose header shifts from page to page
 - Keeping an ignore region on a running footer or document strap line across a long PDF
 - Annotating a repeated label in an invoice, policy document or financial statement where the vertical position drifts as content reflows
-- Any multi-page PDF where you would otherwise redraw the same region page by page
+- Propagating a region across browsers or viewports where the element sits at a different position in each variant
+- Any multi-page PDF or multi-variant screenshot where you would otherwise redraw the same region target by target
 
 ### How to Use
 
-**Step 1:** Open a PDF comparison in an [Omni project](/support/docs/smartui-omni-projects/) and click on the **Actions** button (annotation icon) to open the annotation tool.
-
-> **Note:** Element based anchoring, and page level region propagation generally, are available on PDF comparisons in **Omni projects**. In a standard PDF project the region settings panel offers the region types only, and a region applies to the page it was drawn on.
+**Step 1:** Open a comparison and click on the **Actions** button (annotation icon) to open the annotation tool.
 
 **Step 2:** Draw a box around the content you want to anchor to, and pick the region type you want (for example, **Ignore Region** or **Floating Region**).
 
-**Step 3:** Under **Apply region to**, choose **Apply to all the pages of this PDF**, then tick the **Element based anchoring** checkbox.
+**Step 3:** Under **Apply region to**, choose the propagation scope for the source you are annotating, then tick the **Element based anchoring** checkbox.
 
-**Step 4:** Set the **Search area** value in pixels. This is how far out from the drawn box SmartUI will look for the anchor content on each of the other pages. The default is `50` px, and you can set any value between `0` and `500` px.
+- On a **PDF** comparison, choose **Apply to all the pages of this PDF**.
+- On a **web** comparison, choose **Apply to all variants**.
 
-**Step 5:** Click **Save**, then confirm with **Apply Changes**. SmartUI resolves the anchor on every page and reports how many pages the region was applied to.
+> **Note:** Page level propagation on PDFs is available in **Omni projects**. In a standard PDF project a region applies to the page it was drawn on, so there is nothing to propagate it across.
 
-**What Happens:** On each page of the PDF, SmartUI looks for the anchor content within the search area around the drawn position and places the region where that content is found. Open any other page of the PDF to see the region sitting on the same content, at that page's own position.
+**Step 4:** Set the **Search area** value in pixels. This is how far out from the drawn box SmartUI will look for the anchor content on each of the other targets. The default is `50` px, and you can set any value between `0` and `500` px.
+
+**Step 5:** Click **Save**, then confirm with **Apply Changes**. SmartUI resolves the anchor on every target and reports how many of them the region was applied to.
+
+**What Happens:** On each target, SmartUI looks for the anchor content within the search area around the drawn position and places the region where that content is found. Open any other page of the PDF, or any other variant of the screenshot, to see the region sitting on the same content at that target's own position.
+
+> **Important:** Where the anchor cannot be found within the search area, the region is **not placed on that target at all**, and the result is reported back to you. SmartUI never falls back to stamping the box at the drawn coordinates, because a mask in the wrong place hides real differences.
 
 ### Choosing a Search Area
 
-The search area controls how far the anchor content is allowed to have moved and still be matched on a given page.
+The search area controls how far the anchor content is allowed to have moved and still be matched on a given target.
 
-- **Smaller values** keep the match close to where you drew the region. Use these when the content only shifts slightly between pages, or when similar text appears elsewhere on the page and you want to be sure the nearest occurrence is the one that is used.
-- **Larger values** let SmartUI find the anchor further from the drawn position. Use these when the content moves further down or across the page as the document reflows.
-- **`0`** turns the search off, so the region stays at the coordinates you drew it at, which is the same behaviour as a region without element based anchoring.
+- **Smaller values** keep the match close to where you drew the region. Use these when the content only shifts slightly between targets, or when similar content appears elsewhere and you want to be sure the nearest occurrence is the one that is used.
+- **Larger values** let SmartUI find the anchor further from the drawn position. Use these when the content moves further down or across the page as the document or layout reflows.
+- **`0`** turns the search off. SmartUI looks for the anchored content only inside the drawn box itself: if it is there, the region is placed, and if it is not, the region is not placed on that target. This is **not** the same as a region without element based anchoring, which is copied to the drawn coordinates on every target without checking what is there.
 
-> **Tip:** Start with the default of `50` px. If a page's content sits further from the drawn position than that, raise the search area and apply the region again.
+> **Tip:** Start with the default of `50` px. If a target's content sits further from the drawn position than that, raise the search area and apply the region again.
 
 ### Propagating Regions on PDFs and Websites
 
 Regions propagate on both PDF and website comparisons, but the axis they propagate along is different, so the control you use is different too.
 
-| | PDF comparisons | Website and app comparisons |
-| --- | --- | --- |
-| What a region propagates across | The pages of the PDF | The browser and viewport variants of the screenshot |
-| Scope control | **Apply to all the pages of this PDF** | **Apply to all variants** |
-| Available region types | Ignore, Select, Floating, Ignore Colors, Layout | Ignore, Select, Floating, Ignore Colors |
-| Element based anchoring | Available, on every region type | Not applicable |
-| Project type required | Omni | Any |
+| | PDF comparisons | Website comparisons | App and real device comparisons |
+| --- | --- | --- | --- |
+| What a region propagates across | The pages of the PDF | The browser and viewport variants of the screenshot | The variants of the screenshot |
+| Scope control | **Apply to all the pages of this PDF** | **Apply to all variants** | **Apply to all variants** |
+| Available region types | Ignore, Select, Floating, Ignore Colors, Layout | Ignore, Select, Floating, Ignore Colors, Layout | Ignore, Select, Floating, Ignore Colors |
+| Element based anchoring | Available, on every region type | Available, on every region type | Not offered |
+| What the anchor matches on | The text under the drawn box | The DOM elements under the drawn box | Not applicable |
+| Project type required | Omni, for page level propagation | Any | Any |
 
-**On a PDF**, the same document flows across many pages, so the same element lands at a different position on each one. This is what element based anchoring is for: tick the checkbox, set a search area, and the region is placed on the anchored content page by page.
+**On a PDF**, the same document flows across many pages, so the same element lands at a different position on each one. Tick the checkbox, set a search area, and the region is placed on the anchored content page by page.
 
-**On a website or app screenshot**, a region propagates across the browser and viewport variants of that screenshot instead. Draw the region, choose [**Apply to all variants**](/support/docs/smartui-draw-on-ui/#applying-annotations), and it is copied to every browser and viewport combination for that screenshot. Each region carries its own scope, so applying one region to all variants leaves your other annotations untouched.
+**On a website screenshot**, a region propagates across the browser and viewport variants of that screenshot instead. Draw the region, choose [**Apply to all variants**](/support/docs/smartui-draw-on-ui/#applying-annotations), and tick **Element based anchoring** so that it lands on its element in each variant rather than at the coordinates from the variant you drew it on. Each region carries its own scope, so applying one region to all variants leaves your other annotations untouched.
 
-> **Tip:** If you are annotating a multi-page PDF, reach for **Apply to all the pages of this PDF** with **Element based anchoring**. If you are annotating a website across Chrome, Firefox and Safari or across desktop and mobile viewports, reach for **Apply to all variants**.
+> **Note:** Anchoring on web reads the DOM element data recorded alongside the screenshot, the same data that [Layout Regions](/support/docs/smartui-layout-regions/#dom-recording-requirement-for-web-comparisons) use. A build made from an uploaded image carries no DOM, so there is nothing to anchor to. PDF comparisons are not affected, since they read the structure out of the document itself.
 
-> **Note:** In an [Omni project](/support/docs/smartui-omni-projects/), where PDF, website, app, Figma, Storybook and image sources all co-exist in one project, both propagation controls are available in the same place. The one you see for a given comparison follows the source of the screenshot you are annotating: PDF artifacts offer **Apply to all the pages of this PDF** together with **Element based anchoring**, and website and app artifacts offer **Apply to all variants**.
+> **Note:** In an [Omni project](/support/docs/smartui-omni-projects/), where PDF, website, app, Figma, Storybook and image sources all co-exist in one project, both propagation controls are available in the same place. The one you see for a given comparison follows the source of the screenshot you are annotating: PDF artifacts offer **Apply to all the pages of this PDF**, and website and app artifacts offer **Apply to all variants**.
 
 ### Example
 
 A six-page quarterly statement where the company name in the header sits at a slightly different position on every page. Draw an ignore region around the company name on page 1, choose **Apply to all the pages of this PDF**, tick **Element based anchoring**, and the region lands on the company name on each page rather than on the blank space where page 1's header used to be.
+
+The web equivalent is a cookie banner or a promo strip that sits at a different height on Chrome and Firefox, or at a different position once the page reflows on a narrow viewport. Draw the ignore region on one variant, choose **Apply to all variants** with **Element based anchoring**, and it lands on the banner in each variant.
 
 ## Managing Annotations
 
@@ -368,9 +382,11 @@ You can always edit or delete pre-configured areas or add new ones according to 
 
 **Step 1:** Click on the **Actions** button (annotation icon).
 
-**Step 2:** Click on the annotation box you want to delete, or click **Delete All** to remove all annotations.
+**Step 2:** Click on the annotation box you want to delete, then remove it with the `Delete` or `Backspace` key.
 
 **Step 3:** Click on the **Save** button to confirm deletion.
+
+> **Note:** Annotations are deleted one at a time. There is no control that removes every annotation on a screenshot in a single action, so repeat the steps above for each box you want to remove.
 
 > **Note:** Deleting annotations will trigger a re-run of the comparison, and the previously ignored/selected areas will be included in future comparisons.
 

--- a/static/docs/smartui-omni-projects.md
+++ b/static/docs/smartui-omni-projects.md
@@ -34,7 +34,7 @@ If your runs do not currently send branch information, add it before migrating, 
 
 **A different baseline mental model in the dashboard.** A standard project separates its build list into a **Baseline Build** and **Non Baseline Build** section, so the baseline is a specific build you can point at. An Omni project shows one chronological list, and the baseline is resolved per branch rather than being a single pinned build. Teams with a documented approval process that references "the baseline build" will want to revisit that wording.
 
-**Document annotation is materially better on Omni.** In a standard PDF project a region applies only to the page you drew it on, so a 40 page document means 40 regions placed by hand. Omni adds page level propagation plus [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring-for-pdf-regions), so one region can cover the whole document and follow the anchored content as the pages reflow. For teams testing statements, invoices or policy packs this is usually the single biggest reason to move.
+**Document annotation is materially better on Omni.** In a standard PDF project a region applies only to the page you drew it on, so a 40 page document means 40 regions placed by hand. Omni adds page level propagation plus [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring), so one region can cover the whole document and follow the anchored content as the pages reflow. For teams testing statements, invoices or policy packs this is usually the single biggest reason to move.
 
 **Nothing changes for how you capture.** The CLI commands, SDK hooks and APIs are the same. Omni changes which project accepts the artifact and how baselines are resolved, not how the screenshot is taken, so existing test code does not need rewriting.
 
@@ -121,7 +121,7 @@ Similarly, two artifacts that share a name but were captured at different resolu
 
 Annotations behave the same way in an Omni project as anywhere else, and the [region types and scope controls](/support/docs/smartui-draw-on-ui/) are unchanged. What differs is the axis a region propagates along, which follows the source of the screenshot you drew it on:
 
-- On a **PDF** artifact, a region can be applied to every page of that PDF, and [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring-for-pdf-regions) places it on the anchored content page by page. Both controls are specific to Omni; in a standard PDF project a region stays on the page it was drawn on.
+- On a **PDF** artifact, a region can be applied to every page of that PDF, and [Element Based Anchoring](/support/docs/smartui-draw-on-ui/#element-based-anchoring) places it on the anchored content page by page. Page level propagation is specific to Omni: in a standard PDF project a region stays on the page it was drawn on. Anchoring itself is not limited to Omni, and is available on web comparisons in any project.
 - On a **website or app** artifact, a region can be applied to every browser and viewport variant of that screenshot.
 
 ## Availability and Access


### PR DESCRIPTION
Follow-up to #3398, applying review feedback from Shrinish on the staged page.

Four corrections, all on the Element Based Anchoring content:

**1. Anchoring is not PDF only.** It works on web comparisons too, so the section is renamed from "Element Based Anchoring for PDF Regions" to "Element Based Anchoring" and rewritten to cover both axes:

- PDF comparisons anchor on the text under the drawn box and propagate across the pages of the document.
- Web comparisons anchor on the DOM elements under the drawn box and propagate across the browser and viewport variants of the screenshot.

The "Not applicable" cell for web in the propagation table is gone. Real device and app screenshots are now the documented exception, since they carry neither a DOM nor an extractable document.

**2. Layout Regions are supported on web.** The region type row for web comparisons now lists them. The rest of the page already said Layout works on web captures, so the table was the odd one out.

**3. There is no Delete All button, and there never was.** The deletion step now says to select the box and remove it with `Delete` or `Backspace`, with a note that annotations are removed one at a time.

**4. A search area of `0` does not mean "keep the drawn coordinates".** It turns the search off, so the anchored content has to be found inside the drawn box itself or the region is not placed on that target at all. That is materially different from an unanchored region, which is copied to the same coordinates without checking what is there. The old wording said the two were the same behaviour.

While correcting point 4 I also documented the behaviour that makes it make sense, which the page never stated: when the anchor cannot be resolved on a target, the region is left off that target and reported back, rather than stamped at the drawn position.

### Other changes

- The heading rename moves the anchor to `#element-based-anchoring`. The four internal links in `smartui-omni-projects.md` are updated.
- `smartui-omni-projects.md` claimed both PDF region controls are Omni specific. Page level propagation is, anchoring is not, so that sentence is reworded.
- `static/docs` regenerated with `scripts/generate-static-md.js`.

### Verification

`npx docusaurus build` compiles both pages with no MDX errors and no broken link or anchor warnings. The build then fails on `/support/search/` because Typesense node config is not set locally, which is environmental and unrelated to this change.

Source for the web behaviour: [RFC TE-22284 Element-DOS](https://internal-docs.lambdatestinternal.com/Features-RFC/TE-22284-element-dos-anchoring), which specifies one resolver with a web provider and a PDF provider, and the toggle hidden only for app and native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yg6k4dnq2bs28pRkcV3NC
