### PR TITLE
seo: fix canonical base to avoid doubled /docs in URLs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -14,7 +14,7 @@
   "seo": {
     "metatags": {
       "robots": "noindex, nofollow",
-      "canonical": "https://www.testmuai.com/support"
+      "canonical": "https://www.testmuai.com/docs"
     }
   },
   "fonts": {

--- a/docs.json
+++ b/docs.json
@@ -14,7 +14,7 @@
   "seo": {
     "metatags": {
       "robots": "noindex, nofollow",
-      "canonical": "https://www.testmuai.com/docs"
+      "canonical": "https://www.testmuai.com"
     }
   },
   "fonts": {


### PR DESCRIPTION
## What

Changes the global SEO `canonical` base in `docs.json` from `https://www.testmuai.com/docs` to `https://www.testmuai.com`.

## Why

Mintlify forms each page's canonical as **base + page path**. Every page in this repo lives under `docs/`, so its path already begins with `/docs/...`. With a `/docs` base, the canonical for a page came out doubled:

```
base  https://www.testmuai.com/docs
+path /docs/kane-cli-introduction
=     https://www.testmuai.com/docs/docs/kane-cli-introduction   ❌
```

With the bare domain as the base, canonicals now resolve to the correct live docs URLs:

```
https://www.testmuai.com/docs/kane-cli-introduction   ✅
```

## Scope

- One-line change to `docs.json` (`seo.metatags.canonical`).
- No content or navigation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)