### PR TITLE
docs(app-automation): fix broken HyperExecute CLI flags and SmartUI visual regression nav

### DIFF
--- a/docs/espresso-visual-regression.md
+++ b/docs/espresso-visual-regression.md
@@ -1,7 +1,6 @@
 ﻿---
 id: espresso-visual-regression
 title: Getting Started With Visual Regression Testing Using Espresso On SmartUI Real Devices
-sidebar_label: Espresso
 description: Dive into our detailed Appium Visual Regression support documentation for step-by-step guidance! Efficiently perform visual testing, manage applications, and ensure your mobile apps are visually perfect before launch.
 keywords:
   - Visual Regression

--- a/docs/sharding-espresso.md
+++ b/docs/sharding-espresso.md
@@ -445,12 +445,12 @@ If you are using the `deviceSelectionStrategy: any`, then in that case all the s
 
 ```bash
 chmod u+x <cliFileNAme>
-./<cliFileNAme> -user <userName> -key <accessKey> --verbose -i <yamlFileName>.yaml
+./<cliFileNAme> -u <userName> -k <accessKey> --verbose -i <yamlFileName>.yaml
 ```
 
 You can refer to this example and screenshot below:
 ```
-./hyperexecute -user my_user_name -key xyx123abc --verbose -i hyperexecute.yaml
+./hyperexecute -u my_user_name -k xyx123abc --verbose -i hyperexecute.yaml
 ```
 <img loading="lazy" src={require('../assets/images/app-automation/example-folder.webp').default} alt="cmd" width="768" height="373" className="doc_img"/>
 

--- a/docs/sharding-xcui.md
+++ b/docs/sharding-xcui.md
@@ -335,12 +335,12 @@ If you are using the `deviceSelectionStrategy: any`, then in that case all the m
 
 ```bash
 chmod u+x <cliFileNAme>
-./<cliFileNAme> --u <userName> --k <accessKey> --verbose -i <yamlFileName>.yaml
+./<cliFileNAme> -u <userName> -k <accessKey> --verbose -i <yamlFileName>.yaml
 ```
 
 You can refer to this example and screenshot below:
 ```
-./hyperexecute --u my_user_name --k xyx123abc --verbose -i hyperexecute.yaml
+./hyperexecute -u my_user_name -k xyx123abc --verbose -i hyperexecute.yaml
 ```
 <img loading="lazy" src={require('../assets/images/app-automation/example-folder.webp').default} alt="cmd" width="768" height="373" className="doc_img"/>
 

--- a/docs/xcui-visual-regression.md
+++ b/docs/xcui-visual-regression.md
@@ -1,7 +1,6 @@
 ﻿---
 id: xcui-visual-regression
 title: Getting Started With Visual Regression Testing Using XCUI On SmartUI Real Devices
-sidebar_label: XCUI
 description: Dive into our detailed XCUI Visual Regression support documentation for step-by-step guidance! Efficiently perform visual testing, manage applications, and ensure your mobile apps are visually perfect before launch.
 keywords:
   - Visual Regression

--- a/sidebars.js
+++ b/sidebars.js
@@ -2634,6 +2634,11 @@ module.exports = {
         label: "MockWebServer & Localhost",
         id: "espresso-mockwebserver-localhost",
       },
+      {
+        type: "doc",
+        label: "SmartUI Visual Regression",
+        id: "espresso-visual-regression",
+      },
     ],
   ],
 

--- a/static/docs/sharding-espresso-rd-hyperexecute.md
+++ b/static/docs/sharding-espresso-rd-hyperexecute.md
@@ -290,12 +290,12 @@ If you are using the `deviceSelectionStrategy: any`, then in that case all the s
 
 ```bash
 chmod u+x <cliFileNAme>
-./<cliFileNAme> -user <userName> -key <accessKey> --verbose -i <yamlFileName>.yaml
+./<cliFileNAme> -u <userName> -k <accessKey> --verbose -i <yamlFileName>.yaml
 ```
 
 You can refer to this example and screenshot below:
 ```
-./hyperexecute -user my_user_name -key xyx123abc --verbose -i hyperexecute.yaml
+./hyperexecute -u my_user_name -k xyx123abc --verbose -i hyperexecute.yaml
 ```
 
 5. After the test is started you can follow the test on the below links.

--- a/static/docs/sharding-rd-hyperexec.md
+++ b/static/docs/sharding-rd-hyperexec.md
@@ -204,12 +204,12 @@ If you are using the `deviceSelectionStrategy: any`, then in that case all the m
 
 ```bash
 chmod u+x <cliFileNAme>
-./<cliFileNAme> --u <userName> --k <accessKey> --verbose -i <yamlFileName>.yaml
+./<cliFileNAme> -u <userName> -k <accessKey> --verbose -i <yamlFileName>.yaml
 ```
 
 You can refer to this example and screenshot below:
 ```
-./hyperexecute --u my_user_name --k xyx123abc --verbose -i hyperexecute.yaml
+./hyperexecute -u my_user_name -k xyx123abc --verbose -i hyperexecute.yaml
 ```
 
 5. After the test is started you can follow the test on the below links.


### PR DESCRIPTION
Raised from the Slack thread on the XCUI sharding page. Reported by Rishabh Singh (CLI flags) and Shyamal Makwana (naming and Espresso/XCUI inconsistency).

## 1. HyperExecute CLI credential flags were broken

The reported page ([Sharding for XCUI](https://www.testmuai.com/support/docs/sharding-rd-hyperexec/)) documented `--u` / `--k`. The CLI is cobra/pflag based and exposes `-u, --user` and `-k, --key`. I downloaded the current CLI and confirmed `--u` is rejected outright:

```
$ ./hyperexecute --u my_user_name --k xyz123abc --verbose -i hyperexecute.yaml
Error: unknown flag: --u
```

While checking, I found the **Espresso** sharding page had a different but worse variant, `-user` / `-key`. That one does not error. pflag reads `-user` as shorthand `-u` with value `ser`, then treats the real username as a command:

```
$ ./hyperexecute -user my_user_name -key xyz123abc --verbose -i hyperexecute.yaml
Error: unknown command "my_user_name" for "HyperExecute"
```

Both now use `-u` / `-k`, verified to parse (they reach authentication rather than failing at flag parsing).

**This was the full extent of the problem.** I scanned every HyperExecute invocation in `docs/` and `static/docs/`: these two pages (plus their `static/docs/` mirrors) were the only ones out of step. The other 314 invocations already use the valid `--user` / `--key`. The `-apiKey` on the Katalon page belongs to `katalonc`, not HyperExecute, so it is correct as-is and left alone.

## 2. Sidebar said "XCUI" instead of a visual regression name

The XCUI visual regression page showed up in the nav as just `XCUI`.

`sidebars.js` already had `label: "SmartUI Visual Regression"` (set in Feb 2026), but it never took effect. Docusaurus resolves a doc item label as:

```js
label: sidebarLabel ?? item.label ?? title   // plugin-content-docs/lib/props.js
```

Frontmatter `sidebar_label` wins over the sidebars.js label, so the earlier fix was a silent no-op. Removing the frontmatter override lets each sidebar use its own context-appropriate label:

| Location | Before | After |
|---|---|---|
| XCUI Testing | XCUI | SmartUI Visual Regression |
| SmartUI > Native Apps | XCUI | XCUITest |

## 3. Espresso visual regression was missing from the Espresso nav

To answer the question in the thread directly: **the Espresso page exists and the support is real.** It is a ~600 line guide, and the SDK it documents (`io.github.lambdatest:lambdatest-espresso:1.0.1`) is published on Maven Central and is the current release. Nothing needs to be built.

The inconsistency was purely navigation. The page was only reachable from SmartUI > Native Apps, while the XCUI equivalent was linked from both SmartUI and XCUI Testing. Added the matching entry, so both sections now end with "SmartUI Visual Regression".

## Still open: capability RD/VD badges

The third point in the thread, that [Espresso Supported Capabilities](https://www.testmuai.com/support/docs/espresso-supported-capabilities/) lacks the Real Device / Virtual Device badges [XCUI](https://www.testmuai.com/support/docs/xcui-supported-capabilities/) has, is **not** in this PR.

It is real: XCUI badges nearly every capability, Espresso badges exactly one (`networkProfile`). The components are already imported in the Espresso page, so it is a small edit. 18 of Espresso 22 capabilities also appear in the XCUI table, so the badges could be mirrored.

I have left it out because those badges are product facts about Android emulator support, and there is no source of truth in the repo to derive them from. Mirroring iOS badges onto Android would be guessing. Happy to apply them as soon as someone confirms which Espresso capabilities work on virtual devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdZjipHk3bGHmZBvwoTXvi