### PR TITLE
docs: updated Audio Injection supported devices & add pre-installed app automation section

### DIFF
--- a/docs/audio-injection-manual-browser.md
+++ b/docs/audio-injection-manual-browser.md
@@ -55,7 +55,11 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 With <BrandName /> Real Time browser testing, you can either inject a **pre-uploaded audio file** or stream **Live Input** directly from your system microphone into the device browser.
 
-> To enable it for your organization, please contact us via <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**24×7 chat support**</span> or you can also drop a mail to **support@testmuai.com**.<br />
+:::note Plus Plan Feature
+This feature is available exclusively with the **Real Device Plus Automation Cloud** Plan.
+
+To unlock this feature, purchase or upgrade to the required [plan](https://www.testmuai.com/pricing/). If you need assistance, please contact your <BrandName /> support representative, reach out to our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**[24×7 Chat Support]**</span>, or email us at **support@testmuai.com**.
+:::
 
 ---
 

--- a/docs/audio-injection-manual-browser.md
+++ b/docs/audio-injection-manual-browser.md
@@ -69,14 +69,31 @@ With <BrandName /> Real Time browser testing, you can either inject a **pre-uplo
 
 ---
 
-## Supported Platforms
+## Supported Devices
 
-| Platform | Minimum OS Version | 
+**Audio Injection is supported on selected Real Devices only. It is not available on Emulators or Simulators.**
+
+### Android
+
+| Android Device | Android Version |
 |---|---|
-| **Android** | Android 13 (SDK 33) and above 
-| **iOS** | iOS 16 and above 
+| Galaxy S26 | 16 |
+| Galaxy S24 | 14 |
+| Galaxy S23 | 14 |
+| Pixel 10 | 16 |
+| Pixel 10 Pro | 16 |
+| Pixel 10 Pro XL | 16 |
+| Pixel 9 | 15 |
+| Pixel 8 | 14, 16 |
 
-Audio Injection is supported on **selected real devices only**
+### iOS
+
+| iOS Device | iOS Version |
+|---|---|
+| iPhone 17 Pro | 26 |
+| iPhone 17 | 26 |
+| iPhone 16 | 18 |
+| iPhone 15 | 17 |
 
 ---
 

--- a/docs/audio-injection-manual-browser.md
+++ b/docs/audio-injection-manual-browser.md
@@ -56,7 +56,7 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 With <BrandName /> Real Time browser testing, you can either inject a **pre-uploaded audio file** or stream **Live Input** directly from your system microphone into the device browser.
 
 :::note Plus Plan Feature
-This feature is available exclusively with the **Real Device Plus Automation Cloud** Plan.
+This feature is available exclusively with the **Real Device Plus Live** Plan.
 
 To unlock this feature, purchase or upgrade to the required [plan](https://www.testmuai.com/pricing/). If you need assistance, please contact your <BrandName /> support representative, reach out to our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**[24×7 Chat Support]**</span>, or email us at **support@testmuai.com**.
 :::

--- a/docs/audio-injection-manual.md
+++ b/docs/audio-injection-manual.md
@@ -72,14 +72,31 @@ To unlock this feature, purchase or upgrade to the required [plan](https://www.t
 
 ---
 
-## Supported Platforms
+## Supported Devices
 
-| Platform | Minimum OS Version | 
+**Audio Injection is supported on selected Real Devices only. It is not available on Emulators or Simulators.**
+
+### Android
+
+| Android Device | Android Version |
 |---|---|
-| **Android** | Android 13 (SDK 33) and above 
-| **iOS** | iOS 16 and above 
+| Galaxy S26 | 16 |
+| Galaxy S24 | 14 |
+| Galaxy S23 | 14 |
+| Pixel 10 | 16 |
+| Pixel 10 Pro | 16 |
+| Pixel 10 Pro XL | 16 |
+| Pixel 9 | 15 |
+| Pixel 8 | 14, 16 |
 
-Audio Injection is supported on **selected real devices only** 
+### iOS
+
+| iOS Device | iOS Version |
+|---|---|
+| iPhone 17 Pro | 26 |
+| iPhone 17 | 26 |
+| iPhone 16 | 18 |
+| iPhone 15 | 17 |
 
 ---
 

--- a/docs/audio-injection.md
+++ b/docs/audio-injection.md
@@ -77,14 +77,31 @@ Use it to test speech-to-text, voice commands, voice assistants, in-app recordin
 
 ---
 
-## Supported Platforms
+## Supported Devices
 
-| Platform | Minimum OS Version | 
+**Audio Injection is supported on selected Real Devices only. It is not available on Emulators or Simulators.**
+
+### Android
+
+| Android Device | Android Version |
 |---|---|
-| **Android** | Android 13 (SDK 33) and above | 
-| **iOS** | iOS 16 and above | 
+| Galaxy S26 | 16 |
+| Galaxy S24 | 14 |
+| Galaxy S23 | 14 |
+| Pixel 10 | 16 |
+| Pixel 10 Pro | 16 |
+| Pixel 10 Pro XL | 16 |
+| Pixel 9 | 15 |
+| Pixel 8 | 14, 16 |
 
-Audio Injection is supported on **real devices only**. It is **not** available on emulators or simulators.
+### iOS
+
+| iOS Device | iOS Version |
+|---|---|
+| iPhone 17 Pro | 26 |
+| iPhone 17 | 26 |
+| iPhone 16 | 18 |
+| iPhone 15 | 17 |
 
 ---
 

--- a/docs/select-pre-installed-apps.md
+++ b/docs/select-pre-installed-apps.md
@@ -5,13 +5,15 @@ hide_title: false
 sidebar_label: Select Pre-Installed Apps
 description: Accelerate testing with pre-installed apps on TestMu AI. Start sessions faster, reduce setup time, and enhance efficiency in private cloud environments.
 keywords:
-- select pre installed apps
-- select pre installed apps in session
+  - select pre installed apps
+  - select pre installed apps in session
 url: https://www.testmuai.com/support/docs/select-pre-installed-apps/
 site_name: TestMu AI
 slug: select-pre-installed-apps/
 canonical: https://www.testmuai.com/support/docs/select-pre-installed-apps/
 ---
+
+import CodeBlock from '@theme/CodeBlock';
 import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 
@@ -41,9 +43,19 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
 
 <BrandName /> empowers developers with a comprehensive testing environment, enabling thorough examination of mobile applications and websites across real devices and browsers. One standout feature is the ability to start testing sessions with pre-installed applications, enhancing efficiency, and reducing test start time,  in **private cloud** setups where data retention and reusability are paramount.
 
+:::note
+To access the pre-installed apps, you need to have a **Private Cloud** Plan. 
+
+You can purchase or upgrade to the required [plan](https://www.testmuai.com/pricing/). If you need assistance, please contact your <BrandName /> support representative, reach out to our <span className="doc__lt" onClick={() => window.openLTChatWidget()}>**[24×7 Chat Support]**</span>, or email us at **support@testmuai.com**.
+:::
+
+---
+
 Let's delve into the streamlined steps to initiate a testing session with pre-installed applications:
 
-**Step 1.** Login to your <BrandName /> account. Go to **App Testing** under **Real Device** from the left sidebar. 
+## Start a Manual Session with Pre-Installed Apps
+
+**Step 1.** Login to your <BrandName /> account. Go to **App Testing** under **Real Device** from the left sidebar.
 
 **Step 2.** Enable the toggle to enter into your **Private Cloud**.
 
@@ -57,7 +69,60 @@ Let's delve into the streamlined steps to initiate a testing session with pre-in
 
 By adhering to the above steps, you can seamlessly commence testing sessions with pre-installed applications on <BrandName />. This feature not only expedites the testing process but also enhances efficiency, making it particularly advantageous for private cloud environments. With data retained within the private cloud devices, <BrandName /> ensures enhanced flexibility and productivity in testing workflows.
 
-> **Note:** To access the pre-installed apps, you need to have a private cloud plan.
+---
+
+## Start an Automation Session with Pre-Installed Apps
+
+You can also run app automation tests directly on an app that is already installed on your private device, without reinstalling the app or resetting its existing state.
+
+To do this, pass the `app` capability as `Stock`, in addition to your private cloud capabilities. Along with it:
+
+- For **Android**, pass the `appPackage` and `appActivity` of your app.
+- For **iOS**, pass the `bundleId` of your app.
+
+<Tabs className="docs__val">
+
+<TabItem value="android" label="Android" default>
+
+  <div className="lambdatest__codeblock">
+    <CodeBlock className="language-java">
+  {`DesiredCapabilities capabilities = new DesiredCapabilities();
+HashMap<String, Object> ltOptions = new HashMap<String, Object>();
+ltOptions.put("privateCloud", true);
+ltOptions.put("udid", "<PRIVATE_DEVICE_UDID>");
+ltOptions.put("platformName", "android");
+ltOptions.put("deviceName", "Galaxy S24");
+ltOptions.put("platformVersion", "14");
+ltOptions.put("app", "stock");
+ltOptions.put("appPackage", "com.proverbial");
+ltOptions.put("appActivity", "com.proverbial.MainActivity");
+capabilities.setCapability("lt:options", ltOptions);`}
+  </CodeBlock>
+</div>
+
+</TabItem>
+
+<TabItem value="ios" label="iOS">
+
+  <div className="lambdatest__codeblock">
+    <CodeBlock className="language-java">
+  {`DesiredCapabilities capabilities = new DesiredCapabilities();
+HashMap<String, Object> ltOptions = new HashMap<String, Object>();
+ltOptions.put("privateCloud", true);
+ltOptions.put("udid", "<PRIVATE_DEVICE_UDID>");
+ltOptions.put("platformName", "ios");
+ltOptions.put("deviceName", "iPhone 16");
+ltOptions.put("platformVersion", "18");
+ltOptions.put("app", "stock");
+ltOptions.put("bundleId", "com.proverbial.ios");
+capabilities.setCapability("lt:options", ltOptions);`}
+  </CodeBlock>
+</div>
+
+</TabItem>
+</Tabs>
+
+> **Note:** Since the `app` capability is set to `Stock`, the session launches the app already present on the device, retaining its existing data and state.
 
 <nav aria-label="breadcrumbs">
   <ul className="breadcrumbs">

--- a/docs/select-pre-installed-apps.md
+++ b/docs/select-pre-installed-apps.md
@@ -51,9 +51,9 @@ You can purchase or upgrade to the required [plan](https://www.testmuai.com/pric
 
 ---
 
-Let's delve into the streamlined steps to initiate a testing session with pre-installed applications:
-
 ## Start a Manual Session with Pre-Installed Apps
+
+Let's delve into the streamlined steps to initiate a manual testing session with pre-installed applications:
 
 **Step 1.** Login to your <BrandName /> account. Go to **App Testing** under **Real Device** from the left sidebar.
 


### PR DESCRIPTION
## Summary

This PR updates two Real Device docs:

### 1. Audio Injection – Manual Browser Testing (`docs/audio-injection-manual-browser.md`)
- Replaced the generic minimum-OS table with an explicit **Supported Devices** list, sourced from the current device fleet:
  - **iOS** (feature flag 65): iPhone 17 Pro (26), iPhone 17 (26), iPhone 16 (18), iPhone 15 (17)
  - **Android** (feature flag 64): Galaxy S26 (16), Galaxy S24 (14), Galaxy S23 (14), Pixel 10 / 10 Pro / 10 Pro XL (16), Pixel 9 (15), Pixel 8 (14, 16)
- No other content changed.

### 2. Select Pre-Installed App in Session (`docs/select-pre-installed-apps.md`)
- Restructured the page into **Manual** and **Automation** sub-sections.
- Added a new **Start an Automation Session with Pre-Installed Apps** section for private cloud dedicated devices:
  - `app: "Stock"` capability with `appPackage`/`appActivity` (Android) and `bundleId` (iOS)
  - Includes `privateCloud`, `udid`, `deviceName`, and `platformVersion` caps
  - Android/iOS snippets in the standard `<Tabs>` + `<CodeBlock>` format
- Updated the Private Cloud plan note to a `:::note` admonition with pricing and support contact info.