### PR TITLE
Tunnel Release Notes | Add 3.2.33 parallel --expose services and flag deprecations

### DIFF
--- a/docs/tunel-release-notes.md
+++ b/docs/tunel-release-notes.md
@@ -41,6 +41,12 @@ import BrandName, { BRAND_URL } from '@site/src/component/BrandName';
       })
     }}
 ></script>
+## Version 3.2.33 (23rd August 2026)
+- **Multiple `--expose` Services**
+  - Fixed only the first service being forwarded when several named services were exposed over a TCP-mode tunnel. Each exposed service now runs on its own data channel, so all of them stay reachable for the lifetime of the tunnel.
+- **Deprecated Flags**
+  - `--byod`, `--forceLocal` and `--transport-mode` are now deprecated. They are hidden from `--help` and print a warning when used, but continue to work in this release and will be removed in a future one.
+
 ## Version 3.2.32 (09th August 2026)
 - **Security Updates and Stability Fixes**
   - Security Fixes for CVE


### PR DESCRIPTION
Adds release notes for **Tunnel Client 3.2.33**, shipped in [LambdatestIncPrivate/burrow#659](https://github.com/LambdatestIncPrivate/burrow/pull/659).

### What's new in 3.2.33
- **Multiple `--expose` Services** — every exposed service now gets its own TCP data channel. Previously the channels were opened in a sequential loop and the first one blocked for the life of the tunnel, so only the first named service was ever forwarded (TE-24979, [burrow#653](https://github.com/LambdatestIncPrivate/burrow/pull/653)).
- **Deprecated Flags** — `--byod`, `--forceLocal` and `--transport-mode` are marked deprecated: hidden from `--help` and warned on use, but still parsed this release so existing invocations and the language wrappers keep working ([burrow#656](https://github.com/LambdatestIncPrivate/burrow/pull/656)).

The other commits in this release (CI image cache-busting, repo docs) are internal and have no user-facing change.

Base branch: `stage`.