### PR TITLE
docs: add Kane CLI Evidence section

### DIFF
--- a/docs/kane-cli-evidence-debugging.md
+++ b/docs/kane-cli-evidence-debugging.md
@@ -85,7 +85,7 @@ unzip -p <execution_id>.evidence tests/<test-id>/result.yaml
 
 If a pack will not open, run [`kane-cli evidence validate`](/support/docs/kane-cli-evidence-validate/). An unsealed or truncated pack, for example from a run that was killed hard, reports as invalid, and the run's session directory still holds the raw logs:
 
-```bash
+```text
 ~/.testmuai/kaneai/sessions/<session-id>/evidence/
 ```
 

--- a/docs/kane-cli-evidence-debugging.md
+++ b/docs/kane-cli-evidence-debugging.md
@@ -1,0 +1,95 @@
+---
+id: kane-cli-evidence-debugging
+title: Debugging a Failed Run from its Pack
+sidebar_label: Debugging from a Pack
+description: "Use a kane-cli evidence pack to find the cause of a failed run: the failed step, its per-step console and network logs, the annotated screenshot, and the failed versus broken split."
+keywords:
+  - debug failed test kane cli
+  - evidence pack debugging
+  - failure.yaml
+  - failed vs broken
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-evidence-debugging/
+site_name: TestMu AI
+slug: kane-cli-evidence-debugging/
+canonical: https://www.testmuai.com/support/docs/kane-cli-evidence-debugging/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-introduction/"
+        }]
+      })
+    }}
+></script>
+
+The pack is the fastest way to understand a failure, because everything is in one place and attributed per step.
+
+## The four steps
+
+1. **Open the pack.** Accept the post-run offer, or run `kane-cli evidence serve <pack>` and open the `viewer` URL.
+2. **Go to the failed step.** The run overview marks it. The failure record shows the error message and the page state at the moment of failure.
+3. **Check the step's console and network activity.** Logs are sliced per step, so you see exactly what the browser logged and requested while that step ran. A 4xx or 5xx response, or a JS error here, usually explains the failure.
+4. **Look at the annotated screenshot.** It highlights the element the agent was acting on, which makes "clicked the wrong thing" and "element was not there" failures obvious.
+
+## Reading a failure record
+
+A failed or broken step carries its own `failure.yaml` with the error, the page state at failure, and references into the console and network logs. The pack root carries a `failure.yaml` index that rolls those up, so you can see every failure in the run without opening each step.
+
+A record holds either an error message **or** an expected and actual pair, never both.
+
+## `failed` or `broken`
+
+The verdict tells you where to look first.
+
+| Verdict | What it means | Where to look |
+|---|---|---|
+| `failed` | The oracle was evaluated and the product was wrong. | The assertion and the page state. This is a candidate defect. |
+| `broken` | The oracle could not be evaluated, because of an environment, infrastructure, or test fault. | The network log and the run log. The product may be fine. |
+
+Treating these as one bucket is how a flaky environment gets filed as a product bug. The split exists so it does not.
+
+## Working from the command line
+
+A pack is a zip, so you do not need the viewer to answer a quick question:
+
+```bash
+# list everything in the pack
+unzip -l <execution_id>.evidence
+
+# print the run manifest
+unzip -p <execution_id>.evidence run.yaml
+
+# print one test's result
+unzip -p <execution_id>.evidence tests/<test-id>/result.yaml
+```
+
+## When the pack itself looks wrong
+
+If a pack will not open, run [`kane-cli evidence validate`](/support/docs/kane-cli-evidence-validate/). An unsealed or truncated pack, for example from a run that was killed hard, reports as invalid, and the run's session directory still holds the raw logs:
+
+```bash
+~/.testmuai/kaneai/sessions/<session-id>/evidence/
+```
+
+## Next steps
+
+- [Pack structure](/support/docs/kane-cli-evidence-pack-structure/) — where each artifact lives.
+- [Validating packs](/support/docs/kane-cli-evidence-validate/) — check a suspect pack.

--- a/docs/kane-cli-evidence-debugging.md
+++ b/docs/kane-cli-evidence-debugging.md
@@ -83,7 +83,7 @@ unzip -p <execution_id>.evidence tests/<test-id>/result.yaml
 
 ## When the pack itself looks wrong
 
-If a pack will not open, run [`kane-cli evidence validate`](/support/docs/kane-cli-evidence-validate/). An unsealed or truncated pack, for example from a run that was killed hard, reports as invalid. The session directory still holds that run's pack:
+If a pack will not open, run [`kane-cli evidence validate`](/support/docs/kane-cli-evidence-validate/). An unsealed pack, for example from a run that was killed hard, is checked for structure only and can still report valid. A truncated pack cannot be read at all. Either way the session directory still holds that run's pack:
 
 ```text
 ~/.testmuai/kaneai/sessions/<session-id>/evidence/

--- a/docs/kane-cli-evidence-debugging.md
+++ b/docs/kane-cli-evidence-debugging.md
@@ -44,16 +44,16 @@ The pack is the fastest way to understand a failure, because everything is in on
 
 ## The four steps
 
-1. **Open the pack.** Accept the post-run offer, or run `kane-cli evidence serve <pack>` and open the `viewer` URL.
+1. **Open the pack.** Run `kane-cli evidence serve <pack>` and open the `viewer` URL.
 2. **Go to the failed step.** The run overview marks it. The failure record shows the error message and the page state at the moment of failure.
 3. **Check the step's console and network activity.** Logs are sliced per step, so you see exactly what the browser logged and requested while that step ran. A 4xx or 5xx response, or a JS error here, usually explains the failure.
 4. **Look at the annotated screenshot.** It highlights the element the agent was acting on, which makes "clicked the wrong thing" and "element was not there" failures obvious.
 
 ## Reading a failure record
 
-A failed or broken step carries its own `failure.yaml` with the error, the page state at failure, and references into the console and network logs. The pack root carries a `failure.yaml` index that rolls those up, so you can see every failure in the run without opening each step.
+A failed or broken step normally carries its own `failure.yaml` with the error, the page state at failure, and references into the console and network logs. The pack root carries a `failure.yaml` index that rolls those up, so you can see every failure in the run without opening each step.
 
-A record holds either an error message **or** an expected and actual pair, never both.
+A record must carry evidence of what went wrong: an `error.message`, or both an `expected` and an `actual` value. It may carry both.
 
 ## `failed` or `broken`
 
@@ -68,7 +68,7 @@ Treating these as one bucket is how a flaky environment gets filed as a product 
 
 ## Working from the command line
 
-A pack is a zip, so you do not need the viewer to answer a quick question:
+A sealed pack is a zip, so you do not need the viewer to answer a quick question:
 
 ```bash
 # list everything in the pack
@@ -83,7 +83,7 @@ unzip -p <execution_id>.evidence tests/<test-id>/result.yaml
 
 ## When the pack itself looks wrong
 
-If a pack will not open, run [`kane-cli evidence validate`](/support/docs/kane-cli-evidence-validate/). An unsealed or truncated pack, for example from a run that was killed hard, reports as invalid, and the run's session directory still holds the raw logs:
+If a pack will not open, run [`kane-cli evidence validate`](/support/docs/kane-cli-evidence-validate/). An unsealed or truncated pack, for example from a run that was killed hard, reports as invalid. The session directory still holds that run's pack:
 
 ```text
 ~/.testmuai/kaneai/sessions/<session-id>/evidence/

--- a/docs/kane-cli-evidence-format.md
+++ b/docs/kane-cli-evidence-format.md
@@ -1,0 +1,118 @@
+---
+id: kane-cli-evidence-format
+title: The .evidence Format
+sidebar_label: The .evidence Format
+description: "The open, framework-agnostic .evidence format behind kane-cli packs: the L0 and L1 profiles, what sealing guarantees, and the Apache-2.0 evidence-cli tooling."
+keywords:
+  - evidence format
+  - open test evidence format
+  - evidence cli
+  - L0 L1 profile
+  - framework agnostic test evidence
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-evidence-format/
+site_name: TestMu AI
+slug: kane-cli-evidence-format/
+canonical: https://www.testmuai.com/support/docs/kane-cli-evidence-format/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-introduction/"
+        }]
+      })
+    }}
+></script>
+
+The `.evidence` pack is not a kane-cli-only file. It is an **open, framework-agnostic format** with its own specification, validator, and Apache-2.0 licensed tooling, published at [github.com/LambdaTest/evidence-cli](https://github.com/LambdaTest/evidence-cli).
+
+One shape, whatever made it: a browser agent, a Playwright suite, a Jest run, or an API check. A pack is readable by a CI dashboard, an auditor, or a human without knowing the framework that wrote it.
+
+## Who writes what
+
+This is the part worth understanding, because it explains what the format guarantees and what it does not.
+
+| Part of the pack | Written by |
+|---|---|
+| `run.yaml` identity, `tests/<id>/result.yaml`, the test definition | kane-cli |
+| Per-step folders, screenshots, console, network, and trace logs | the kane-cli runner |
+| The derived totals, the definition hashes, the run-level failure index, and the seal | `evidence finalize` |
+
+The tooling in `evidence-cli` **captures nothing**. It has no browser and no runtime. It validates a pack, derives what can be derived, and seals it. A screenshot is in your pack because kane-cli put it there.
+
+That is the point of the split: the container is open, so anything can produce a pack, and any tool can read one.
+
+## Profiles
+
+A profile is a rung on one contract. `L1` adds requirements to `L0` and never rewrites it.
+
+| Profile | Requires |
+|---|---|
+| **L0** | The minimal core: a top-level `run.yaml`, and per test a definition file plus a `result.yaml`. |
+| **L1** | All of L0, plus the captured artifact layer: declared logs, the `steps/` layer, a `coverage/` directory, and the run-level failure index. Video is optional. |
+
+The definition file is **opaque**. The format references and hashes it, and never parses it. It can be a `test.md` from kane-cli, a `login.spec.ts` from Playwright, or anything else.
+
+:::note
+The contract version and the profile are different axes. The version, currently `0.1`, is the meaning of the fields. Adding a profile is additive and never changes it. Only a breaking change to an existing meaning bumps the version.
+:::
+
+## What sealing does and does not give you
+
+`finalize` rolls up the totals, writes each definition's content hash, sets the run to `finalized`, and seals the directory into the zip. The seal replaces the live directory in place, atomically, so a complete copy exists at every instant.
+
+The definition hash makes the pack **tamper-evident** for the thing that was tested: change the test file after the fact and the hash no longer matches. Packs are **not signed**, so this is evidence of change, not proof of origin.
+
+## Using the format directly
+
+If you want to produce or read packs outside kane-cli, the tooling is on npm:
+
+```bash
+npm install -g @testmuai/evidence-cli
+```
+
+```bash
+evidence validate my-run.evidence --profile L0
+evidence finalize my-run.evidence/
+```
+
+The standalone CLI ships `validate`, `finalize`, and `merge`, with exit codes `0` valid, `1` invalid, and `2` usage error. It reads its config from `~/.testmuai/evidence/config.json`, and the active profile resolves from the `--profile` flag, then the config, then the built-in default of `L0`.
+
+It is also a library, so `validate` and `finalize` can be called in process:
+
+```ts
+import { validate, finalize } from "@testmuai/evidence-cli";
+
+const report = await validate("my-run.evidence", { profile: "L1" });
+if (!report.valid) {
+  for (const d of report.diagnostics) {
+    console.error(`${d.severity} ${d.location}: ${d.message} [${d.code}]`);
+  }
+}
+```
+
+:::note
+The standalone `evidence` CLI defaults to the `L0` profile, while `kane-cli evidence validate` defaults to `L1`, because a kane-cli pack always carries the captured layer.
+:::
+
+## Next steps
+
+- [Pack structure](/support/docs/kane-cli-evidence-pack-structure/) — the layout in full.
+- [Validating packs](/support/docs/kane-cli-evidence-validate/) — the checks the validator runs.

--- a/docs/kane-cli-evidence-format.md
+++ b/docs/kane-cli-evidence-format.md
@@ -51,11 +51,10 @@ This is the part worth understanding, because it explains what the format guaran
 
 | Part of the pack | Written by |
 |---|---|
-| `run.yaml` identity, `tests/<id>/result.yaml`, the test definition | kane-cli |
-| Per-step folders, screenshots, console, network, and trace logs | the kane-cli runner |
-| The derived totals, the definition hashes, the run-level failure index, and the seal | `evidence finalize` |
+| `run.yaml`, each `result.yaml`, the test definition, the per-step folders and screenshots, and the console, network and runner logs | kane-cli |
+| The derived totals, each definition hash, the run-level failure index, and the seal | `evidence finalize` |
 
-The tooling in `evidence-cli` **captures nothing**. It has no browser and no runtime. It validates a pack, derives what can be derived, and seals it. A screenshot is in your pack because kane-cli put it there.
+The tooling in `evidence-cli` **captures nothing**. It drives no browser and executes no tests. It validates a pack, derives what can be derived, and seals it. A screenshot is in your pack because kane-cli put it there.
 
 That is the point of the split: the container is open, so anything can produce a pack, and any tool can read one.
 
@@ -66,7 +65,7 @@ A profile is a rung on one contract. `L1` adds requirements to `L0` and never re
 | Profile | Requires |
 |---|---|
 | **L0** | The minimal core: a top-level `run.yaml`, and per test a definition file plus a `result.yaml`. |
-| **L1** | All of L0, plus the captured artifact layer: declared logs, the `steps/` layer, a `coverage/` directory, and the run-level failure index. Video is optional. |
+| **L1** | All of L0, plus, once the run is finalized, the captured artifact layer: declared logs, the `steps/` layer, a `coverage/` directory, and the run-level failure index. Video is optional. Before finalize, L1 checks only the shape of what is already there. |
 
 The definition file is **opaque**. The format references and hashes it, and never parses it. It can be a `test.md` from kane-cli, a `login.spec.ts` from Playwright, or anything else.
 
@@ -78,7 +77,7 @@ The contract version and the profile are different axes. The version, currently 
 
 `finalize` rolls up the totals, writes each definition's content hash, sets the run to `finalized`, and seals the directory into the zip. The seal replaces the live directory in place, atomically, so a complete copy exists at every instant.
 
-The definition hash makes the pack **tamper-evident** for the thing that was tested: change the test file after the fact and the hash no longer matches. Packs are **not signed**, so this is evidence of change, not proof of origin.
+The recorded definition hash is an integrity check on the thing that was tested: `validate` fails a finalized pack whose definition no longer hashes to the value recorded at seal time. Packs are **not signed**, so this says nothing about who produced the pack.
 
 ## Using the format directly
 
@@ -93,7 +92,7 @@ evidence validate my-run.evidence --profile L0
 evidence finalize my-run.evidence/
 ```
 
-The standalone CLI ships `validate`, `finalize`, and `merge`, with exit codes `0` valid, `1` invalid, and `2` usage error. It reads its config from `~/.testmuai/evidence/config.json`, and the active profile resolves from the `--profile` flag, then the config, then the built-in default of `L0`.
+The standalone CLI ships `validate`, `finalize`, and `merge`. Exit codes differ by command: `validate` returns `0` valid, `1` invalid, `2` usage error, and `merge` returns `0` merged, `1` policy abort, `2` usage error. It reads its config from `~/.testmuai/evidence/config.json` by default, overridable with `--config` or the `EVIDENCE_CONFIG` environment variable, and the active profile resolves from the `--profile` flag, then the config, then the built-in default of `L0`.
 
 It is also a library, so `validate` and `finalize` can be called in process:
 
@@ -109,7 +108,7 @@ if (!report.valid) {
 ```
 
 :::note
-The standalone `evidence` CLI defaults to the `L0` profile, while `kane-cli evidence validate` defaults to `L1`, because a kane-cli pack always carries the captured layer.
+The standalone `evidence` CLI defaults to the `L0` profile, while `kane-cli evidence validate` defaults to `L1`.
 :::
 
 ## Next steps

--- a/docs/kane-cli-evidence-merge.md
+++ b/docs/kane-cli-evidence-merge.md
@@ -1,0 +1,89 @@
+---
+id: kane-cli-evidence-merge
+title: Merging Evidence Packs
+sidebar_label: Merging Packs
+description: "Combine several kane-cli evidence packs into a single sealed pack with kane-cli evidence merge, including the strict default policy and collision handling."
+keywords:
+  - kane cli evidence merge
+  - merge evidence packs
+  - nightly evidence rollup
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-evidence-merge/
+site_name: TestMu AI
+slug: kane-cli-evidence-merge/
+canonical: https://www.testmuai.com/support/docs/kane-cli-evidence-merge/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-introduction/"
+        }]
+      })
+    }}
+></script>
+
+`kane-cli evidence merge` combines several packs into one, for example the packs from a set of related runs you want to hand over as a single file:
+
+```bash
+kane-cli evidence merge <targets...> --run-id nightly-2026-07-11
+```
+
+Targets are execution ids or pack paths, and **order matters**. Earlier targets win where the policy has to choose.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--run-id <id>` | Run id for the merged pack, **required** | — |
+| `-o, --out <path>` | Output path | `.testmuai/evidence/<run-id>.evidence` |
+| `--rules <path>` | Custom merge-rules file, replaces the defaults wholesale | built-in defaults |
+| `--on-collision <action>` | `error`, `prefer-first`, `prefer-latest`, or `discard` | `error` |
+| `--title <title>` | Title for the merged run | first eligible pack's |
+| `--no-finalize` | Keep the merged pack live instead of sealing it | seals by default |
+| `--json` | Machine-readable merge report | off |
+| `--env <name>` | Environment (`prod` or `stage`) | active env |
+
+`--rules` and `--on-collision` are mutually exclusive.
+
+Exit codes: `0` merged, `1` policy abort, `2` usage error.
+
+## The default policy
+
+Out of the box, merge is strict:
+
+- inputs must be **sealed and valid**,
+- duplicate run ids are skipped,
+- packs from **different projects or organisations** are refused,
+- a test-id collision is an **error**, unless you choose another action with `--on-collision`.
+
+## A nightly roll-up
+
+```bash
+kane-cli evidence merge \
+  .testmuai/evidence/*.evidence \
+  --run-id nightly-2026-07-11 \
+  --title "Nightly regression" \
+  -o nightly.evidence
+```
+
+The result is one sealed pack holding every member's tests, which opens in the viewer like any other pack.
+
+## Next steps
+
+- [Validating packs](/support/docs/kane-cli-evidence-validate/) — confirm the merged pack before handing it over.
+- [Viewing evidence](/support/docs/kane-cli-evidence-viewing/) — open the merged pack.

--- a/docs/kane-cli-evidence-merge.md
+++ b/docs/kane-cli-evidence-merge.md
@@ -51,7 +51,7 @@ Targets are execution ids or pack paths, and **order matters**. Earlier targets 
 |---|---|---|
 | `--run-id <id>` | Run id for the merged pack, **required** | — |
 | `-o, --out <path>` | Output path | `.testmuai/evidence/<run-id>.evidence` |
-| `--rules <path>` | Custom merge-rules file, replaces the defaults wholesale | built-in defaults |
+| `--rules <path>` | Custom merge-rules file. Settings you omit keep their default value; the rule list itself is replaced | built-in defaults |
 | `--on-collision <action>` | `error`, `prefer-first`, `prefer-latest`, or `discard` | `error` |
 | `--title <title>` | Title for the merged run | first eligible pack's |
 | `--no-finalize` | Keep the merged pack live instead of sealing it | seals by default |

--- a/docs/kane-cli-evidence-merge.md
+++ b/docs/kane-cli-evidence-merge.md
@@ -77,11 +77,12 @@ Out of the box, merge is strict:
 kane-cli evidence merge \
   .testmuai/evidence/*.evidence \
   --run-id nightly-2026-07-11 \
-  --title "Nightly regression" \
-  -o nightly.evidence
+  --title "Nightly regression"
 ```
 
-The result is one sealed pack holding every member's tests, which opens in the viewer like any other pack.
+With no `-o`, the merged pack is written to `.testmuai/evidence/<run-id>.evidence`, which stays unique as long as the run id does.
+
+The result is one sealed pack holding the tests from every pack that passed the policy. Packs the policy skipped contribute nothing, and the merge report (`--json`) lists what was skipped and why.
 
 ## Next steps
 

--- a/docs/kane-cli-evidence-pack-structure.md
+++ b/docs/kane-cli-evidence-pack-structure.md
@@ -1,0 +1,123 @@
+---
+id: kane-cli-evidence-pack-structure
+title: Evidence Pack Structure
+sidebar_label: Pack Structure
+description: "Every file inside a kane-cli .evidence pack and what it is for, from the run.yaml manifest anchor to per-step screenshots, logs, and failure records."
+keywords:
+  - evidence pack structure
+  - run.yaml
+  - result.yaml
+  - evidence pack layout
+  - kane cli evidence
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-evidence-pack-structure/
+site_name: TestMu AI
+slug: kane-cli-evidence-pack-structure/
+canonical: https://www.testmuai.com/support/docs/kane-cli-evidence-pack-structure/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-introduction/"
+        }]
+      })
+    }}
+></script>
+
+A `.evidence` file is a standard zip. `unzip -l <pack>` lists it, and `unzip -p <pack> <entry>` prints one file without extracting the whole pack.
+
+## The layout
+
+```text
+<execution_id>.evidence
+├── run.yaml                          # Run manifest: title, status, started/ended, totals
+├── failure.yaml                      # Run-level failure rollup
+└── tests/
+    └── <test-id>/                    # One directory per test in the run
+        ├── test.md                   # The test definition
+        ├── result.yaml               # Verdict, per-step outcomes, tags, executed-by,
+        │                             #   share identifiers, environment (browser/OS/resolution)
+        ├── logs/
+        │   ├── meta.yaml             # Declares every log file below
+        │   ├── tui.log               # Session narrative
+        │   ├── <n>-run.log           # Runner log, one set per run index n (0, 1, …)
+        │   ├── <n>-actions.ndjson    # Step-by-step actions the agent performed
+        │   ├── <n>-console.ndjson    # Browser console output, attributed per step
+        │   └── <n>-network.har       # Network traffic (HAR), attributed per step
+        ├── steps/
+        │   └── <ordinal>-<step-id>/  # One directory per executed step
+        │       ├── screenshot.png    # The page as the agent saw it
+        │       ├── annotated.png     # Same shot with the acted-on element highlighted
+        │       ├── step.json         # Step metadata: kind, status, duration, url,
+        │       │                     #   action id, click coordinates, element rect
+        │       └── failure.yaml      # Failed/broken steps only: error, page state,
+        │                             #   console/network references, triage
+        ├── auteur/
+        │   └── execution.json        # Full execution trajectory (step.json's action id
+        │                             #   joins to operations in this tree)
+        └── v16-trajectory/           # Per-run planning summaries and diagrams
+```
+
+A `testrun` pack has one `tests/<test-id>/` directory per member, all under the same root.
+
+## The load-bearing files
+
+Three files carry the structured record. Everything else is additive.
+
+| File | Role |
+|---|---|
+| `run.yaml` | The manifest anchor. A directory or zip is a valid pack if and only if it has a top-level `run.yaml`. Holds run identity, lifecycle status, and the derived totals. |
+| `tests/<id>/test.md` | The test definition, that is, what was asked of the agent. |
+| `tests/<id>/result.yaml` | The structured per-step outcomes for that test. |
+
+## Reading a pack without unzipping it
+
+The sealed zip is **flat**: its entries are exactly the contents of the pack directory, with `run.yaml` at the archive root and no wrapping folder. Because nothing is solid-compressed, a consumer can read the zip's central directory and then fetch only the entries it needs.
+
+That is why the hosted viewer opens a very large pack after fetching only a few kilobytes: it reads `run.yaml` and each `result.yaml` first, and pulls a screenshot only when you look at it.
+
+## Run status and test verdicts
+
+The format keeps two axes separate.
+
+**Run lifecycle**, in `run.yaml.status`:
+
+| Status | Meaning |
+|---|---|
+| `running` | The run is in flight. Totals, `ended`, and definition hashes are not yet authoritative. |
+| `finalized` | The pack is sealed. This is the only authoritative state. |
+| `aborted` | The run ended without sealing. |
+
+**Test verdicts**, used at both test level and step level:
+
+| Verdict | Meaning |
+|---|---|
+| `passed` | The oracle was satisfied. |
+| `failed` | The oracle was evaluated and the product was wrong, that is, a real defect. |
+| `broken` | The oracle could not be evaluated, because of an environment, infrastructure, or test fault. |
+| `skipped` | Not executed. |
+
+The `failed` versus `broken` split is the heart of the model: it separates "the product is wrong" from "we could not tell". A run can be `finalized` and still contain `failed` tests. The lifecycle is not a verdict.
+
+## Next steps
+
+- [Viewing evidence](/support/docs/kane-cli-evidence-viewing/) — open a pack in the viewer.
+- [Validating packs](/support/docs/kane-cli-evidence-validate/) — check a pack's integrity.
+- [The .evidence format](/support/docs/kane-cli-evidence-format/) — the profiles and the open contract.

--- a/docs/kane-cli-evidence-pack-structure.md
+++ b/docs/kane-cli-evidence-pack-structure.md
@@ -2,7 +2,7 @@
 id: kane-cli-evidence-pack-structure
 title: Evidence Pack Structure
 sidebar_label: Pack Structure
-description: "Every file inside a kane-cli .evidence pack and what it is for, from the run.yaml manifest anchor to per-step screenshots, logs, and failure records."
+description: "What is inside a kane-cli .evidence pack and what each part is for, from the run.yaml manifest anchor to per-step screenshots, logs, and failure records."
 keywords:
   - evidence pack structure
   - run.yaml
@@ -79,19 +79,21 @@ A `testrun` pack has one `tests/<test-id>/` directory per member, all under the 
 
 ## The load-bearing files
 
-Three files carry the structured record. Everything else is additive.
+Three files are load-bearing at **L0**, the minimal profile.
 
 | File | Role |
 |---|---|
-| `run.yaml` | The manifest anchor. A directory or zip is a valid pack if and only if it has a top-level `run.yaml`. Holds run identity, lifecycle status, and the derived totals. |
-| `tests/<id>/test.md` | The test definition, that is, what was asked of the agent. |
+| `run.yaml` | The manifest anchor. A directory or zip **is a pack** if and only if it has a top-level `run.yaml`. Holds run identity, lifecycle status, and the derived totals. Being a pack is not the same as passing validation, see [Validating packs](/support/docs/kane-cli-evidence-validate/). |
+| `tests/<id>/test.md` | The test definition, that is, what was asked of the agent. It is **opaque**: the format references and hashes it, and never parses it. |
 | `tests/<id>/result.yaml` | The structured per-step outcomes for that test. |
+
+At **L1**, the profile a kane-cli pack validates against, four more artifacts are required once the run is finalized: each test's `logs/` (with its `meta.yaml`), each test's `steps/` directory, a global `coverage/` directory, and the pack-root `failure.yaml`.
 
 ## Reading a pack without unzipping it
 
 The sealed zip is **flat**: its entries are exactly the contents of the pack directory, with `run.yaml` at the archive root and no wrapping folder. Because nothing is solid-compressed, a consumer can read the zip's central directory and then fetch only the entries it needs.
 
-That is why the hosted viewer opens a very large pack after fetching only a few kilobytes: it reads `run.yaml` and each `result.yaml` first, and pulls a screenshot only when you look at it.
+That is why the hosted viewer opens a very large pack after fetching only a few kilobytes.
 
 ## Run status and test verdicts
 

--- a/docs/kane-cli-evidence-validate.md
+++ b/docs/kane-cli-evidence-validate.md
@@ -1,0 +1,104 @@
+---
+id: kane-cli-evidence-validate
+title: Validating Evidence Packs
+sidebar_label: Validating Packs
+description: "Check a kane-cli evidence pack's integrity and completeness with kane-cli evidence validate, including the L0 and L1 profiles and CI-friendly exit codes."
+keywords:
+  - kane cli evidence validate
+  - validate evidence pack
+  - evidence profile L0 L1
+  - evidence pack ci
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-evidence-validate/
+site_name: TestMu AI
+slug: kane-cli-evidence-validate/
+canonical: https://www.testmuai.com/support/docs/kane-cli-evidence-validate/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-introduction/"
+        }]
+      })
+    }}
+></script>
+
+`kane-cli evidence validate` checks a pack's integrity and completeness:
+
+```bash
+kane-cli evidence validate <execution-id-or-path>
+```
+
+The target can be an execution id, resolved against the project store, a live pack directory, or a sealed `.evidence` file.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--profile <profile>` | Validation profile, `L0` or `L1` | `L1` |
+| `--json` | Machine-readable report | off |
+
+Exit codes: `0` valid, `1` invalid, `2` not found. `--json` plus the exit code makes this easy to gate in CI or scripts.
+
+## Gating a pipeline
+
+```bash
+kane-cli evidence validate .testmuai/evidence/<execution_id>.evidence --json > report.json || exit 1
+```
+
+## What validation checks
+
+Validation is **status-gated**. A pack that is still `running` or was `aborted` is checked for structure only. A `finalized` pack gets the full seal checks as well.
+
+**Structure, on every run status:**
+
+- the manifest anchor `run.yaml` and its identity fields are present,
+- each test's recorded id equals its `tests/<id>/` directory name,
+- every test directory has a `result.yaml` and a declared definition path, and the file at that path exists,
+- the definition path is contained, with no leading `/`, no `..`, and no escape out of the pack,
+- step ordinals are unique and strictly increasing, with gaps allowed.
+
+**Full seal, added when the run is `finalized`:**
+
+- `ended` and `totals` are present, and `ended` is at or after `started`,
+- `totals` equals the rolled-up per-test verdicts, and the test count equals the sum of the verdict buckets,
+- every definition hash is present and matches its file.
+
+A test status that disagrees with its own steps is a **warning**, never a failure. The test verdict is authored, so the validator checks it, it does not overrule it.
+
+## Profiles
+
+| Profile | What it requires |
+|---|---|
+| `L0` | The minimal core: `run.yaml`, and for each test a definition file and a `result.yaml`. |
+| `L1` | Everything in L0, plus the captured artifact layer: declared logs, the `steps/` layer, a `coverage/` directory, and the run-level failure index. |
+
+kane-cli packs carry the captured layer, so they validate at `L1`, which is why it is the default for this command.
+
+:::note
+A missing per-step screenshot is a **warning**, not an error. Not every framework captures a frame per step, and not every step needs a folder.
+:::
+
+## When a pack will not open
+
+If a pack will not open in the viewer, validate it. An unsealed or truncated pack, for example from a run that was killed hard, reports as invalid, and the run's session directory still holds the raw logs.
+
+## Next steps
+
+- [Merging packs](/support/docs/kane-cli-evidence-merge/) — combine several runs into one file.
+- [The .evidence format](/support/docs/kane-cli-evidence-format/) — what the profiles mean.

--- a/docs/kane-cli-evidence-validate.md
+++ b/docs/kane-cli-evidence-validate.md
@@ -69,24 +69,25 @@ Validation is **status-gated**. A pack that is still `running` or was `aborted` 
 
 - the manifest anchor `run.yaml` and its identity fields are present,
 - each test's recorded id equals its `tests/<id>/` directory name,
-- every test directory has a `result.yaml` and a declared definition path, and the file at that path exists,
-- the definition path is contained, with no leading `/`, no `..`, and no escape out of the pack,
+- every test directory has a `result.yaml`, and where a `result.yaml` declares a definition path, the file at that path exists,
+- a declared definition path is contained, with no leading `/`, no `..`, and no escape out of the pack,
 - step ordinals are unique and strictly increasing, with gaps allowed.
 
 **Full seal, added when the run is `finalized`:**
 
 - `ended` and `totals` are present, and `ended` is at or after `started`,
 - `totals` equals the rolled-up per-test verdicts, and the test count equals the sum of the verdict buckets,
-- every definition hash is present and matches its file.
+- every declared definition carries a hash, and the hash matches its file.
+- at `L1`, each test has a `logs/` directory whose `meta.yaml` declares at least one log, and a `steps/` directory; the pack has a global `coverage/` directory and the finalize-generated root `failure.yaml`.
 
-A test status that disagrees with its own steps is a **warning**, never a failure. The test verdict is authored, so the validator checks it, it does not overrule it.
+A test marked `passed` that still has a `failed` or `broken` step is a **warning**, never a failure. The test verdict is authored, so the validator checks it, it does not overrule it.
 
 ## Profiles
 
 | Profile | What it requires |
 |---|---|
-| `L0` | The minimal core: `run.yaml`, and for each test a definition file and a `result.yaml`. |
-| `L1` | Everything in L0, plus the captured artifact layer: declared logs, the `steps/` layer, a `coverage/` directory, and the run-level failure index. |
+| `L0` | The minimal core: `run.yaml`, and for each test a `result.yaml`, plus its definition file where one is declared. |
+| `L1` | Everything in L0, plus the captured artifact layer: declared logs, the `steps/` layer, a `coverage/` directory, and the run-level failure index. These need to be present only once the run is `finalized`. |
 
 kane-cli packs carry the captured layer, so they validate at `L1`. That is the default for this command.
 
@@ -96,7 +97,7 @@ A missing per-step screenshot is a **warning**, not an error. Not every framewor
 
 ## When a pack will not open
 
-If a pack will not open in the viewer, validate it. An unsealed or truncated pack, for example from a run that was killed hard, reports as invalid, and the run's session directory still holds the raw logs.
+If a pack will not open in the viewer, validate it. An unsealed pack, for example from a run that was killed hard, is checked for structure only, so it can still report valid. A truncated pack cannot be read at all and fails before any verdict.
 
 ## Next steps
 

--- a/docs/kane-cli-evidence-validate.md
+++ b/docs/kane-cli-evidence-validate.md
@@ -88,7 +88,7 @@ A test status that disagrees with its own steps is a **warning**, never a failur
 | `L0` | The minimal core: `run.yaml`, and for each test a definition file and a `result.yaml`. |
 | `L1` | Everything in L0, plus the captured artifact layer: declared logs, the `steps/` layer, a `coverage/` directory, and the run-level failure index. |
 
-kane-cli packs carry the captured layer, so they validate at `L1`, which is why it is the default for this command.
+kane-cli packs carry the captured layer, so they validate at `L1`. That is the default for this command.
 
 :::note
 A missing per-step screenshot is a **warning**, not an error. Not every framework captures a frame per step, and not every step needs a folder.

--- a/docs/kane-cli-evidence-viewing.md
+++ b/docs/kane-cli-evidence-viewing.md
@@ -40,7 +40,7 @@ canonical: https://www.testmuai.com/support/docs/kane-cli-evidence-viewing/
     }}
 ></script>
 
-A sealed pack opens in the hosted viewer. Nothing is uploaded: the viewer page reads the pack bytes from your machine and renders them locally.
+A sealed pack opens in the hosted viewer. When you serve a pack with `kane-cli evidence serve`, the server is local only and nothing is uploaded, because the viewer page reads the pack bytes from your machine.
 
 ## After a run
 

--- a/docs/kane-cli-evidence-viewing.md
+++ b/docs/kane-cli-evidence-viewing.md
@@ -1,0 +1,106 @@
+---
+id: kane-cli-evidence-viewing
+title: Viewing Evidence Packs
+sidebar_label: Viewing Evidence
+description: "Open a kane-cli evidence pack in the hosted viewer with kane-cli evidence serve, a localhost-only server that uploads nothing."
+keywords:
+  - kane cli evidence serve
+  - evidence viewer
+  - view evidence pack
+  - evidence lambdatest com
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-evidence-viewing/
+site_name: TestMu AI
+slug: kane-cli-evidence-viewing/
+canonical: https://www.testmuai.com/support/docs/kane-cli-evidence-viewing/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-introduction/"
+        }]
+      })
+    }}
+></script>
+
+A sealed pack opens in the hosted viewer. Nothing is uploaded: the viewer page reads the pack bytes from your machine and renders them locally.
+
+## After a run
+
+After a successful run in a terminal, kane-cli offers to open the pack:
+
+```text
+View evidence in browser? (y/N)
+```
+
+Accepting starts a local server and opens the hosted viewer pointed at your pack.
+
+In agent or non-interactive runs there is no prompt. kane-cli prints a hint line to stderr instead:
+
+```text
+evidence: view locally with `kane-cli evidence serve <path-to-pack>`
+```
+
+## `kane-cli evidence serve`
+
+Serves one or more sealed packs to the hosted viewer:
+
+```bash
+kane-cli evidence serve .testmuai/evidence/<execution_id>.evidence
+```
+
+```text
+serving 1 pack on http://127.0.0.1:54321
+<execution_id>.evidence
+  pack    http://127.0.0.1:54321/<token>/<execution_id>.evidence
+  viewer  https://evidence.lambdatest.com/?pack=http%3A%2F%2F127.0.0.1%3A54321%2F...
+press Ctrl-C to stop
+```
+
+Open the `viewer` URL in your browser.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--port <n>` | Pin the local port | ephemeral |
+| `--viewer-url <base>` | Override the hosted viewer base URL | environment's viewer |
+| `--env <name>` | Environment (`prod` or `stage`) | active profile's env |
+
+`serve` accepts sealed `.evidence` files only. A live, unsealed pack directory is rejected.
+
+Exit codes: `0` after a clean Ctrl-C shutdown, `2` for any bad input or a port that cannot be bound.
+
+:::note
+The server binds to `127.0.0.1` only and uses a random per-instance token in the URL path. Nothing is uploaded anywhere.
+:::
+
+## The hosted viewer
+
+The viewer at `https://evidence.lambdatest.com` is a static page that opens packs three ways:
+
+- a `?pack=<url>` query parameter, which is what `evidence serve` and the post-run offer construct for you,
+- drag and drop of a `.evidence` file,
+- a file picker.
+
+It remembers your recently opened packs, and reads packs with ranged requests, so even a very large pack opens after fetching only a few kilobytes.
+
+## Next steps
+
+- [Debugging a failed run](/support/docs/kane-cli-evidence-debugging/) — what to look at first.
+- [Validating packs](/support/docs/kane-cli-evidence-validate/) — if a pack will not open.

--- a/docs/kane-cli-evidence-viewing.md
+++ b/docs/kane-cli-evidence-viewing.md
@@ -44,7 +44,7 @@ A sealed pack opens in the hosted viewer. When you serve a pack with `kane-cli e
 
 ## After a run
 
-After a successful run in a terminal, kane-cli offers to open the pack:
+After a run in an interactive terminal, kane-cli offers to open the pack:
 
 ```text
 View evidence in browser? (y/N)

--- a/docs/kane-cli-evidence.md
+++ b/docs/kane-cli-evidence.md
@@ -55,7 +55,7 @@ Opened in the viewer (or unzipped), a pack contains:
 - **Run logs** — the CLI and runner logs for the execution.
 - **Failure records** — on failed runs, a per-step record with the error message, the page state at failure, and references into the console/network logs.
 
-For a mobile run, the result summary records the **device** in the run environment (for example the device model and OS version), and the per-step logs include **device logs** from the emulator or simulator alongside the usual browser logs.
+For a mobile run, the result summary records the **device** in the run environment, for example the device model and OS version.
 
 :::note
 The pack is the **only** place run artifacts live. There is no separate per-run log directory on disk.
@@ -63,7 +63,7 @@ The pack is the **only** place run artifacts live. There is no separate per-run 
 
 ## Where packs live
 
-Every run seals a pack in its session directory:
+Every run except `testrun run` seals a pack in its session directory:
 
 ```text
 ~/.testmuai/kaneai/sessions/<session-id>/evidence/<execution_id>.evidence
@@ -79,7 +79,7 @@ What lands in the project store depends on the surface:
 
 | Surface | Copied to `.testmuai/evidence/`? |
 |---|---|
-| `kane-cli run` / TUI session | Only when the session is **named** (`--name`, `/name` in the TUI, or the save prompt at exit) |
+| `kane-cli run` / TUI session | Only when the session is **named** (`--name`, or the save prompt at exit) |
 | `kane-cli testmd run` | Always |
 | `kane-cli testrun run` | Always (the pack is created directly in the store) |
 

--- a/docs/kane-cli-evidence.md
+++ b/docs/kane-cli-evidence.md
@@ -65,13 +65,13 @@ The pack is the **only** place run artifacts live. There is no separate per-run 
 
 Every run seals a pack in its session directory:
 
-```bash
+```text
 ~/.testmuai/kaneai/sessions/<session-id>/evidence/<execution_id>.evidence
 ```
 
 Runs you keep are additionally copied into the **project store** in your working directory:
 
-```bash
+```text
 <cwd>/.testmuai/evidence/<execution_id>.evidence
 ```
 

--- a/docs/kane-cli-evidence.md
+++ b/docs/kane-cli-evidence.md
@@ -1,0 +1,107 @@
+---
+id: kane-cli-evidence
+title: Evidence Packs
+sidebar_label: Overview
+description: "Every kane-cli run seals an evidence pack: a portable .evidence file holding the test definition, per-step screenshots, console and network logs, and failure records for the run."
+keywords:
+  - kane cli evidence
+  - evidence pack
+  - kane cli evidence pack
+  - test run artifacts
+  - kaneai
+  - testmu ai
+url: https://www.testmuai.com/support/docs/kane-cli-evidence/
+site_name: TestMu AI
+slug: kane-cli-evidence/
+canonical: https://www.testmuai.com/support/docs/kane-cli-evidence/
+---
+
+<script type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify({
+       "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [{
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.testmuai.com"
+        },{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Support",
+          "item": "https://www.testmuai.com/support/docs/"
+        },{
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Kane CLI",
+          "item": "https://www.testmuai.com/support/docs/kane-cli-introduction/"
+        }]
+      })
+    }}
+></script>
+
+Every kane-cli run produces an **evidence pack**: a single sealed `.evidence` file containing everything about the run — the test definition, a result summary, per-step screenshots (plus annotated copies highlighting what the agent acted on), browser console and network logs attributed to each step, run logs, and on failures a per-step failure record with the error, page state, and pointers into the logs.
+
+A pack is a self-contained zip. You can open it in the hosted viewer, share it with a teammate, archive it in CI, validate it, or merge several packs into one.
+
+## What's inside a pack
+
+Opened in the viewer (or unzipped), a pack contains:
+
+- **The test definition** — what was asked of the agent.
+- **A result summary** — status, duration, per-step outcomes, tags, who ran it (user name/email), a share link, and the environment (browser resolution, OS version).
+- **Per-step screenshots** — the page as the agent saw it, plus an **annotated** copy highlighting the element the agent acted on.
+- **Browser console and network logs** — captured for the whole run and attributed to the step that produced them.
+- **Run logs** — the CLI and runner logs for the execution.
+- **Failure records** — on failed runs, a per-step record with the error message, the page state at failure, and references into the console/network logs.
+
+For a mobile run, the result summary records the **device** in the run environment (for example the device model and OS version), and the per-step logs include **device logs** from the emulator or simulator alongside the usual browser logs.
+
+:::note
+The pack is the **only** place run artifacts live. There is no separate per-run log directory on disk.
+:::
+
+## Where packs live
+
+Every run seals a pack in its session directory:
+
+```bash
+~/.testmuai/kaneai/sessions/<session-id>/evidence/<execution_id>.evidence
+```
+
+Runs you keep are additionally copied into the **project store** in your working directory:
+
+```bash
+<cwd>/.testmuai/evidence/<execution_id>.evidence
+```
+
+What lands in the project store depends on the surface:
+
+| Surface | Copied to `.testmuai/evidence/`? |
+|---|---|
+| `kane-cli run` / TUI session | Only when the session is **named** (`--name`, `/name` in the TUI, or the save prompt at exit) |
+| `kane-cli testmd run` | Always |
+| `kane-cli testrun run` | Always (the pack is created directly in the store) |
+
+An interactive TUI session maps to one pack: it accumulates every run in the session and seals when you `/exit` or start over with `/new`.
+
+If kane-cli crashes mid-run, the next start automatically sweeps incomplete or orphaned packs. Packs belonging to live concurrent processes are untouched. There is nothing to clean up by hand.
+
+## The `kane-cli evidence` commands
+
+| Command | What it does |
+|---|---|
+| [`evidence serve`](/support/docs/kane-cli-evidence-viewing/) | Serve one or more sealed packs to the hosted viewer from a localhost-only server |
+| [`evidence validate`](/support/docs/kane-cli-evidence-validate/) | Check a pack's integrity and completeness against a profile |
+| [`evidence merge`](/support/docs/kane-cli-evidence-merge/) | Combine several packs into one |
+
+## Publishing to the dashboard
+
+Runs that upload to Test Manager attach their sealed pack automatically. Replayed `testmd` runs and `testrun` executions publish their packs to your project as well, so the dashboard shows execution evidence even for cache-replayed runs that never re-author.
+
+## Next steps
+
+- [Pack structure](/support/docs/kane-cli-evidence-pack-structure/) — every file inside a pack and what it is for.
+- [Viewing evidence](/support/docs/kane-cli-evidence-viewing/) — open a pack in the viewer.
+- [Debugging a failed run](/support/docs/kane-cli-evidence-debugging/) — the fastest path from a red run to a cause.
+- [The .evidence format](/support/docs/kane-cli-evidence-format/) — the open format behind the pack.

--- a/sidebars.js
+++ b/sidebars.js
@@ -4526,6 +4526,48 @@ module.exports = {
       {
         type: "category",
         collapsed: true,
+        label: "Evidence",
+        items: [
+          {
+            type: "doc",
+            label: "Overview",
+            id: "kane-cli-evidence",
+          },
+          {
+            type: "doc",
+            label: "Pack Structure",
+            id: "kane-cli-evidence-pack-structure",
+          },
+          {
+            type: "doc",
+            label: "Viewing Evidence",
+            id: "kane-cli-evidence-viewing",
+          },
+          {
+            type: "doc",
+            label: "Validating Packs",
+            id: "kane-cli-evidence-validate",
+          },
+          {
+            type: "doc",
+            label: "Merging Packs",
+            id: "kane-cli-evidence-merge",
+          },
+          {
+            type: "doc",
+            label: "Debugging from a Pack",
+            id: "kane-cli-evidence-debugging",
+          },
+          {
+            type: "doc",
+            label: "The .evidence Format",
+            id: "kane-cli-evidence-format",
+          },
+        ],
+      },
+      {
+        type: "category",
+        collapsed: true,
         label: "Checkpoints",
         items: [
           {


### PR DESCRIPTION
### What

Adds an **Evidence** section to the Kane CLI docs, placed after Assurance in the sidebar.

Every kane-cli run seals an `.evidence` pack, but the docs site had no section covering it. This adds seven pages:

| Page | Covers |
|---|---|
| **Overview** | What a pack is, what is inside one, where packs live per surface, publishing to the dashboard |
| **Pack Structure** | The full tree file by file, the three load-bearing files, run status versus test verdicts |
| **Viewing Evidence** | The post-run offer, `kane-cli evidence serve`, the hosted viewer |
| **Validating Packs** | `kane-cli evidence validate`, the L0 and L1 profiles, what the validator checks at each run status, CI gating |
| **Merging Packs** | `kane-cli evidence merge` and its strict default policy |
| **Debugging from a Pack** | The four-step failure workflow, reading a failure record, `failed` versus `broken` |
| **The .evidence Format** | The open contract, who writes what, profiles, what sealing guarantees, the Apache-2.0 tooling |

### Sourcing

The producer side is ported from **`LambdaTest/kane-cli`** → `docs/user-guide/evidence.md`, following the same convention used for the Assurance section: same prose, plus Docusaurus frontmatter, the breadcrumb block, and site-relative links.

The format side is sourced from the public **`LambdaTest/evidence-cli`** contract (`design/contract/`) and its CLI. Every flag string, default, and exit code quoted here was checked against the code rather than the spec, because the two differ in one place: `evidence index` is specified in `design/contract/03-commands.md` but is not registered in `src/cli.ts`, so it is not documented here.

### Accuracy notes for reviewers

Three things the pages are deliberately precise about:

- **The two CLIs differ and the docs say so.** `kane-cli evidence` has `serve` and defaults to profile **L1**; the standalone `evidence` CLI has `finalize` and defaults to **L0**. Exit code `2` means "not found" for `kane-cli evidence validate` and "usage error" for the standalone CLI.
- **evidence-cli captures nothing.** kane-cli and its runner write the screenshots and logs; `finalize` only derives totals and hashes, and seals. The format page states this explicitly because the split is easy to misread.
- **Packs are tamper-evident, not tamper-proof.** The definition hash detects a changed test file; packs are not signed. Contract `0.1` has profiles L0 and L1 only, so nothing here promises L2, L3, or signing.

### Checks

- Production `docusaurus build` passes with **0 broken links**; all seven routes render.
- Frontmatter matches the Kane CLI house template (9 fields in order, keywords ending `kaneai` then `testmu ai`).
- Breadcrumb JSON-LD is byte-identical to the existing Assurance pages.
- All internal links are site-relative `/support/docs/<slug>/`.
- No images, no `package-lock.json`, no generated artifacts in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
