### PR TITLE
Sync kane cli docs from testmuCom (MDX format)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -104,6 +104,18 @@
                 ]
               },
               {
+                "group": "Evidence",
+                "pages": [
+                  "docs/kane-cli-evidence",
+                  "docs/kane-cli-evidence-pack-structure",
+                  "docs/kane-cli-evidence-viewing",
+                  "docs/kane-cli-evidence-validate",
+                  "docs/kane-cli-evidence-merge",
+                  "docs/kane-cli-evidence-debugging",
+                  "docs/kane-cli-evidence-format"
+                ]
+              },
+              {
                 "group": "Checkpoints",
                 "pages": [
                   "docs/kane-cli-checkpoints",

--- a/docs/kane-cli-evidence-debugging.mdx
+++ b/docs/kane-cli-evidence-debugging.mdx
@@ -1,0 +1,67 @@
+---
+title: "Debugging a Failed Run from its Pack"
+sidebarTitle: "Debugging from a Pack"
+description: "Use a kane-cli evidence pack to find the cause of a failed run: the failed step, its per-step console and network logs, the annotated screenshot, and the failed versus broken split."
+keywords: ['debug failed test kane cli', 'evidence pack debugging', 'failure.yaml', 'failed vs broken', 'kaneai', 'testmu ai']
+"og:description": "Use a kane-cli evidence pack to find the cause of a failed run: the failed step, its per-step console and network logs, the annotated screenshot, and the failed versus broken split."
+---
+
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
+---
+
+<AgentSkillCallout />
+
+The pack is the fastest way to understand a failure, because everything is in one place and attributed per step.
+
+## The four steps
+
+1. **Open the pack.** Run `kane-cli evidence serve <pack>` and open the `viewer` URL.
+2. **Go to the failed step.** The run overview marks it. The failure record shows the error message and the page state at the moment of failure.
+3. **Check the step's console and network activity.** Logs are sliced per step, so you see exactly what the browser logged and requested while that step ran. A 4xx or 5xx response, or a JS error here, usually explains the failure.
+4. **Look at the annotated screenshot.** It highlights the element the agent was acting on, which makes "clicked the wrong thing" and "element was not there" failures obvious.
+
+## Reading a failure record
+
+A failed or broken step normally carries its own `failure.yaml` with the error, the page state at failure, and references into the console and network logs. The pack root carries a `failure.yaml` index that rolls those up, so you can see every failure in the run without opening each step.
+
+A record must carry evidence of what went wrong: an `error.message`, or both an `expected` and an `actual` value. It may carry both.
+
+## `failed` or `broken`
+
+The verdict tells you where to look first.
+
+| Verdict | What it means | Where to look |
+|---|---|---|
+| `failed` | The oracle was evaluated and the product was wrong. | The assertion and the page state. This is a candidate defect. |
+| `broken` | The oracle could not be evaluated, because of an environment, infrastructure, or test fault. | The network log and the run log. The product may be fine. |
+
+Treating these as one bucket is how a flaky environment gets filed as a product bug. The split exists so it does not.
+
+## Working from the command line
+
+A sealed pack is a zip, so you do not need the viewer to answer a quick question:
+
+```bash
+# list everything in the pack
+unzip -l <execution_id>.evidence
+
+# print the run manifest
+unzip -p <execution_id>.evidence run.yaml
+
+# print one test's result
+unzip -p <execution_id>.evidence tests/<test-id>/result.yaml
+```
+
+## When the pack itself looks wrong
+
+If a pack will not open, run [`kane-cli evidence validate`](/docs/kane-cli-evidence-validate/). An unsealed pack, for example from a run that was killed hard, is checked for structure only and can still report valid. A truncated pack cannot be read at all. Either way the session directory still holds that run's pack:
+
+```text
+~/.testmuai/kaneai/sessions/<session-id>/evidence/
+```
+
+## Next steps
+
+- [Pack structure](/docs/kane-cli-evidence-pack-structure/) — where each artifact lives.
+- [Validating packs](/docs/kane-cli-evidence-validate/) — check a suspect pack.

--- a/docs/kane-cli-evidence-format.mdx
+++ b/docs/kane-cli-evidence-format.mdx
@@ -1,0 +1,88 @@
+---
+title: "The .evidence Format"
+sidebarTitle: "The .evidence Format"
+description: "The open, framework-agnostic .evidence format behind kane-cli packs: the L0 and L1 profiles, what sealing guarantees, and the Apache-2.0 evidence-cli tooling."
+keywords: ['evidence format', 'open test evidence format', 'evidence cli', 'L0 L1 profile', 'framework agnostic test evidence', 'kaneai', 'testmu ai']
+"og:description": "The open, framework-agnostic .evidence format behind kane-cli packs: the L0 and L1 profiles, what sealing guarantees, and the Apache-2.0 evidence-cli tooling."
+---
+
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
+---
+
+<AgentSkillCallout />
+
+The `.evidence` pack is not a kane-cli-only file. It is an **open, framework-agnostic format** with its own specification, validator, and Apache-2.0 licensed tooling, published at [github.com/LambdaTest/evidence-cli](https://github.com/LambdaTest/evidence-cli).
+
+One shape, whatever made it: a browser agent, a Playwright suite, a Jest run, or an API check. A pack is readable by a CI dashboard, an auditor, or a human without knowing the framework that wrote it.
+
+## Who writes what
+
+This is the part worth understanding, because it explains what the format guarantees and what it does not.
+
+| Part of the pack | Written by |
+|---|---|
+| `run.yaml`, each `result.yaml`, the test definition, the per-step folders and screenshots, and the console, network and runner logs | kane-cli |
+| The derived totals, each definition hash, the run-level failure index, and the seal | `evidence finalize` |
+
+The tooling in `evidence-cli` **captures nothing**. It drives no browser and executes no tests. It validates a pack, derives what can be derived, and seals it. A screenshot is in your pack because kane-cli put it there.
+
+That is the point of the split: the container is open, so anything can produce a pack, and any tool can read one.
+
+## Profiles
+
+A profile is a rung on one contract. `L1` adds requirements to `L0` and never rewrites it.
+
+| Profile | Requires |
+|---|---|
+| **L0** | The minimal core: a top-level `run.yaml`, and per test a definition file plus a `result.yaml`. |
+| **L1** | All of L0, plus, once the run is finalized, the captured artifact layer: declared logs, the `steps/` layer, a `coverage/` directory, and the run-level failure index. Video is optional. Before finalize, L1 checks only the shape of what is already there. |
+
+The definition file is **opaque**. The format references and hashes it, and never parses it. It can be a `test.md` from kane-cli, a `login.spec.ts` from Playwright, or anything else.
+
+<Note>
+The contract version and the profile are different axes. The version, currently `0.1`, is the meaning of the fields. Adding a profile is additive and never changes it. Only a breaking change to an existing meaning bumps the version.
+</Note>
+
+## What sealing does and does not give you
+
+`finalize` rolls up the totals, writes each definition's content hash, sets the run to `finalized`, and seals the directory into the zip. The seal replaces the live directory in place, atomically, so a complete copy exists at every instant.
+
+The recorded definition hash is an integrity check on the thing that was tested: `validate` fails a finalized pack whose definition no longer hashes to the value recorded at seal time. Packs are **not signed**, so this says nothing about who produced the pack.
+
+## Using the format directly
+
+If you want to produce or read packs outside kane-cli, the tooling is on npm:
+
+```bash
+npm install -g @testmuai/evidence-cli
+```
+
+```bash
+evidence validate my-run.evidence --profile L0
+evidence finalize my-run.evidence/
+```
+
+The standalone CLI ships `validate`, `finalize`, and `merge`. Exit codes differ by command: `validate` returns `0` valid, `1` invalid, `2` usage error, and `merge` returns `0` merged, `1` policy abort, `2` usage error. It reads its config from `~/.testmuai/evidence/config.json` by default, overridable with `--config` or the `EVIDENCE_CONFIG` environment variable, and the active profile resolves from the `--profile` flag, then the config, then the built-in default of `L0`.
+
+It is also a library, so `validate` and `finalize` can be called in process:
+
+```ts
+import { validate, finalize } from "@testmuai/evidence-cli";
+
+const report = await validate("my-run.evidence", { profile: "L1" });
+if (!report.valid) {
+  for (const d of report.diagnostics) {
+    console.error(`${d.severity} ${d.location}: ${d.message} [${d.code}]`);
+  }
+}
+```
+
+<Note>
+The standalone `evidence` CLI defaults to the `L0` profile, while `kane-cli evidence validate` defaults to `L1`.
+</Note>
+
+## Next steps
+
+- [Pack structure](/docs/kane-cli-evidence-pack-structure/) — the layout in full.
+- [Validating packs](/docs/kane-cli-evidence-validate/) — the checks the validator runs.

--- a/docs/kane-cli-evidence-merge.mdx
+++ b/docs/kane-cli-evidence-merge.mdx
@@ -1,0 +1,63 @@
+---
+title: "Merging Evidence Packs"
+sidebarTitle: "Merging Packs"
+description: "Combine several kane-cli evidence packs into a single sealed pack with kane-cli evidence merge, including the strict default policy and collision handling."
+keywords: ['kane cli evidence merge', 'merge evidence packs', 'nightly evidence rollup', 'kaneai', 'testmu ai']
+"og:description": "Combine several kane-cli evidence packs into a single sealed pack with kane-cli evidence merge, including the strict default policy and collision handling."
+---
+
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
+---
+
+<AgentSkillCallout />
+
+`kane-cli evidence merge` combines several packs into one, for example the packs from a set of related runs you want to hand over as a single file:
+
+```bash
+kane-cli evidence merge <targets...> --run-id nightly-2026-07-11
+```
+
+Targets are execution ids or pack paths, and **order matters**. Earlier targets win where the policy has to choose.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--run-id <id>` | Run id for the merged pack, **required** | — |
+| `-o, --out <path>` | Output path | `.testmuai/evidence/<run-id>.evidence` |
+| `--rules <path>` | Custom merge-rules file. Settings you omit keep their default value; the rule list itself is replaced | built-in defaults |
+| `--on-collision <action>` | `error`, `prefer-first`, `prefer-latest`, or `discard` | `error` |
+| `--title <title>` | Title for the merged run | first eligible pack's |
+| `--no-finalize` | Keep the merged pack live instead of sealing it | seals by default |
+| `--json` | Machine-readable merge report | off |
+| `--env <name>` | Environment (`prod` or `stage`) | active env |
+
+`--rules` and `--on-collision` are mutually exclusive.
+
+Exit codes: `0` merged, `1` policy abort, `2` usage error.
+
+## The default policy
+
+Out of the box, merge is strict:
+
+- inputs must be **sealed and valid**,
+- duplicate run ids are skipped,
+- packs from **different projects or organisations** are refused,
+- a test-id collision is an **error**, unless you choose another action with `--on-collision`.
+
+## A nightly roll-up
+
+```bash
+kane-cli evidence merge \
+  .testmuai/evidence/*.evidence \
+  --run-id nightly-2026-07-11 \
+  --title "Nightly regression"
+```
+
+With no `-o`, the merged pack is written to `.testmuai/evidence/<run-id>.evidence`, which stays unique as long as the run id does.
+
+The result is one sealed pack holding the tests from every pack that passed the policy. Packs the policy skipped contribute nothing, and the merge report (`--json`) lists what was skipped and why.
+
+## Next steps
+
+- [Validating packs](/docs/kane-cli-evidence-validate/) — confirm the merged pack before handing it over.
+- [Viewing evidence](/docs/kane-cli-evidence-viewing/) — open the merged pack.

--- a/docs/kane-cli-evidence-pack-structure.mdx
+++ b/docs/kane-cli-evidence-pack-structure.mdx
@@ -1,0 +1,96 @@
+---
+title: "Evidence Pack Structure"
+sidebarTitle: "Pack Structure"
+description: "What is inside a kane-cli .evidence pack and what each part is for, from the run.yaml manifest anchor to per-step screenshots, logs, and failure records."
+keywords: ['evidence pack structure', 'run.yaml', 'result.yaml', 'evidence pack layout', 'kane cli evidence', 'kaneai', 'testmu ai']
+"og:description": "What is inside a kane-cli .evidence pack and what each part is for, from the run.yaml manifest anchor to per-step screenshots, logs, and failure records."
+---
+
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
+---
+
+<AgentSkillCallout />
+
+A `.evidence` file is a standard zip. `unzip -l <pack>` lists it, and `unzip -p <pack> <entry>` prints one file without extracting the whole pack.
+
+## The layout
+
+```text
+<execution_id>.evidence
+├── run.yaml                          # Run manifest: title, status, started/ended, totals
+├── failure.yaml                      # Run-level failure rollup
+└── tests/
+    └── <test-id>/                    # One directory per test in the run
+        ├── test.md                   # The test definition
+        ├── result.yaml               # Verdict, per-step outcomes, tags, executed-by,
+        │                             #   share identifiers, environment (browser/OS/resolution)
+        ├── logs/
+        │   ├── meta.yaml             # Declares every log file below
+        │   ├── tui.log               # Session narrative
+        │   ├── <n>-run.log           # Runner log, one set per run index n (0, 1, …)
+        │   ├── <n>-actions.ndjson    # Step-by-step actions the agent performed
+        │   ├── <n>-console.ndjson    # Browser console output, attributed per step
+        │   └── <n>-network.har       # Network traffic (HAR), attributed per step
+        ├── steps/
+        │   └── <ordinal>-<step-id>/  # One directory per executed step
+        │       ├── screenshot.png    # The page as the agent saw it
+        │       ├── annotated.png     # Same shot with the acted-on element highlighted
+        │       ├── step.json         # Step metadata: kind, status, duration, url,
+        │       │                     #   action id, click coordinates, element rect
+        │       └── failure.yaml      # Failed/broken steps only: error, page state,
+        │                             #   console/network references, triage
+        ├── auteur/
+        │   └── execution.json        # Full execution trajectory (step.json's action id
+        │                             #   joins to operations in this tree)
+        └── v16-trajectory/           # Per-run planning summaries and diagrams
+```
+
+A `testrun` pack has one `tests/<test-id>/` directory per member, all under the same root.
+
+## The load-bearing files
+
+Three files are load-bearing at **L0**, the minimal profile.
+
+| File | Role |
+|---|---|
+| `run.yaml` | The manifest anchor. A directory or zip **is a pack** if and only if it has a top-level `run.yaml`. Holds run identity, lifecycle status, and the derived totals. Being a pack is not the same as passing validation, see [Validating packs](/docs/kane-cli-evidence-validate/). |
+| `tests/<id>/test.md` | The test definition, that is, what was asked of the agent. It is **opaque**: the format references and hashes it, and never parses it. |
+| `tests/<id>/result.yaml` | The structured per-step outcomes for that test. |
+
+At **L1**, the profile a kane-cli pack validates against, four more artifacts are required once the run is finalized: each test's `logs/` (with its `meta.yaml`), each test's `steps/` directory, a global `coverage/` directory, and the pack-root `failure.yaml`.
+
+## Reading a pack without unzipping it
+
+The sealed zip is **flat**: its entries are exactly the contents of the pack directory, with `run.yaml` at the archive root and no wrapping folder. Because nothing is solid-compressed, a consumer can read the zip's central directory and then fetch only the entries it needs.
+
+That is why the hosted viewer opens a very large pack after fetching only a few kilobytes.
+
+## Run status and test verdicts
+
+The format keeps two axes separate.
+
+**Run lifecycle**, in `run.yaml.status`:
+
+| Status | Meaning |
+|---|---|
+| `running` | The run is in flight. Totals, `ended`, and definition hashes are not yet authoritative. |
+| `finalized` | The pack is sealed. This is the only authoritative state. |
+| `aborted` | The run ended without sealing. |
+
+**Test verdicts**, used at both test level and step level:
+
+| Verdict | Meaning |
+|---|---|
+| `passed` | The oracle was satisfied. |
+| `failed` | The oracle was evaluated and the product was wrong, that is, a real defect. |
+| `broken` | The oracle could not be evaluated, because of an environment, infrastructure, or test fault. |
+| `skipped` | Not executed. |
+
+The `failed` versus `broken` split is the heart of the model: it separates "the product is wrong" from "we could not tell". A run can be `finalized` and still contain `failed` tests. The lifecycle is not a verdict.
+
+## Next steps
+
+- [Viewing evidence](/docs/kane-cli-evidence-viewing/) — open a pack in the viewer.
+- [Validating packs](/docs/kane-cli-evidence-validate/) — check a pack's integrity.
+- [The .evidence format](/docs/kane-cli-evidence-format/) — the profiles and the open contract.

--- a/docs/kane-cli-evidence-validate.mdx
+++ b/docs/kane-cli-evidence-validate.mdx
@@ -1,0 +1,77 @@
+---
+title: "Validating Evidence Packs"
+sidebarTitle: "Validating Packs"
+description: "Check a kane-cli evidence pack's integrity and completeness with kane-cli evidence validate, including the L0 and L1 profiles and CI-friendly exit codes."
+keywords: ['kane cli evidence validate', 'validate evidence pack', 'evidence profile L0 L1', 'evidence pack ci', 'kaneai', 'testmu ai']
+"og:description": "Check a kane-cli evidence pack's integrity and completeness with kane-cli evidence validate, including the L0 and L1 profiles and CI-friendly exit codes."
+---
+
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
+---
+
+<AgentSkillCallout />
+
+`kane-cli evidence validate` checks a pack's integrity and completeness:
+
+```bash
+kane-cli evidence validate <execution-id-or-path>
+```
+
+The target can be an execution id, resolved against the project store, a live pack directory, or a sealed `.evidence` file.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--profile <profile>` | Validation profile, `L0` or `L1` | `L1` |
+| `--json` | Machine-readable report | off |
+
+Exit codes: `0` valid, `1` invalid, `2` not found. `--json` plus the exit code makes this easy to gate in CI or scripts.
+
+## Gating a pipeline
+
+```bash
+kane-cli evidence validate .testmuai/evidence/<execution_id>.evidence --json > report.json || exit 1
+```
+
+## What validation checks
+
+Validation is **status-gated**. A pack that is still `running` or was `aborted` is checked for structure only. A `finalized` pack gets the full seal checks as well.
+
+**Structure, on every run status:**
+
+- the manifest anchor `run.yaml` and its identity fields are present,
+- each test's recorded id equals its `tests/<id>/` directory name,
+- every test directory has a `result.yaml`, and where a `result.yaml` declares a definition path, the file at that path exists,
+- a declared definition path is contained, with no leading `/`, no `..`, and no escape out of the pack,
+- step ordinals are unique and strictly increasing, with gaps allowed.
+
+**Full seal, added when the run is `finalized`:**
+
+- `ended` and `totals` are present, and `ended` is at or after `started`,
+- `totals` equals the rolled-up per-test verdicts, and the test count equals the sum of the verdict buckets,
+- every declared definition carries a hash, and the hash matches its file.
+- at `L1`, each test has a `logs/` directory whose `meta.yaml` declares at least one log, and a `steps/` directory; the pack has a global `coverage/` directory and the finalize-generated root `failure.yaml`.
+
+A test marked `passed` that still has a `failed` or `broken` step is a **warning**, never a failure. The test verdict is authored, so the validator checks it, it does not overrule it.
+
+## Profiles
+
+| Profile | What it requires |
+|---|---|
+| `L0` | The minimal core: `run.yaml`, and for each test a `result.yaml`, plus its definition file where one is declared. |
+| `L1` | Everything in L0, plus the captured artifact layer: declared logs, the `steps/` layer, a `coverage/` directory, and the run-level failure index. These need to be present only once the run is `finalized`. |
+
+kane-cli packs carry the captured layer, so they validate at `L1`. That is the default for this command.
+
+<Note>
+A missing per-step screenshot is a **warning**, not an error. Not every framework captures a frame per step, and not every step needs a folder.
+</Note>
+
+## When a pack will not open
+
+If a pack will not open in the viewer, validate it. An unsealed pack, for example from a run that was killed hard, is checked for structure only, so it can still report valid. A truncated pack cannot be read at all and fails before any verdict.
+
+## Next steps
+
+- [Merging packs](/docs/kane-cli-evidence-merge/) — combine several runs into one file.
+- [The .evidence format](/docs/kane-cli-evidence-format/) — what the profiles mean.

--- a/docs/kane-cli-evidence-viewing.mdx
+++ b/docs/kane-cli-evidence-viewing.mdx
@@ -1,0 +1,78 @@
+---
+title: "Viewing Evidence Packs"
+sidebarTitle: "Viewing Evidence"
+description: "Open a kane-cli evidence pack in the hosted viewer with kane-cli evidence serve, a localhost-only server that uploads nothing."
+keywords: ['kane cli evidence serve', 'evidence viewer', 'view evidence pack', 'evidence lambdatest com', 'kaneai', 'testmu ai']
+"og:description": "Open a kane-cli evidence pack in the hosted viewer with kane-cli evidence serve, a localhost-only server that uploads nothing."
+---
+
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
+---
+
+<AgentSkillCallout />
+
+A sealed pack opens in the hosted viewer. When you serve a pack with `kane-cli evidence serve`, the server is local only and nothing is uploaded, because the viewer page reads the pack bytes from your machine.
+
+## After a run
+
+After a run in an interactive terminal, kane-cli offers to open the pack:
+
+```text
+View evidence in browser? (y/N)
+```
+
+Accepting starts a local server and opens the hosted viewer pointed at your pack.
+
+In agent or non-interactive runs there is no prompt. kane-cli prints a hint line to stderr instead:
+
+```text
+evidence: view locally with `kane-cli evidence serve <path-to-pack>`
+```
+
+## `kane-cli evidence serve`
+
+Serves one or more sealed packs to the hosted viewer:
+
+```bash
+kane-cli evidence serve .testmuai/evidence/<execution_id>.evidence
+```
+
+```text
+serving 1 pack on http://127.0.0.1:54321
+<execution_id>.evidence
+  pack    http://127.0.0.1:54321/<token>/<execution_id>.evidence
+  viewer  https://evidence.lambdatest.com/?pack=http%3A%2F%2F127.0.0.1%3A54321%2F...
+press Ctrl-C to stop
+```
+
+Open the `viewer` URL in your browser.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--port <n>` | Pin the local port | ephemeral |
+| `--viewer-url <base>` | Override the hosted viewer base URL | environment's viewer |
+| `--env <name>` | Environment (`prod` or `stage`) | active profile's env |
+
+`serve` accepts sealed `.evidence` files only. A live, unsealed pack directory is rejected.
+
+Exit codes: `0` after a clean Ctrl-C shutdown, `2` for any bad input or a port that cannot be bound.
+
+<Note>
+The server binds to `127.0.0.1` only and uses a random per-instance token in the URL path. Nothing is uploaded anywhere.
+</Note>
+
+## The hosted viewer
+
+The viewer at `https://evidence.lambdatest.com` is a static page that opens packs three ways:
+
+- a `?pack=<url>` query parameter, which is what `evidence serve` and the post-run offer construct for you,
+- drag and drop of a `.evidence` file,
+- a file picker.
+
+It remembers your recently opened packs, and reads packs with ranged requests, so even a very large pack opens after fetching only a few kilobytes.
+
+## Next steps
+
+- [Debugging a failed run](/docs/kane-cli-evidence-debugging/) — what to look at first.
+- [Validating packs](/docs/kane-cli-evidence-validate/) — if a pack will not open.

--- a/docs/kane-cli-evidence.mdx
+++ b/docs/kane-cli-evidence.mdx
@@ -1,0 +1,79 @@
+---
+title: "Evidence Packs"
+sidebarTitle: "Overview"
+description: "Every kane-cli run seals an evidence pack: a portable .evidence file holding the test definition, per-step screenshots, console and network logs, and failure records for the run."
+keywords: ['kane cli evidence', 'evidence pack', 'kane cli evidence pack', 'test run artifacts', 'kaneai', 'testmu ai']
+"og:description": "Every kane-cli run seals an evidence pack: a portable .evidence file holding the test definition, per-step screenshots, console and network logs, and failure records for the run."
+---
+
+import AgentSkillCallout from "/snippets/AgentSkillCallout.mdx";
+
+---
+
+<AgentSkillCallout />
+
+Every kane-cli run produces an **evidence pack**: a single sealed `.evidence` file containing everything about the run — the test definition, a result summary, per-step screenshots (plus annotated copies highlighting what the agent acted on), browser console and network logs attributed to each step, run logs, and on failures a per-step failure record with the error, page state, and pointers into the logs.
+
+A pack is a self-contained zip. You can open it in the hosted viewer, share it with a teammate, archive it in CI, validate it, or merge several packs into one.
+
+## What's inside a pack
+
+Opened in the viewer (or unzipped), a pack contains:
+
+- **The test definition** — what was asked of the agent.
+- **A result summary** — status, duration, per-step outcomes, tags, who ran it (user name/email), a share link, and the environment (browser resolution, OS version).
+- **Per-step screenshots** — the page as the agent saw it, plus an **annotated** copy highlighting the element the agent acted on.
+- **Browser console and network logs** — captured for the whole run and attributed to the step that produced them.
+- **Run logs** — the CLI and runner logs for the execution.
+- **Failure records** — on failed runs, a per-step record with the error message, the page state at failure, and references into the console/network logs.
+
+For a mobile run, the result summary records the **device** in the run environment, for example the device model and OS version.
+
+<Note>
+The pack is the **only** place run artifacts live. There is no separate per-run log directory on disk.
+</Note>
+
+## Where packs live
+
+Every run except `testrun run` seals a pack in its session directory:
+
+```text
+~/.testmuai/kaneai/sessions/<session-id>/evidence/<execution_id>.evidence
+```
+
+Runs you keep are additionally copied into the **project store** in your working directory:
+
+```text
+<cwd>/.testmuai/evidence/<execution_id>.evidence
+```
+
+What lands in the project store depends on the surface:
+
+| Surface | Copied to `.testmuai/evidence/`? |
+|---|---|
+| `kane-cli run` / TUI session | Only when the session is **named** (`--name`, or the save prompt at exit) |
+| `kane-cli testmd run` | Always |
+| `kane-cli testrun run` | Always (the pack is created directly in the store) |
+
+An interactive TUI session maps to one pack: it accumulates every run in the session and seals when you `/exit` or start over with `/new`.
+
+If kane-cli crashes mid-run, the next start automatically sweeps incomplete or orphaned packs. Packs belonging to live concurrent processes are untouched. There is nothing to clean up by hand.
+
+## The `kane-cli evidence` commands
+
+| Command | What it does |
+|---|---|
+| [`evidence serve`](/docs/kane-cli-evidence-viewing/) | Serve one or more sealed packs to the hosted viewer from a localhost-only server |
+| [`evidence validate`](/docs/kane-cli-evidence-validate/) | Check a pack's integrity and completeness against a profile |
+| [`evidence merge`](/docs/kane-cli-evidence-merge/) | Combine several packs into one |
+
+## Publishing to the dashboard
+
+Runs that upload to Test Manager attach their sealed pack automatically. Replayed `testmd` runs and `testrun` executions publish their packs to your project as well, so the dashboard shows execution evidence even for cache-replayed runs that never re-author.
+
+## Next steps
+
+- [Pack structure](/docs/kane-cli-evidence-pack-structure/) — every file inside a pack and what it is for.
+- [Viewing evidence](/docs/kane-cli-evidence-viewing/) — open a pack in the viewer.
+- [Debugging a failed run](/docs/kane-cli-evidence-debugging/) — the fastest path from a red run to a cause.
+- [The .evidence format](/docs/kane-cli-evidence-format/) — the open format behind the pack.


### PR DESCRIPTION
## Summary

Compared the `testmuCom` branch against `stage-mintlify` for Kane CLI docs changes since the last sync. Found one new section: **Evidence Packs** (`docs: add Kane CLI Evidence section` and follow-up corrections in `testmuCom`), which had no MDX counterpart yet. All previously-synced Kane CLI pages are unchanged.

## Changes

Added 7 new MDX pages, converted from the Docusaurus markdown source in `testmuCom`, following the same conversion pattern used by prior syncs on this branch (frontmatter → Mintlify format, JSON-LD breadcrumb script dropped, `:::note` → `<Note>`, `AgentSkillCallout` snippet added, `/support/docs/...` links rewritten to `/docs/...`):

- `docs/kane-cli-evidence.mdx` — Overview
- `docs/kane-cli-evidence-pack-structure.mdx` — Pack Structure
- `docs/kane-cli-evidence-viewing.mdx` — Viewing Evidence
- `docs/kane-cli-evidence-validate.mdx` — Validating Packs
- `docs/kane-cli-evidence-merge.mdx` — Merging Packs
- `docs/kane-cli-evidence-debugging.mdx` — Debugging from a Pack
- `docs/kane-cli-evidence-format.mdx` — The .evidence Format

Also wired a new **Evidence** navigation group into `docs.json`, placed after **Assurance** to mirror the source `sidebars.js` ordering in `testmuCom`.

## Notes

- Content and structure were preserved as closely as possible; only the Docusaurus → Mintlify formatting differences (frontmatter, admonitions, imports, links) were changed, consistent with earlier sync PRs on this branch.
- No images/videos are referenced by these 7 source pages, so no new assets were needed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lh3Sx5RVHVtoGcmF6tJ4cZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lh3Sx5RVHVtoGcmF6tJ4cZ)_