### PR TITLE
docs(seo): fix canonical base to avoid doubled /docs in URLs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -14,7 +14,7 @@
   "seo": {
     "metatags": {
       "robots": "noindex, nofollow",
-      "canonical": "https://www.testmuai.com/support"
+      "canonical": "https://www.testmuai.com"
     }
   },
   "fonts": {


### PR DESCRIPTION
## What
Changes the global SEO `canonical` base in `docs.json` from `https://www.testmuai.com/support` to `https://www.testmuai.com`.

## Why
Mintlify forms each page's canonical as **base + page path**. Every page in this repo lives under `docs/`, so its path already begins with `/docs/...`. A base that itself carries a path segment produces malformed/duplicated canonicals. With the bare domain as the base, canonicals resolve to the correct live docs URLs:

```
https://www.testmuai.com/docs/kane-cli-introduction   ✅
```

## Scope
- One-line change to `docs.json` (`seo.metatags.canonical`).
- No content or navigation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)